### PR TITLE
Thread mapping

### DIFF
--- a/kernels/src/kernel.rs
+++ b/kernels/src/kernel.rs
@@ -135,8 +135,7 @@ pub trait Kernel<'a>: Sized {
                         leaves.push(BoundSample { actions, bound, runtime });
                     }).into());
                 } else {
-                    let n = num_tested.fetch_sub(1, atomic::Ordering::SeqCst);
-                    error!("{}", n);
+                    num_tested.fetch_sub(1, atomic::Ordering::SeqCst);
                 }
             }
         });

--- a/kernels/src/kernel.rs
+++ b/kernels/src/kernel.rs
@@ -245,10 +245,12 @@ pub fn analyze_bounds(mut bounds: Vec<BoundSample>) {
             println!("{}% worst error: {}", i*100/num_printed, bounds[index]);
         }
     }
-    if num_errors != bounds.len() {
-        for i in 0..NUM_QUANTILES {
-            let index = (i+1)*(bounds.len()-num_errors)/NUM_QUANTILES - 1;
-            println!("{}% worst: {}", (i+1)*100/NUM_QUANTILES, bounds[num_errors + index]);
+    if num_errors < bounds.len() {
+        let num_bounds = bounds.len() - num_errors;
+        let num_quantiles = std::cmp::min(NUM_QUANTILES, num_bounds);
+        for i in 0..num_quantiles {
+            let index = (i+1)*(num_bounds/num_quantiles) - 1;
+            println!("{}% worst: {}", (i+1)*100/num_quantiles, bounds[num_errors + index]);
         }
     }
 }

--- a/kernels/src/kernel.rs
+++ b/kernels/src/kernel.rs
@@ -74,7 +74,7 @@ pub trait Kernel<'a>: Sized {
             let leaf = local_selection::descend(order, context, candidate, CUT);
             if let Some(leaf) = leaf {
                 let device_fn = codegen::Function::build(&leaf.space);
-                unwrap!(context.evaluate(&device_fn),
+                unwrap!(context.evaluate(&device_fn, device::EvalMode::FindBest),
                     "evaluation failed for kernel {}, with actions {:?}",
                     Self::name(), leaf.actions);
                 if let Err(err) = kernel.check_result(&expected_output, context) {

--- a/kernels/src/lib.rs
+++ b/kernels/src/lib.rs
@@ -3,8 +3,6 @@
 extern crate cuda_sys;
 extern crate itertools;
 extern crate libc;
-#[macro_use]
-extern crate log;
 extern crate ndarray;
 extern crate num;
 extern crate num_cpus;

--- a/kernels/src/lib.rs
+++ b/kernels/src/lib.rs
@@ -3,6 +3,8 @@
 extern crate cuda_sys;
 extern crate itertools;
 extern crate libc;
+#[macro_use]
+extern crate log;
 extern crate ndarray;
 extern crate num;
 extern crate num_cpus;

--- a/kernels/src/linalg.rs
+++ b/kernels/src/linalg.rs
@@ -298,7 +298,7 @@ impl<'a, S: Scalar> Kernel<'a> for MatMul<'a, S> {
         // TODO(search_space): more tilings
         let mn_log2 = std::cmp::min(m_log2, n_log2); 
         let t1_max = std::cmp::min(mn_log2, 6);
-        let t2_max = std::cmp::min(k_log2, 5);
+        let t2_max = std::cmp::min(k_log2, 4);
         let tilings = (0..t1_max).into_par_iter().flat_map(|t1| {
             (0..std::cmp::min(mn_log2-t1, t2_max)).into_par_iter()
             .map(move |t2| (1u32 << t1, 1u32 << t2))
@@ -330,16 +330,14 @@ impl<'a, S: Scalar> Kernel<'a> for MatMul<'a, S> {
             builder.order(&st_c.inst(), &acc_dim_k, Order::AFTER);
             // Arbitrary constrains to reduce the search space
             // TODO(search_space): remove arbitrary decisions.
-            builder.action(Action::InstFlag(ld_a.inst(), InstFlag::MEM_CG | InstFlag::MEM_NC));
-            builder.action(Action::InstFlag(ld_b.inst(), InstFlag::MEM_CG | InstFlag::MEM_NC));
-            builder.action(Action::InstFlag(st_c.inst(), InstFlag::MEM_CS));
+            //builder.action(Action::InstFlag(ld_a.inst(), InstFlag::MEM_CG | InstFlag::MEM_NC));
+            //builder.action(Action::InstFlag(ld_b.inst(), InstFlag::MEM_CG | InstFlag::MEM_NC));
+            //builder.action(Action::InstFlag(st_c.inst(), InstFlag::MEM_CS));
 
-            builder.action(Action::DimKind(init_dim_n[0], DimKind::BLOCK));
-            builder.action(Action::DimKind(init_dim_m[0], DimKind::BLOCK));
+            //builder.action(Action::DimKind(init_dim_n[0], DimKind::BLOCK));
+            //builder.action(Action::DimKind(init_dim_m[0], DimKind::BLOCK));
             builder.get()
-            /*builder.action(Action::DimKind(thread_dim_0_n, DimKind::THREAD_Y));
-            builder.action(Action::DimKind(thread_dim_0_m, DimKind::THREAD_X));
-            builder.action(Action::DimKind(unroll_dim_0_n, DimKind::UNROLL));
+            /*builder.action(Action::DimKind(unroll_dim_0_n, DimKind::UNROLL));
             builder.action(Action::DimKind(unroll_dim_0_m, DimKind::UNROLL));
             builder.order(unroll_dim_0_n.into(), unroll_dim_0_m.into(), Order::OUTER);
             builder.order(unroll_dim_1_n.into(), unroll_dim_1_m.into(), Order::INNER);

--- a/kernels/src/linalg.rs
+++ b/kernels/src/linalg.rs
@@ -53,7 +53,6 @@ impl<'a, S> Kernel<'a> for Axpy<'a, S> where S: Scalar {
         let y_op = ld_y.dim_map(&[&mad_dim], GlobalScope, &mut builder);
         let mad = VirtualTensor::new(builder.mad(&x_op, &"alpha", &y_op), vec![mad_dim]);
         mad.store(&self.z, &mut builder);
-
         vec![builder.get()]
     }
 

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -1,6 +1,6 @@
 use codegen::{Dimension, InductionLevel, Instruction};
 use ir;
-use search_space::{DimKind, Domain, Order, SearchSpace, ThreadMapping};
+use search_space::{DimKind, Order, SearchSpace, ThreadMapping};
 use itertools::Itertools;
 use std::{self, fmt};
 
@@ -274,8 +274,10 @@ fn gen_events<'a>(space: &'a SearchSpace<'a>,
                 ThreadMapping::MAPPED_OUT => std::cmp::Ordering::Less,
                 ThreadMapping::MAPPED_IN => std::cmp::Ordering::Greater,
                 ThreadMapping::MAPPED => std::cmp::Ordering::Equal,
-                _ => panic!("invalid mapping between thread dims {:?} and {:?}",
-                            probe.id(), dim.id()),
+                mapping => {
+                    panic!("invalid mapping between thread dims {:?} and {:?}: {:?}",
+                           probe.id(), dim.id(), mapping)
+                }
             }
         });
         match pos {

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -238,7 +238,7 @@ fn gen_events<'a>(space: &'a SearchSpace<'a>,
     for mut dim in dims {
         match dim.kind() {
             DimKind::BLOCK => block_dims.push(dim),
-            DimKind::THREAD_X | DimKind::THREAD_Y | DimKind::THREAD_Z => {
+            DimKind::THREAD => {
                 events.push(CfgEvent::Exit(dim.id(), ExitEvent::ThreadDim));
                 thread_dims.push(dim);
             },

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -69,7 +69,6 @@ impl<'a> Cfg<'a> {
     {
         use self::CfgEvent::*;
         let mut body = vec![];
-        // FIXME: move thread mask before unrolled and vector dimensions
         loop {
             match events.next() {
                 Some(Exec(inst)) => {

--- a/src/codegen/dimension.rs
+++ b/src/codegen/dimension.rs
@@ -250,8 +250,7 @@ fn get_ind_var_levels<'a>(ind_var: &'a ir::InductionVar<'a>, space: &SearchSpace
         match space.domain().get_dim_kind(dim) {
             DimKind::VECTOR => (),
             DimKind::LOOP | DimKind::UNROLL => mut_levels.push((dim, size)),
-            DimKind::BLOCK | DimKind::THREAD_X | DimKind::THREAD_Y | DimKind::THREAD_Z =>
-                const_levels.push((dim, size)),
+            DimKind::BLOCK | DimKind::THREAD => const_levels.push((dim, size)),
             x => panic!("unspecified dim kind {:?}", x),
         }
     }

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -303,4 +303,7 @@ impl<'a> Instruction<'a> {
 
     /// Returns the memory flag of the intruction, if any.
     pub fn mem_flag(&self) -> Option<search_space::InstFlag> { self.mem_flag }
+
+    /// Indicates if the instruction has observable side effects.
+    pub fn has_side_effects(&self) -> bool { self.instruction.has_side_effects() }
 }

--- a/src/codegen/namer.rs
+++ b/src/codegen/namer.rs
@@ -55,6 +55,8 @@ pub struct NameMap<'a, 'b> {
     induction_levels: HashMap<(ir::IndVarId, ir::dim::Id), String>,
     /// Casted sizes.
     size_casts: HashMap<(&'a ir::Size<'a>, ir::Type), String>,
+    /// Guard to use in front of instructions with side effects.
+    side_effect_guard: Option<RcStr>,
 }
 
 impl<'a, 'b> NameMap<'a, 'b> {
@@ -105,6 +107,7 @@ impl<'a, 'b> NameMap<'a, 'b> {
             total_num_threads: function.num_threads(),
             size_casts: HashMap::default(),
             indexes, params, mem_blocks, induction_vars, induction_levels,
+            side_effect_guard: None,
         };
         // Setup induction variables.
         for var in function.induction_vars() {
@@ -324,5 +327,15 @@ impl<'a, 'b> NameMap<'a, 'b> {
                 Cow::Borrowed(size)
             },
         }
+    }
+
+    /// Returns the side-effect guard, if any is set.
+    pub fn side_effect_guard(&self) -> Option<RcStr> {
+        self.side_effect_guard.clone()
+    }
+
+    /// Sets the predicate to use in front of side-effect instruction.
+    pub fn set_side_effect_guard(&mut self, guard: Option<RcStr>) {
+        self.side_effect_guard = guard;
     }
 }

--- a/src/device/context.rs
+++ b/src/device/context.rs
@@ -16,7 +16,7 @@ pub trait Context: Sync {
     /// Returns the description of the device the code runs on.
     fn device(&self) -> &Device;
     /// Returns the execution time of a fully specified implementation in nanoseconds.
-    fn evaluate(&self, space: &Function) -> Result<f64, ()>;
+    fn evaluate(&self, space: &Function, mode: EvalMode) -> Result<f64, ()>;
     /// Compiles and benchmarks a functions. As opposed to `Self::evaluate`, the measured
     /// time contains potential startup times.
     fn benchmark(&self, space: &Function, num_samples: usize) -> Vec<f64>;

--- a/src/device/cuda/api/jit_daemon.rs
+++ b/src/device/cuda/api/jit_daemon.rs
@@ -30,7 +30,7 @@ impl Drop for JITDaemon {
         unwrap!(self.ptx_sender.send(&[]));
         unsafe {
             if libc::waitpid(self.daemon, std::ptr::null_mut(), 0) == -1 {
-                panic!("unable to kill jit process: {}", errno());
+                info!("unable to kill jit process: {}", errno());
             }
         }
     }

--- a/src/device/cuda/context.rs
+++ b/src/device/cuda/context.rs
@@ -15,7 +15,7 @@ use device::context::AsyncCallback;
 /// Max number of candidates waiting to be evaluated.
 const EVAL_BUFFER_SIZE: usize = 100;
 // TODO(perf): enable optimizations when possible
-const JIT_OPT_LEVEL: usize = 1;
+const JIT_OPT_LEVEL: usize = 2;
 
 /// A CUDA evaluation context.
 pub struct Context<'a> {

--- a/src/device/cuda/context.rs
+++ b/src/device/cuda/context.rs
@@ -58,6 +58,14 @@ impl<'a> Context<'a> {
     pub fn bind_param(&mut self, name: String, arg: Arc<Argument + 'a>) {
         self.parameters.insert(name, arg);
     }
+
+    /// Returns the optimization level to use.
+    fn opt_level(mode: EvalMode) -> usize {
+        match mode {
+            EvalMode::TestBound => 1,
+            EvalMode::FindBest => JIT_OPT_LEVEL,
+        }
+    }
 }
 
 
@@ -84,9 +92,9 @@ impl<'a> device::Context for Context<'a> {
 
     fn param_as_size(&self, name: &str) -> Option<u32> { self.get_param(name).as_size() }
 
-    fn evaluate(&self, function: &device::Function) -> Result<f64, ()> {
+    fn evaluate(&self, function: &device::Function, mode: EvalMode) -> Result<f64, ()> {
         let gpu = &self.gpu_model;
-        let kernel = Kernel::compile(function, gpu, self.executor, JIT_OPT_LEVEL);
+        let kernel = Kernel::compile(function, gpu, self.executor, Self::opt_level(mode));
         Ok(kernel.evaluate(self)? as f64 / self.gpu_model.smx_clock)
     }
 
@@ -102,7 +110,6 @@ impl<'a> device::Context for Context<'a> {
         let blocked_time = &atomic::AtomicUsize::new(0);
         let (send, recv) = mpsc::sync_channel(EVAL_BUFFER_SIZE);
         let clock_rate = self.gpu_model.smx_clock;
-        let opt_level = if mode == EvalMode::TestBound { 1 } else { JIT_OPT_LEVEL }; 
         // Correct because the thread handle is not escaped.
         crossbeam::scope(move |scope| {
             // Start the explorer threads.
@@ -110,7 +117,7 @@ impl<'a> device::Context for Context<'a> {
                 let mut evaluator = AsyncEvaluator {
                     context: self,
                     sender: send.clone(),
-                    ptx_daemon: self.executor.spawn_jit(opt_level),
+                    ptx_daemon: self.executor.spawn_jit(Self::opt_level(mode)),
                     blocked_time,
                 };
                 unwrap!(scope.builder().name("Telamon - Explorer Thread".to_string())
@@ -160,7 +167,8 @@ pub struct AsyncEvaluator<'a, 'b> where 'a: 'b {
 impl<'a, 'b, 'c> device::AsyncEvaluator<'a, 'c> for AsyncEvaluator<'a, 'b>
     where 'a: 'b, 'c: 'b
 {
-    fn add_kernel(&mut self, candidate: explorer::Candidate<'a>, callback: device::AsyncCallback<'a, 'c> ) {
+    fn add_kernel(&mut self, candidate: explorer::Candidate<'a>,
+                  callback: device::AsyncCallback<'a, 'c> ) {
         let thunk = {
             let dev_fun = device::Function::build(&candidate.space);
             let gpu = &self.context.gpu();

--- a/src/device/cuda/gpu.rs
+++ b/src/device/cuda/gpu.rs
@@ -216,9 +216,9 @@ impl Gpu {
             pressure.add_sequential(&self.loop_init_overhead.into());
             pressure
         } else if DimKind::THREAD.contains(kind) {
-            let mut pressure: HwPressure = self.syncthread_inst.into();
-            pressure.repeat_parallel(f64::from(size));
-            pressure
+            // The repetition along the thread is taken into account by
+            // `num_unmapped_thread` as the current thread is accounted as not mapped.
+            self.syncthread_inst.into()
         } else { HwPressure::zero(self) }
     }
 

--- a/src/device/cuda/gpu.rs
+++ b/src/device/cuda/gpu.rs
@@ -353,6 +353,10 @@ impl device::Device for Gpu {
         } else { panic!() }
     }
 
+    fn skipped_pressure(&self) -> HwPressure {
+        (InstDesc { issue: 1.0, .. InstDesc::default() }).into()
+    }
+
     fn loop_iter_pressure(&self, kind: DimKind) -> (HwPressure, HwPressure) {
         if kind == DimKind::LOOP {
             let end_pressure = InstDesc {

--- a/src/device/cuda/gpu.rs
+++ b/src/device/cuda/gpu.rs
@@ -289,8 +289,7 @@ impl Gpu {
     /// Computes the number of blocks that can fit in an smx.
     pub fn blocks_per_smx(&self, space: &SearchSpace) -> u32 {
         let mut block_per_smx = self.max_block_per_smx;
-        let num_thread = space.ir_instance().insts()
-            .map(|inst| space.domain().get_num_threads(inst.id()).min).max().unwrap_or(1);
+        let num_thread = space.domain().get_num_threads().min;
         min_assign(&mut block_per_smx, self.thread_per_smx/num_thread);
         let shared_mem_used = space.domain().get_shared_mem_used().min;
         if shared_mem_used != 0 {

--- a/src/device/cuda/mem_model.rs
+++ b/src/device/cuda/mem_model.rs
@@ -1,6 +1,6 @@
 //! Memory accesses analysis.
 use device::cuda;
-use ir::{self, BasicBlock};
+use ir;
 use itertools::Itertools;
 use search_space::{DimKind, Domain, InstFlag, ThreadMapping, SearchSpace};
 use std;
@@ -224,7 +224,7 @@ fn external_thread_dims<'a>(inst: &'a ir::Instruction, space: &'a SearchSpace)
 {
     space.ir_instance().thread_dims().flat_map(move |dim| {
         let is_mapped = inst.iteration_dims().iter().map(|&other| {
-            if dim.id() == other.id() { return Trivalent::True; }
+            if dim.id() == other { return Trivalent::True; }
             let mapping = space.domain().get_thread_mapping(dim.id(), other);
             mapping.is(ThreadMapping::MAPPED)
         }).fold(Trivalent::False, |l, r| l | r);
@@ -386,6 +386,7 @@ mod tests {
     use helper;
     use ir;
     use env_logger;
+    use search_space::Order;
 
     /// Generates function with a load in two thread dimensions, with non-coalesced
     /// accessed on the first one.

--- a/src/device/cuda/mem_model.rs
+++ b/src/device/cuda/mem_model.rs
@@ -224,6 +224,7 @@ fn external_thread_dims<'a>(inst: &'a ir::Instruction, space: &'a SearchSpace)
 {
     space.ir_instance().thread_dims().flat_map(move |dim| {
         let is_mapped = inst.iteration_dims().iter().map(|&other| {
+            if dim.id() == other.id() { return Trivalent::True; }
             let mapping = space.domain().get_thread_mapping(dim.id(), other);
             mapping.is(ThreadMapping::MAPPED)
         }).fold(Trivalent::False, |l, r| l | r);

--- a/src/device/cuda/mem_model.rs
+++ b/src/device/cuda/mem_model.rs
@@ -186,7 +186,6 @@ fn tensor_thread_dims(space: &SearchSpace,
                       tensor_dims: &[ir::dim::Id],
                       sizes: &HashMap<ir::dim::Id, u32>,
                       gpu: &cuda::Gpu) -> Vec<ThreadDimInfo> {
-    // FIXME: add the thread dimensions that are not mapped to an active dimension
     let base_stride = base_stride as u64;
     let non_zero_strides = tensor_dims.iter().rev().scan(base_stride, |stride, dim| {
         let current_stride = *stride;

--- a/src/device/cuda/printer.rs
+++ b/src/device/cuda/printer.rs
@@ -180,7 +180,9 @@ fn inst(inst: &Instruction, namer: &mut NameMap, fun: &Function) -> String {
         op::St(ref addr, ref val, _,  _) => {
             let operator = st_operator(unwrap!(inst.mem_flag()));
             let t = lower_type(val.t(), fun);
-            let guard = namer.side_effect_guard();
+            let guard = if inst.has_side_effects() {
+                namer.side_effect_guard()
+            } else { None };
             assemble(operator, guard, t, &[Addr(addr), Op(val)], namer)
         },
         op::Cast(ref op, t) => {
@@ -213,7 +215,9 @@ fn vector_inst(inst: &Instruction, dim: &Dimension, namer: &mut NameMap, fun: &F
         op::St(ref addr, ref val, _, _) => {
             let operator = format!("{}.v{}", st_operator(flag), size);
             let operands = [Addr(addr), VecOp(val, dim.id(), size)];
-            let guard = namer.side_effect_guard();
+            let guard = if inst.has_side_effects() {
+                namer.side_effect_guard()
+            } else { None };
             assemble(&operator, guard, lower_type(val.t(), fun), &operands, namer)
         },
         _ => panic!("non-vectorizable instruction"),

--- a/src/device/cuda/printer.rs
+++ b/src/device/cuda/printer.rs
@@ -256,7 +256,7 @@ fn enable_threads(fun: &Function, threads: &[bool], namer: &mut NameMap) -> Stri
         let index = namer.name_index(dim.id());
         unwrap!(writeln!(ops, "  setp.eq.s32 {}, {}, 0;", new_guard, index));
         if let Some(ref guard) = guard {
-            unwrap!(writeln!(ops, "  and.pred {}, {}, {}", guard, guard, new_guard));
+            unwrap!(writeln!(ops, "  and.pred {}, {}, {};", guard, guard, new_guard));
         } else {
             guard = Some(new_guard);
         };
@@ -375,9 +375,9 @@ fn ptx_loop(fun: &Function, dim: &Dimension, cfgs: &[Cfg], namer: &mut NameMap)
         },
         DimKind::VECTOR => match *cfgs {
             [Cfg::Instruction(ref inst)] => vector_inst(inst, dim, namer, fun),
-            _ => panic!("Invalid vector dimension body"),
+            ref body => panic!("invalid vector dimension body: {:?}", body),
         },
-        kind => panic!("Invalid loop kind for ptx printing: {:?}", kind)
+        kind => panic!("invalid loop kind for ptx printing: {:?}", kind)
     }
 }
 

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -50,6 +50,8 @@ pub trait Device: Sync {
                    dim_sizes: &HashMap<ir::dim::Id, u32>,
                    nesting: &HashMap<ir::BBId, Nesting>,
                    bb: &ir::BasicBlock) -> HwPressure;
+    /// Returns the pressure caused by skipping a predicated instruction.
+    fn skipped_pressure(&self) -> HwPressure;
     /// Returns the pressure produced by a single iteration of a loop and the latency
     /// overhead of iterations.
     fn loop_iter_pressure(&self, kind: DimKind) -> (HwPressure, HwPressure);

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -15,7 +15,7 @@ use ir;
 use search_space::{SearchSpace, DimKind};
 use std::hash;
 use std::io::Write;
-use model::{HwPressure, Nesting};
+use model::{BottleneckLevel, HwPressure, Nesting};
 use utils::*;
 
 // TODO(perf): in PTX, shared and local pointers can have a 32-bit size, even in 64-bit
@@ -58,9 +58,9 @@ pub trait Device: Sync {
     /// Returns the processing rates of a single thread, in units/ns
     fn thread_rates(&self) -> HwPressure;
     /// Returns the processing rates of a single block, in units/ns.
-    fn block_rates(&self, max_num_threads: u64) -> HwPressure;
+    fn block_rates(&self,) -> HwPressure;
     /// Returns the processing rates of the whole accelerator un units/ns.
-    fn total_rates(&self, max_num_threads: u64) -> HwPressure;
+    fn total_rates(&self) -> HwPressure;
     /// Returns the names of potential bottlenecks.
     fn bottlenecks(&self) -> &[&'static str];
     /// Returns the number of blocks that can be executed in parallel on the device.
@@ -69,6 +69,10 @@ pub trait Device: Sync {
     fn additive_indvar_pressure(&self, t: &ir::Type) -> HwPressure;
     /// Returns the pressure caused by a multiplicative induction variable level.
     fn multiplicative_indvar_pressure(&self, t: &ir::Type) -> HwPressure;
+    /// Returns the ratio of hardware capacities wasted by the parallelism, given the
+    /// least common multiple of the possible numbers of threads per block.
+    fn get_waste_ratio(&self, bound_level: BottleneckLevel, lcm_threads_per_block: u64)
+        -> HwPressure;
 
     /// Lowers a type using the memory space information. Returns `None` if some
     /// information is not yet specified.

--- a/src/explorer/choice.rs
+++ b/src/explorer/choice.rs
@@ -51,16 +51,6 @@ pub fn list<'a>(space: &'a SearchSpace<'a>) -> impl Iterator<Item=Choice> + 'a {
     }))
 }
 
-/*
-/// Indicates if two dimensions are worth ordering.
-fn should_order_dims(space: &SearchSpace, lhs: ir::dim::Id, rhs: ir::dim::Id) -> bool {
-    // TODO(search_space): currently ignored ordering decisions may actually
-    // have an impact. We should use a differential model to detect when.
-    let lhs_kind = space.domain().get_dim_kind(lhs);
-    let rhs_kind = space.domain().get_dim_kind(rhs);
-    !(lhs_kind.intersects(DimKind::VECTOR) || rhs_kind.intersects(DimKind::VECTOR))
-}*/
-
 /// Generates a choice from a list of possible values.
 fn gen_choice<T, IT>(values: IT, action_gen: &Fn(T) -> Action) -> Option<Choice>
         where IT: IntoIterator<Item=T> {
@@ -70,13 +60,13 @@ fn gen_choice<T, IT>(values: IT, action_gen: &Fn(T) -> Action) -> Option<Choice>
 
 /// Chooses an order between instructions and dimensions when multiple are possible.
 /// The function assumes the order between dimensions is already fixed.
+// TODO(search_space): fix order has currently no effect. Should we remove it ?
+// It is unused because inst-dim and dim-dim decisions are fixed by the explorer. We
+// cannot make them free as we might end-up in a dead-end.
 pub fn fix_order(mut space: SearchSpace) -> SearchSpace {
-    // FIXME: unused for the moment, need to replace it
     // TODO(search_space): make fix_order useless with a differential model
     trace!("adding arbitrary constraints to the order");
     // Fix the order between instructions and dimensions.
-    // TODO(search_space): put the nesting back into the search space, as it might not
-    // be avoided by fix_order due to dependencies between orders.
     let pairs = space.ir_instance().blocks()
         .cartesian_product(space.ir_instance().dims())
         .map(|(lhs, rhs)| (lhs.bb_id(), rhs.bb_id()))

--- a/src/ir/dimension.rs
+++ b/src/ir/dimension.rs
@@ -23,13 +23,18 @@ pub struct Dimension<'a> {
     size: ir::Size<'a>,
     id: Id,
     iterated: Vec<ir::InstId>,
+    is_thread_dim: bool,
 }
 
 impl<'a> Dimension<'a> {
     /// Creates a new dimension.
     pub fn new(size: ir::Size, id: Id) -> Dimension {
         assert_ne!(size.as_int(), Some(1));
-        Dimension { size, id, iterated: Vec::new() }
+        Dimension {
+            size, id,
+            iterated: Vec::new(),
+            is_thread_dim: false,
+        }
     }
 
     /// Retruns the size of the dimension.
@@ -45,6 +50,12 @@ impl<'a> Dimension<'a> {
 
     /// Adds a bb that is iterated along self.
     pub fn add_iterated(&mut self, inst: ir::InstId) { self.iterated.push(inst); }
+
+    /// Indicates if the dimension is a thread dimension.
+    pub fn is_thread_dim(&self) -> bool { self.is_thread_dim }
+
+    /// Sets the dimension as a thread dimension.
+    pub fn set_thread_dim(&mut self) { self.is_thread_dim = true }
 }
 
 impl<'a> BasicBlock<'a> for Dimension<'a> {

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -34,6 +34,7 @@ pub struct Function<'a> {
     device: &'a Device,
     insts: Vec<Instruction<'a>>,
     dims: Vec<Dimension<'a>>,
+    thread_dims: Vec<ir::dim::Id>,
     mem_insts: Vec<ir::InstId>,
     mem_blocks: mem::BlockMap<'a>,
     layouts_to_lower: Vec<ir::mem::InternalId>,
@@ -50,6 +51,7 @@ impl<'a> Function<'a> {
             insts: vec![],
             mem_insts: vec![],
             dims: vec![],
+            thread_dims: vec![],
             mem_blocks,
             layouts_to_lower: Vec::new(),
             induction_vars: Vec::new(),
@@ -108,6 +110,11 @@ impl<'a> Function<'a> {
     /// Lists all `BasicBlock`s.
     pub fn blocks<'b>(&'b self) -> impl Iterator<Item=&'b BasicBlock<'a>> {
         self.insts.iter().map(|x| x as _).chain(self.dims.iter().map(|x| x as _))
+    }
+
+    /// Returns the list of thread dimensions.
+    pub fn thread_dims(&self) -> impl Iterator<Item=&Dimension<'a>> {
+        self.thread_dims.iter().map(move |&d| self.dim(d))
     }
 
     /// Returns an instruction given its id.

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -141,14 +141,6 @@ impl<'a> Function<'a> {
         }
     }
 
-    /// Returns a mutable reference to a basicblock.
-    fn block_mut(&mut self, id: BBId) -> &mut BasicBlock<'a> {
-        match id {
-            BBId::Inst(id) => &mut self.insts[id.0 as usize],
-            BBId::Dim(id) => &mut self.dims[id.0 as usize],
-        }
-    }
-
     /// Returns the list of memory blocks. The block with id `i` is in i-th position.
     pub fn mem_blocks<'b>(&'b self) -> impl Iterator<Item=&'b mem::Block> {
         self.mem_blocks.blocks()

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -130,7 +130,7 @@ impl<'a> Function<'a> {
 
     /// Returns a mutable reference to a dimension given its ID.
     fn dim_mut(&mut self, id: dim::Id) -> &mut Dimension<'a> {
-        &mut self.dims[id.id as usize]
+        &mut self.dims[id.0 as usize]
     }
 
     /// Returns a `BasicBlock` given its id.

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -53,6 +53,7 @@ pub struct NewObjs {
     pub internal_mem_blocks: Vec<mem::InternalId>,
     pub mem_insts: Vec<InstId>,
     pub iteration_dims: Vec<(InstId, dim::Id)>,
+    pub thread_dims: Vec<dim::Id>,
 }
 
 impl NewObjs {
@@ -84,6 +85,9 @@ impl NewObjs {
     pub fn add_iteration_dim(&mut self, inst: InstId, dim: dim::Id) {
         self.iteration_dims.push((inst, dim));
     }
+
+    /// Sets a dimension as a new thread dimension.
+    pub fn add_thread_dim(&mut self, dim: dim::Id) { self.thread_dims.push(dim) }
 
     /// Registers a new memory block.
     pub fn add_mem_block(&mut self, id: mem::InternalId) {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -74,6 +74,7 @@ impl NewObjs {
     pub fn add_dimension(&mut self, dim: &Dimension) {
         self.add_bb(dim);
         self.dimensions.push(dim.id());
+        if dim.is_thread_dim() { self.add_thread_dim(dim.id()); }
     }
 
     /// Registers a new basic block.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,11 +44,10 @@ pub mod model;
 pub mod search_space;
 
 // FIXME: thread-mapping
-// - test thread mapping in codegen
-//  > how ?
-// - use the thread mapping in the performance model
-//  > in active dimensions
-//    - use the global number of threads
-//    - remove dimensions that can be merged to a thread from the list of active dimensions
-//  > in mem model
-// - remove old mapping constraints
+// > test the model is corrent
+//   - test local info
+//   - test sum_pressure
+// > test the codegen is correct
+//   - thread mapping
+//   - predicated store
+// > fix store

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,7 @@ pub mod model;
 pub mod search_space;
 
 // FIXME: thread-mapping
-// - rely on thread-mapping for the dim maps
-// - put constraints on the threads quotient rather than individual instructions
 // - use the thread mapping in codegen
+// - explore thread mapping decisions
 // - use the thread mapping in the performance model
 // - remove old mapping constraints

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,11 @@ pub mod model;
 pub mod search_space;
 
 // FIXME: thread-mapping
-// - use the thread mapping in codegen
-// - explore thread mapping decisions
+// - test thread mapping in codegen
+//  > how ?
 // - use the thread mapping in the performance model
+//  > in active dimensions
+//    - use the global number of threads
+//    - remove dimensions that can be merged to a thread from the list of active dimensions
+//  > in mem model
 // - remove old mapping constraints

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,3 +42,11 @@ pub mod explorer;
 pub mod ir;
 pub mod model;
 pub mod search_space;
+
+// FIXME: thread-mapping
+// - have a quotient set to list active thread dims
+// - rely on thread-mapping for the dim maps
+// - put constraints on the threads quotient rather than individual instructions
+// - use the thread mapping in codegen
+// - use the thread mapping in the performance model
+// - remove old mapping constraints

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,6 @@ pub mod model;
 pub mod search_space;
 
 // FIXME: thread-mapping
-// - have a quotient set to list active thread dims
 // - rely on thread-mapping for the dim maps
 // - put constraints on the threads quotient rather than individual instructions
 // - use the thread mapping in codegen

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,12 +42,3 @@ pub mod explorer;
 pub mod ir;
 pub mod model;
 pub mod search_space;
-
-// FIXME: thread-mapping
-// > test the model is corrent
-//   - test local info
-//   - test sum_pressure
-// > test the codegen is correct
-//   - thread mapping
-//   - predicated store
-// > fix store

--- a/src/model/hw_pressure.rs
+++ b/src/model/hw_pressure.rs
@@ -297,7 +297,7 @@ impl fmt::Display for Origin {
                     iterations, dims.iter().format(", "), inner)
             },
             Origin::Scale { ref inner, factor } =>
-                write!(f, "scale by {:.2e}:  {}", factor, inner),
+                write!(f, "scale by {:.2e}: {}", factor, inner),
             Origin::Chain { ref before, ref mid_point, ref after } => {
                 display_inline_chain(before, f)?;
                 write!(f, " to {}, then ", mid_point)?;

--- a/src/model/hw_pressure.rs
+++ b/src/model/hw_pressure.rs
@@ -135,7 +135,7 @@ pub enum FastOrigin {
 }
 
 /// The level at which a bottleneck is computed.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum BottleneckLevel { Global, Block, Thread }
 
 impl BottleneckLevel {

--- a/src/model/hw_pressure.rs
+++ b/src/model/hw_pressure.rs
@@ -135,7 +135,7 @@ pub enum FastOrigin {
 }
 
 /// The level at which a bottleneck is computed.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum BottleneckLevel { Global, Block, Thread }
 
 impl BottleneckLevel {

--- a/src/model/hw_pressure.rs
+++ b/src/model/hw_pressure.rs
@@ -398,4 +398,12 @@ impl HwPressure {
     /// Returns the pressure on a bottleneck.
     #[cfg(test)]
     pub fn get_bottleneck(&self, index: usize) -> f64 { self.bottlenecks[index] }
+
+    /// Pointwise multiplication of the pressure on each resource.
+    pub fn multiply(&mut self, other: &HwPressure) {
+        self.latency *= other.latency;
+        for (b, &other_b) in self.bottlenecks.iter_mut().zip_eq(&other.bottlenecks) {
+            *b *= other_b;
+        }
+    }
 }

--- a/src/model/level.rs
+++ b/src/model/level.rs
@@ -42,7 +42,7 @@ impl Level {
         // Compute the thread-level pressure.
         let thread_rates = device.thread_rates();
         let pressure = sum_pressure(
-            device, space, local_info, BottleneckLevel::Thread, 1, &dims);
+            device, space, local_info, BottleneckLevel::Thread, &dims);
         let end_latency = dims.iter().map(|d| {
             local_info.dim_overhead[d].1.bound(BottleneckLevel::Thread, &thread_rates)
         }).min().unwrap_or_else(FastBound::zero);
@@ -63,15 +63,21 @@ pub fn sum_pressure(device: &Device,
                     space: &SearchSpace,
                     local_info: &LocalInfo,
                     bound_level: BottleneckLevel,
-                    min_num_threads: u64,
                     dims: &[ir::dim::Id]) -> HwPressure {
     // Compute the pressure induced by the dimensions overhead.
     let mut pressure = HwPressure::min(dims.iter().map(|d| &local_info.dim_overhead[d].0))
         .unwrap_or_else(|| HwPressure::zero(device));
-    if bound_level == BottleneckLevel::Global {
-        // FIXME:Take min_num_thread from the bound level instead of the argument
-        let thread_overhead = &local_info.thread_overhead;
-        pressure.repeat_and_add_bottlenecks(min_num_threads as f64, thread_overhead);
+    if dims.is_empty() {
+        let threads_per_block = space.domain().get_num_threads().min as u64;
+        let num_threads = match bound_level {
+            BottleneckLevel::Global =>
+                threads_per_block * local_info.parallelism.min_num_blocks,
+            BottleneckLevel::Block => threads_per_block,
+            BottleneckLevel::Thread => 1,
+        };
+        let mut init_pressure = device.get_waste_ratio(bound_level, threads_per_block);
+        init_pressure.multiply(&local_info.thread_overhead);
+        pressure.repeat_and_add_bottlenecks(num_threads as f64, &init_pressure);
     }
     // Get the list of inner dimensions and inner dimensions on wich the pressure is summed.
     let inner_dim_sets = dims.iter().map(|&d| &local_info.nesting[&d.into()].inner_dims);
@@ -90,6 +96,7 @@ pub fn sum_pressure(device: &Device,
         });
     // Sum the pressure on all bbs.
     for bb in inner_bbs {
+        let nesting = &local_info.nesting[&bb];
         // Skip dimensions that can be merged into another one.
         let merge_dims = &local_info.nesting[&bb].bigger_merged_dims;
         if inner_dims.intersection(merge_dims).next().is_some() { continue; }
@@ -98,17 +105,20 @@ pub fn sum_pressure(device: &Device,
             .intersection(&local_info.nesting[&bb].outer_dims)
             .map(|d| f64::from(local_info.dim_sizes[d]))
             .product::<f64>();
-        let bb_pressure = if let ir::BBId::Dim(dim) = bb {
+        let mut bb_pressure = if let ir::BBId::Dim(dim) = bb {
             let kind = space.domain().get_dim_kind(dim);
             if !bound_level.accounts_for_dim(kind) {
                 &local_info.dim_overhead[&dim].0
             } else { &local_info.hw_pressure[&bb] }
         } else { &local_info.hw_pressure[&bb] };
-        // Predicated instructions are not executed on unmapped thread dimensions.
-        let is_predicated = space.ir_instance().block(bb).as_inst()
-            .map(|i| i.has_side_effects()).unwrap_or(false);
-        let unmapped_threads = local_info.nesting[&bb].num_unmapped_threads as f64;
+        // From parallel levels, we must take into account the thread dimensions that re
+        // not mapped to a dimension outside of the block. Predicated instructions require
+        // special care as they are only active on the dimensions they are nested on. Other
+        // threads just skip the instruction.
         if bound_level <= BottleneckLevel::Block {
+            let is_predicated = space.ir_instance().block(bb).as_inst()
+                .map(|i| i.has_side_effects()).unwrap_or(false);
+            let unmapped_threads = nesting.num_unmapped_threads as f64;
             if is_predicated {
                 let num_skipped = unmapped_threads * (num_instances - 1.0);
                 pressure.repeat_and_add_bottlenecks(num_skipped, &device.skipped_pressure());
@@ -116,7 +126,10 @@ pub fn sum_pressure(device: &Device,
                 num_instances *= unmapped_threads;
             }
         }
-        pressure.repeat_and_add_bottlenecks(num_instances, bb_pressure);
+        let mut bb_apparent_pressure = device.get_waste_ratio(
+            bound_level, nesting.max_threads_per_block);
+        bb_apparent_pressure.multiply(bb_pressure);
+        pressure.repeat_and_add_bottlenecks(num_instances, &bb_apparent_pressure);
     }
     pressure
 }
@@ -135,16 +148,12 @@ fn intersect_sets<'a, T, IT>(mut it: IT) -> Option<VecSet<T>>
 /// Generates a bound based on the pressure produced by a block of threads.
 fn block_bound(device: &Device, space: &SearchSpace, info: &LocalInfo,
                dims: &[ir::dim::Id]) -> FastBound {
-    // Compute the minimal and maximal number of threads.
-    let min_num_threads = info.parallelism.min_num_threads_per_block;
-    let max_num_threads = info.parallelism.max_num_threads_per_block;
     // Compute the pressure on the execution units in a single iteration.
-    let mut pressure = sum_pressure(device, space, info, BottleneckLevel::Block,
-                                    min_num_threads, dims);
+    let mut pressure = sum_pressure(device, space, info, BottleneckLevel::Block, dims);
     // Repeat the pressure by the number of iterations of the level and compute the bound.
     let n_iters = dims.iter().map(|&d| u64::from(info.dim_sizes[&d])).product::<u64>();
     pressure.repeat_parallel(n_iters as f64);
-    pressure.bound(BottleneckLevel::Block, &device.block_rates(max_num_threads))
+    pressure.bound(BottleneckLevel::Block, &device.block_rates())
 }
 
 /// Indicates if a dimension should be considered for dimension levels.

--- a/src/model/local_info.rs
+++ b/src/model/local_info.rs
@@ -114,7 +114,7 @@ pub struct Nesting {
     pub bigger_merged_dims: VecSet<ir::dim::Id>,
     /// Indicates if the block may have thread dimensions nested inside it.
     /// Only consider thread dimensions that are sure to be mapped to threads.
-    pub has_inner_thread_dims: bool,
+    has_inner_thread_dims: bool,
     /// Number of threads that are not represented in the active dimensions of the block.
     pub num_unmapped_threads: u32,
 }
@@ -244,6 +244,13 @@ fn parallelism(space: &SearchSpace, nesting: &HashMap<ir::BBId, Nesting>,
         }
         par
     }).fold(Parallelism::default(), |lhs, rhs| Parallelism {
+        // FIXME: use lcm rather than max: we assume the real is a multiple
+        // - where ?
+        // max_t_per_b> we really need the lcm, but do not use the max: rename ?
+        // min_num_thread_per_blocks is only used for thread overhead, is easy to obtain
+        // max_num_blocks is used for scaling. Do we need lcm ?
+        // min_num_blocks is used for scaling. Do we need a multiples, gcd ? ?
+        // min_num_threads is only used for thread overhead > really need the min
         min_num_blocks: cmp::max(lhs.min_num_blocks, rhs.min_num_blocks),
         max_num_blocks: cmp::max(lhs.max_num_blocks, rhs.max_num_blocks),
         min_num_threads: cmp::max(lhs.min_num_threads, rhs.min_num_threads),

--- a/src/model/local_info.rs
+++ b/src/model/local_info.rs
@@ -2,7 +2,7 @@
 use device::{Context, Device};
 use ir::{self, BasicBlock};
 use model::HwPressure;
-use search_space::{DimKind, Domain, Order, SearchSpace};
+use search_space::{DimKind, Domain, Order, SearchSpace, ThreadMapping};
 use std::cmp;
 use utils::*;
 
@@ -29,14 +29,30 @@ impl LocalInfo {
     pub fn compute(space: &SearchSpace, context: &Context) -> Self {
         let dim_sizes = space.ir_instance().dims()
             .map(|d| (d.id(), context.eval_size(d.size()))).collect();
-        let nesting = space.ir_instance().blocks()
-            .map(|bb| (bb.bb_id(), Nesting::compute(space, bb.bb_id()))).collect();
+        let nesting: HashMap<_, _> = space.ir_instance().blocks().map(|bb| {
+            (bb.bb_id(), Nesting::compute(space, bb.bb_id(), &dim_sizes))
+        }).collect();
         let mut hw_pressure = space.ir_instance().blocks().map(|bb| {
-            (bb.bb_id(), context.device().hw_pressure(space, &dim_sizes, &nesting, bb))
+            let is_thread = if let ir::BBId::Dim(id) = bb.bb_id() {
+                space.domain().get_dim_kind(id) == DimKind::THREAD
+            } else { false };
+            // Only keep the pressure of innermost thread dimensions. Otherwise it
+            // will be taken multiple times into account.
+            let pressure = if is_thread && nesting[&bb.bb_id()].has_inner_thread_dims {
+                HwPressure::zero(context.device())
+            } else { context.device().hw_pressure(space, &dim_sizes, &nesting, bb) };
+            (bb.bb_id(), pressure)
         }).collect();
         let mut dim_overhead = space.ir_instance().dims().map(|d| {
             let kind = space.domain().get_dim_kind(d.id());
-            (d.id(), context.device().loop_iter_pressure(kind))
+            if kind == DimKind::THREAD && nesting[&d.bb_id()].has_inner_thread_dims {
+                // Only keep the overhead on innermost thread dimensions. Otherwise it
+                // will be taken multiple times into account.
+                let zero = HwPressure::zero(context.device());
+                (d.id(), (zero.clone(), zero))
+            } else {
+                (d.id(), context.device().loop_iter_pressure(kind))
+            }
         }).collect();
         let parallelism = parallelism(space, &nesting, &dim_sizes);
         // Add the pressure induced by induction variables.
@@ -96,22 +112,33 @@ pub struct Nesting {
     pub after_self: VecSet<ir::dim::Id>,
     /// The dimensions that can be merged to this one and have a bigger ID.
     pub bigger_merged_dims: VecSet<ir::dim::Id>,
+    /// Indicates if the block has thread dimensions nested inside it.
+    pub has_inner_thread_dims: bool,
+    /// Number of threads that are not represented in the active dimensions of the block.
+    pub num_unmapped_threads: u32,
 }
 
 impl Nesting {
     /// Computes the nesting of a `BasicBlock`.
-    fn compute(space: &SearchSpace, bb: ir::BBId) -> Self {
+    fn compute(space: &SearchSpace, bb: ir::BBId,
+               dim_sizes: &HashMap<ir::dim::Id, u32>) -> Self {
         let mut inner_dims = Vec::new();
         let mut inner_bbs = Vec::new();
         let mut before_self = Vec::new();
         let mut after_self = Vec::new();
         let mut bigger_merged_dims = Vec::new();
+        let mut has_inner_thread_dims = false;
         for other_bb in space.ir_instance().blocks().map(|bb| bb.bb_id()) {
             if other_bb == bb { continue; }
             let order = space.domain().get_order(other_bb, bb);
             if Order::INNER.contains(order) { inner_bbs.push(other_bb); }
             if let ir::BBId::Dim(id) = other_bb {
                 if Order::INNER.contains(order) { inner_dims.push(id); }
+                if order.intersects(Order::INNER) {
+                    if space.domain().get_dim_kind(id) == DimKind::THREAD {
+                        has_inner_thread_dims = true;
+                    }
+                }
                 if (Order::INNER | Order::BEFORE).contains(order) { before_self.push(id); }
                 if (Order::OUTER | Order::AFTER).contains(order) { after_self.push(id); }
                 if order.intersects(Order::MERGED) && other_bb > bb {
@@ -119,6 +146,13 @@ impl Nesting {
                 }
             }
         }
+        let num_unmapped_threads = space.ir_instance().thread_dims().filter(|dim| {
+            !outer_dims.iter().any(|&other| {
+                if dim.id() == other { return true; }
+                let mapping = space.domain().get_thread_mapping(dim.id(), other);
+                mapping.intersects(ThreadMapping::MAPPED)
+            })
+        }).map(|d| dim_sizes[&d.id()]).product::<u32>();
         Nesting {
             inner_dims: VecSet::new(inner_dims),
             inner_bbs: VecSet::new(inner_bbs),
@@ -126,6 +160,8 @@ impl Nesting {
             before_self: VecSet::new(before_self),
             after_self: VecSet::new(after_self),
             bigger_merged_dims: VecSet::new(bigger_merged_dims),
+            has_inner_thread_dims,
+            num_unmapped_threads,
         }
     }
 
@@ -181,26 +217,38 @@ impl Default for Parallelism {
 /// Computes the minimal and maximal parallelism accross instructions.
 fn parallelism(space: &SearchSpace, nesting: &HashMap<ir::BBId, Nesting>,
                dim_sizes: &HashMap<ir::dim::Id, u32>) -> Parallelism {
-    space.ir_instance().insts().map(|inst| {
+    let min_num_threads_per_block = space.domain().get_num_threads().min as u64;
+    let mut par = space.ir_instance().insts().map(|inst| {
         let mut par = Parallelism::default();
+        par.max_num_threads_per_block = min_num_threads_per_block;
+        par.min_num_threads = min_num_threads_per_block;
         for &dim in &nesting[&inst.bb_id()].outer_dims {
             let kind = space.domain().get_dim_kind(dim);
             let size = u64::from(dim_sizes[&dim]);
             if kind == DimKind::BLOCK { par.min_num_blocks *= size; }
             if kind.intersects(DimKind::BLOCK) { par.max_num_blocks *= size; }
-            let thread_or_block = DimKind::THREAD | DimKind::BLOCK;
-            if thread_or_block.contains(kind) { par.min_num_threads *= size; }
-            if kind == DimKind::THREAD { par.min_num_threads_per_block *= size; }
-            if DimKind::THREAD.intersects(kind) { par.max_num_threads_per_block *= size; }
+            if DimKind::THREAD.intersects(kind) {
+                let is_mapped = space.ir_instance().thread_dims().any(|other| {
+                    if dim == other.id() { return true };
+                    let mapping = space.domain().get_thread_mapping(dim, other.id());
+                    mapping.intersects(ThreadMapping::MAPPED)
+                });
+                if !is_mapped {
+                    par.max_num_threads_per_block *= size;
+                    let thread_or_block = DimKind::THREAD | DimKind::BLOCK;
+                    if thread_or_block.contains(kind) { par.min_num_threads *= size; }
+                }
+            }
         }
         par
     }).fold(Parallelism::default(), |lhs, rhs| Parallelism {
         min_num_blocks: cmp::max(lhs.min_num_blocks, rhs.min_num_blocks),
         max_num_blocks: cmp::max(lhs.max_num_blocks, rhs.max_num_blocks),
         min_num_threads: cmp::max(lhs.min_num_threads, rhs.min_num_threads),
-        min_num_threads_per_block: cmp::max(
-            lhs.min_num_threads_per_block, rhs.min_num_threads_per_block),
         max_num_threads_per_block: cmp::max(
             lhs.max_num_threads_per_block, rhs.max_num_threads_per_block),
-    })
+        min_num_threads_per_block: 1,
+    });
+    par.min_num_threads_per_block = min_num_threads_per_block;
+    par
 }

--- a/src/model/local_info.rs
+++ b/src/model/local_info.rs
@@ -117,6 +117,9 @@ pub struct Nesting {
     has_inner_thread_dims: bool,
     /// Number of threads that are not represented in the active dimensions of the block.
     pub num_unmapped_threads: u32,
+    /// Maximal number of threads this block can be in, considering only outer and mapped
+    /// out dimensions.
+    pub max_threads_per_block: u64
 }
 
 impl Nesting {
@@ -129,40 +132,49 @@ impl Nesting {
         let mut after_self = Vec::new();
         let mut bigger_merged_dims = Vec::new();
         let mut has_inner_thread_dims = false;
-        for other_bb in space.ir_instance().blocks().map(|bb| bb.bb_id()) {
-            if other_bb == bb { continue; }
-            let order = space.domain().get_order(other_bb, bb);
-            if Order::INNER.contains(order) { inner_bbs.push(other_bb); }
-            if let ir::BBId::Dim(id) = other_bb {
-                if Order::INNER.contains(order) { inner_dims.push(id); }
+        let mut max_threads_per_block = 1u64;
+        for other_bb in space.ir_instance().blocks() {
+            if other_bb.bb_id() == bb { continue; }
+            let order = space.domain().get_order(other_bb.bb_id(), bb);
+            if Order::INNER.contains(order) { inner_bbs.push(other_bb.bb_id()); }
+            if let Some(dim) = other_bb.as_dim() {
+                let other_kind = space.domain().get_dim_kind(dim.id());
+                if Order::INNER.contains(order) { inner_dims.push(dim.id()); }
                 if order.intersects(Order::INNER) {
-                    if space.domain().get_dim_kind(id) == DimKind::THREAD {
-                        has_inner_thread_dims = true;
-                    }
+                    if other_kind == DimKind::THREAD { has_inner_thread_dims = true; }
                 }
-                if (Order::INNER | Order::BEFORE).contains(order) { before_self.push(id); }
-                if (Order::OUTER | Order::AFTER).contains(order) { after_self.push(id); }
-                if order.intersects(Order::MERGED) && other_bb > bb {
-                    bigger_merged_dims.push(id);
+                if (Order::INNER | Order::BEFORE).contains(order) {
+                    before_self.push(dim.id());
+                }
+                if (Order::OUTER | Order::AFTER).contains(order) {
+                    after_self.push(dim.id());
+                }
+                if order.intersects(Order::MERGED) && other_bb.bb_id() > bb {
+                    bigger_merged_dims.push(dim.id());
                 }
             }
         }
-        let num_unmapped_threads = space.ir_instance().thread_dims().filter(|dim| {
+        let outer_dims = Self::get_iteration_dims(space, bb);
+        let max_threads_per_block = space.ir_instance().thread_dims().filter(|dim| {
             !outer_dims.iter().any(|&other| {
                 if dim.id() == other { return true; }
                 let mapping = space.domain().get_thread_mapping(dim.id(), other);
                 mapping.intersects(ThreadMapping::MAPPED)
             })
-        }).map(|d| dim_sizes[&d.id()]).product::<u32>();
+        }).map(|d| d.id())
+        .chain(outer_dims.iter().cloned().filter(|&d| {
+            space.domain().get_dim_kind(d).intersects(DimKind::THREAD)
+        }).map(|d| dim_sizes[&d.id()] as u64).product::<u64>();
         Nesting {
             inner_dims: VecSet::new(inner_dims),
             inner_bbs: VecSet::new(inner_bbs),
-            outer_dims: Self::get_iteration_dims(space, bb),
+            outer_dims,
             before_self: VecSet::new(before_self),
             after_self: VecSet::new(after_self),
             bigger_merged_dims: VecSet::new(bigger_merged_dims),
             has_inner_thread_dims,
             num_unmapped_threads,
+            max_threads_per_block,
         }
     }
 
@@ -195,12 +207,6 @@ pub struct Parallelism {
     pub min_num_blocks: u64,
     /// Maximal number of blocks of threads.
     pub max_num_blocks: u64,
-    /// Minimal number of threads in the whole GPU.
-    pub min_num_threads: u64,
-    /// Minimal number of threads per thread blocks.
-    pub min_num_threads_per_block: u64,
-    /// Maximal number of threads per thread blocks.
-    pub max_num_threads_per_block: u64,
 }
 
 impl Default for Parallelism {
@@ -208,9 +214,6 @@ impl Default for Parallelism {
         Parallelism {
             min_num_blocks: 1,
             max_num_blocks: 1,
-            min_num_threads: 1,
-            min_num_threads_per_block: 1,
-            max_num_threads_per_block: 1,
         }
     }
 }
@@ -218,46 +221,21 @@ impl Default for Parallelism {
 /// Computes the minimal and maximal parallelism accross instructions.
 fn parallelism(space: &SearchSpace, nesting: &HashMap<ir::BBId, Nesting>,
                dim_sizes: &HashMap<ir::dim::Id, u32>) -> Parallelism {
-    let min_num_threads_per_block = space.domain().get_num_threads().min as u64;
-    let mut par = space.ir_instance().insts().map(|inst| {
+    let par = space.ir_instance().insts().map(|inst| {
         let mut par = Parallelism::default();
-        par.max_num_threads_per_block = min_num_threads_per_block;
-        par.min_num_threads = min_num_threads_per_block;
         for &dim in &nesting[&inst.bb_id()].outer_dims {
             let kind = space.domain().get_dim_kind(dim);
             let size = u64::from(dim_sizes[&dim]);
             if kind == DimKind::BLOCK { par.min_num_blocks *= size; }
             if kind.intersects(DimKind::BLOCK) { par.max_num_blocks *= size; }
-            if DimKind::THREAD.intersects(kind) {
-                // FIXME: incorrect
-                let is_mapped = space.ir_instance().thread_dims().any(|other| {
-                    if dim == other.id() { return true };
-                    let mapping = space.domain().get_thread_mapping(dim, other.id());
-                    mapping.intersects(ThreadMapping::MAPPED)
-                });
-                if !is_mapped {
-                    par.max_num_threads_per_block *= size;
-                    let thread_or_block = DimKind::THREAD | DimKind::BLOCK;
-                    if thread_or_block.contains(kind) { par.min_num_threads *= size; }
-                }
-            }
         }
         par
     }).fold(Parallelism::default(), |lhs, rhs| Parallelism {
         // FIXME: use lcm rather than max: we assume the real is a multiple
-        // - where ?
-        // max_t_per_b> we really need the lcm, but do not use the max: rename ?
-        // min_num_thread_per_blocks is only used for thread overhead, is easy to obtain
-        // max_num_blocks is used for scaling. Do we need lcm ?
-        // min_num_blocks is used for scaling. Do we need a multiples, gcd ? ?
-        // min_num_threads is only used for thread overhead > really need the min
+        // > max_num_blocks is used for scaling. Do we need lcm ?
+        // > min_num_blocks is used for scaling. Do we need a multiples, gcd ? ?
         min_num_blocks: cmp::max(lhs.min_num_blocks, rhs.min_num_blocks),
         max_num_blocks: cmp::max(lhs.max_num_blocks, rhs.max_num_blocks),
-        min_num_threads: cmp::max(lhs.min_num_threads, rhs.min_num_threads),
-        max_num_threads_per_block: cmp::max(
-            lhs.max_num_threads_per_block, rhs.max_num_threads_per_block),
-        min_num_threads_per_block: 1,
     });
-    par.min_num_threads_per_block = min_num_threads_per_block;
     par
 }

--- a/src/model/local_info.rs
+++ b/src/model/local_info.rs
@@ -112,7 +112,8 @@ pub struct Nesting {
     pub after_self: VecSet<ir::dim::Id>,
     /// The dimensions that can be merged to this one and have a bigger ID.
     pub bigger_merged_dims: VecSet<ir::dim::Id>,
-    /// Indicates if the block has thread dimensions nested inside it.
+    /// Indicates if the block may have thread dimensions nested inside it.
+    /// Only consider thread dimensions that are sure to be mapped to threads.
     pub has_inner_thread_dims: bool,
     /// Number of threads that are not represented in the active dimensions of the block.
     pub num_unmapped_threads: u32,
@@ -228,6 +229,7 @@ fn parallelism(space: &SearchSpace, nesting: &HashMap<ir::BBId, Nesting>,
             if kind == DimKind::BLOCK { par.min_num_blocks *= size; }
             if kind.intersects(DimKind::BLOCK) { par.max_num_blocks *= size; }
             if DimKind::THREAD.intersects(kind) {
+                // FIXME: incorrect
                 let is_mapped = space.ir_instance().thread_dims().any(|other| {
                     if dim == other.id() { return true };
                     let mapping = space.domain().get_thread_mapping(dim, other.id());

--- a/src/model/local_info.rs
+++ b/src/model/local_info.rs
@@ -105,11 +105,11 @@ fn add_indvar_pressure(device: &Device,
 /// Nesting of an object.
 #[derive(Debug)]
 pub struct Nesting {
-    /// Dimensions nested outside the current BB.
+    /// Dimensions nested inside the current BB.
     pub inner_dims: VecSet<ir::dim::Id>,
     /// Basic blocks nested inside the current BB.
     pub inner_bbs: VecSet<ir::BBId>,
-    /// Dimensions nested inside the current BB.
+    /// Dimensions nested outsidethe current BB.
     pub outer_dims: VecSet<ir::dim::Id>,
     /// Dimensions to be processed before the current BB.
     pub before_self: VecSet<ir::dim::Id>,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -314,8 +314,7 @@ mod tests {
 
         let dim_z = builder.open_dim_ex(size, DimKind::THREAD);
         let (addr, pattern) = builder.tensor_access(&"z", z, &ir::Type::F(32), &[&dim_z]);
-        builder.st(&addr, &0f32, pattern);
-        // FIXME: works for ld but not st ?
+        let st_z = builder.st(&addr, &0f32, pattern);
 
         builder.order(&dim_x, &dim_z, Order::BEFORE);
         builder.order(&dim_x, &dim_y, Order::OUTER);
@@ -323,6 +322,7 @@ mod tests {
         let partial_pressure = {
             let space = builder.get_clone();
             let local_info = LocalInfo::compute(&space, &context);
+            trace!("partial nesting: {:?}", local_info.nesting[&st_z.into()]);
             sum_pressure(context.device(), &space, &local_info,
                          BottleneckLevel::Global, &[])
         }.get_bottleneck(3);
@@ -331,6 +331,7 @@ mod tests {
         let final_pressure = {
             let space = builder.get_clone();
             let local_info = LocalInfo::compute(&space, &context);
+            trace!("final nesting: {:?}", local_info.nesting[&st_z.into()]);
             sum_pressure(context.device(), &space, &local_info,
                          BottleneckLevel::Global, &[])
         }.get_bottleneck(3);

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -282,8 +282,9 @@ fn apply_dim_map(device: &Device,
     }
 }
 
+#[cfg(feature="cuda")]
 #[cfg(test)]
-mod tests {
+mod cuda_tests {
     use codegen;
     use device::{Context, cuda, EvalMode};
     use env_logger;
@@ -292,12 +293,11 @@ mod tests {
     use search_space::*;
     use super::*;
 
-    #[cfg(feature="cuda")]
     #[test]
     fn partial_bound_0() {
         let _ = env_logger::try_init();
         let executor = cuda::Executor::init();
-        let mut context = cuda::Context::new(&executor); 
+        let mut context = cuda::Context::new(&executor);
         let z;
         let signature = {
             let mut builder = SignatureBuilder::new("test", &mut context);
@@ -342,7 +342,6 @@ mod tests {
                 final_pressure, partial_pressure);
     }
 
-    #[cfg(feature="cuda")]
     #[test]
     fn partial_bound_1() {
         let _ = env_logger::try_init();
@@ -387,7 +386,6 @@ mod tests {
     }
 
 
-    #[cfg(feature="cuda")]
     #[test]
     fn partial_bound_2() {
         let _ = env_logger::try_init();
@@ -448,12 +446,11 @@ mod tests {
 
     }
 
-    #[cfg(feature="cuda")]
     #[test]
     fn final_bound_0() {
         let _ = env_logger::try_init();
         let executor = cuda::Executor::init();
-        let mut context = cuda::Context::new(&executor); 
+        let mut context = cuda::Context::new(&executor);
 
         let (x, y, z);
         let signature = {
@@ -499,10 +496,5 @@ mod tests {
         let kernel = codegen::Function::build(&space);
         let eval = unwrap!(context.evaluate(&kernel, EvalMode::TestBound));
         assert!(eval * 1.001 >= bound.value(), "{:.2e} < {}", eval, bound);
-
-        // FIXME:
-        // * Thread dim accounted twice
-        // * 3 syncthreads/thread instead of 2.
-        // * nested thread dimensions are all accounted for
     }
 }

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -81,6 +81,19 @@ quotient IterationDims($inst in Instructions) of $dim in Dimensions:
   add_to_set = "::search_space::add_iteration_dim($fun, $inst, $item)"
 end
 
+quotient ThreadDims of $dim in Dimensions:
+  is_thread_dim = dim_kind($dim) is THREAD / thread_mapping is MAPPED
+  item_type = "ir::Dimension"
+  id_type = "ir::dim::Id"
+  item_getter = "$fun.dim($id)"
+  id_getter = "$item.id()"
+  iterator = "$fun.thread_dims()"
+  var_prefix = "thread_dim"
+  new_objs = "$objs.thread_dims"
+  from_superset = "(if $item.is_thread_dim() { Some($item) } else { None })"
+  add_to_set = "::search_space::add_thread_dim($fun, $item)"
+end
+
 /// Specifies how iteration dimensions are implemented.
 define enum dim_kind($dim in Dimensions):
   /// The dimension is implemented as a regular loop.

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -117,22 +117,8 @@ define enum dim_kind($dim in Dimensions):
       dim_kind($other_dim) is BLOCK || order($dim, $other_dim) is OUTER
     requires forall $other in BasicBlocks:
       order($dim, $other) is NESTED | MERGED
-  /// Outermost thread dimension (reverse CUDA convention).
-  value THREAD_X:
-    requires forall $other in Dimensions:
-      order($dim, $other) is not INNER || dim_kind($other) is not THREAD
-  /// Middle thread dimension.
-  value THREAD_Y:
-    requires num_thread_x($dim) > "0"
-    requires forall $other in Dimensions:
-      order($dim, $other) is not INNER || dim_kind($other) is not THREAD_Y | THREAD_Z
-  /// Innermost thread dimension (reverse CUDA convention).
-  value THREAD_Z:
-    requires num_thread_y($dim) > "0"
-    requires forall $other in Dimensions:
-      order($dim, $other) is not INNER || dim_kind($other) is not THREAD_Z
   /// The dimension is mapped to a thread dimension on the device.
-  alias THREAD = THREAD_X | THREAD_Y | THREAD_Z:
+  value THREAD:
     requires "$dim.size().as_int().is_some()"
   /// The dimension is parallel.
   alias PARALLEL = BLOCK | THREAD | VECTOR:
@@ -243,39 +229,6 @@ require forall $lhs in Dimensions:
     dim_kind($lhs) is not THREAD || dim_kind($lhs) != dim_kind($rhs)
       || "$lhs.size() == $rhs.size()"
 
-/// Counts the number of thread dimensions.
-// TODO(cc_perf): try to rely exclusively on the counter instead of thread slots.
-
-// FIXME: replace with a late counter
-define internal counter num_thread_x($bb in BasicBlocks):
-  forall $dim in Dimensions:
-    sum "1" when:
-      order($dim, $bb) is OUTER
-      dim_kind($dim) is THREAD_X
-end
-
-// FIXME: replace with a late counter
-define internal counter num_thread_y($bb in BasicBlocks):
-  forall $dim in Dimensions:
-    sum "1" when:
-      order($dim, $bb) is OUTER
-      dim_kind($dim) is THREAD_Y
-end
-
-// FIXME: replace with a late counter
-define internal counter num_thread_z($bb in BasicBlocks):
-  forall $dim in Dimensions:
-    sum "1" when:
-      order($dim, $bb) is OUTER
-      dim_kind($dim) is THREAD_Z
-end
-
-require forall $lhs in Instructions:
-  forall $rhs in Instructions:
-    num_thread_x($lhs) <= "0" || num_thread_x($rhs) > "0"
-    num_thread_y($lhs) <= "0" || num_thread_y($rhs) > "0"
-    num_thread_z($lhs) <= "0" || num_thread_z($rhs) > "0"
-
 /// Specifies the valid mappings between two dimensions.
 define enum dim_mapping($lhs in Dimensions, $rhs in Dimensions):
   symmetric
@@ -333,7 +286,7 @@ require forall $outer in Dimensions:
     forall $mid in Dimensions:
       order($outer, $mid) is not OUTER || order($mid, $inner) is not OUTER
         || dim_kind($outer) is not THREAD || dim_kind($inner) is not THREAD
-        || dim_kind($mid) is THREAD_Y
+        || dim_kind($mid) is THREAD
 
 // A basic block nested with a thread dimension is nested or merged with the other
 require forall $bb in BasicBlocks:

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -345,6 +345,15 @@ require forall $bb in BasicBlocks:
         || dim_kind($other_thread) is not THREAD
         || order($bb, $other_thread) is not ORDERED
 
+/// Limits the number of threads.
+define half counter num_threads():
+  forall $dim in Dimensions:
+    mul "$dim.size().as_int().unwrap_or(1)" when:
+      is_thread_dim($dim) is TRUE
+end
+
+require num_threads() <= "$fun.device().max_threads()"
+
 /// Limits the number of nested unrolled loop.
 define half counter unroll_factor($inst in Instructions):
   forall $dim in Dimensions:
@@ -361,18 +370,9 @@ define half counter num_block_dims($inst in Instructions):
       dim_kind($dim) is BLOCK
 end
 
-/// Limits the number of threads.
-define half counter num_threads($inst in Instructions):
-  forall $dim in Dimensions:
-    mul "$dim.size().as_int().unwrap_or(1)" when:
-      is_iteration_dim($inst, $dim) is TRUE
-      dim_kind($dim) is THREAD
-end
-
 require forall $inst in Instructions:
   unroll_factor($inst) <= "$fun.device().max_unrolling()"
   num_block_dims($inst) <= "$fun.device().max_block_dims()"
-  num_threads($inst) <= "$fun.device().max_threads()"
 
 /// Counts the number on instructions nested in each dimension.
 define half counter num_nested_inst($dim in Dimensions):

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -280,6 +280,41 @@ define enum dim_mapping($lhs in Dimensions, $rhs in Dimensions):
     requires "$lhs.size() == $rhs.size()"
 end
 
+/// Indicates how are thread dimensions mapped on the GPU.
+define enum thread_mapping($lhs in Dimensions, $rhs in Dimensions):
+  antisymmetric:
+    MAPPED_OUT -> MAPPED_IN
+  /// One of the dimensions is a not thread.
+  value NOT_THREADS:
+    requires dim_kind($lhs) is not THREAD || dim_kind($rhs) is not THREAD
+  /// The two dimensions are threads mapped to the same dimension on the GPU.
+  value MAPPED:
+    requires dim_kind($lhs) is THREAD
+    requires dim_kind($rhs) is THREAD
+    requires order($lhs, $rhs) is MERGED | ORDERED
+    requires "$lhs.size() == $rhs.size()"
+  /// The two dimensions are threads, but `lhs` is mapped to a dimension outside of `rhs`.
+  value MAPPED_OUT:
+    requires dim_kind($lhs) is THREAD
+    requires dim_kind($rhs) is THREAD
+    requires order($lhs, $rhs) is OUTER | ORDERED
+  /// The two dimensions are threads, but `lhs` is mapped to a dimension inside of `rhs`.
+  value MAPPED_IN:
+    requires dim_kind($lhs) is THREAD
+    requires dim_kind($rhs) is THREAD
+    requires order($lhs, $rhs) is INNER | ORDERED
+end
+
+// Enforce coherence between threads activations.
+require forall $lhs in Dimensions:
+  forall $rhs in Dimensions:
+    forall $other in Dimensions:
+      thread_mapping($lhs, $rhs) is not MAPPED ||
+        thread_mapping($lhs, $other) == thread_mapping($rhs, $other)
+      thread_mapping($lhs, $other) is not MAPPED_OUT ||
+        thread_mapping($other, $rhs) is not MAPPED_OUT ||
+        thread_mapping($lhs, $rhs) is MAPPED_OUT
+
 // Thread dimensions are grouped together
 require forall $outer in Dimensions:
   forall $inner in Dimensions:

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -286,8 +286,7 @@ define enum dim_mapping($lhs in Dimensions, $rhs in Dimensions):
     requires dim_kind($lhs) is UNROLL | VECTOR || order($lhs, $rhs) is MERGED
   /// Values may be transmitted using one register for each thread.
   value THREAD_MAP:
-    requires dim_kind($lhs) is THREAD
-    requires dim_kind($lhs) == dim_kind($rhs)
+    requires thread_mapping($lhs, $rhs) is MAPPED
   /// Values are transmitted through registers.
   alias MAPPED = UNROLL_MAP | THREAD_MAP:
     requires "$lhs.size() == $rhs.size()"
@@ -353,6 +352,14 @@ define half counter num_threads():
 end
 
 require num_threads() <= "$fun.device().max_threads()"
+
+/// Limits the number of thread dimensions.
+define half counter num_thread_dims():
+  forall $dim in Dimensions:
+    sum "1" when: is_thread_dim($dim) is TRUE
+end
+
+require num_thread_dims() <= "3"
 
 /// Limits the number of nested unrolled loop.
 define half counter unroll_factor($inst in Instructions):

--- a/src/search_space/mod.rs
+++ b/src/search_space/mod.rs
@@ -11,8 +11,6 @@ pub use self::choices::{Action, Bool, DimKind, Domain, DomainStore, InstFlag, Or
 use self::choices::{apply_action, DomainDiff, init_domain};
 use std::sync::Arc;
 
-// FIXME: unrolled loops of size 1 should not be allowed
-
 /// A partially specified implementation.
 #[derive(Clone)]
 pub struct SearchSpace<'a> {

--- a/src/search_space/mod.rs
+++ b/src/search_space/mod.rs
@@ -97,3 +97,11 @@ fn add_iteration_dim(ir_instance: &mut ir::Function,
     }
     new_objs
 }
+
+/// Adds a dimension to the list of thread dimensions.
+fn add_thread_dim(ir_instance: &mut ir::Function, dim: ir::dim::Id) -> ir::NewObjs {
+    debug!("set {:?} as a thread dimension", dim);
+    let mut new_objs = ir::NewObjs::default();
+    if ir_instance.add_thread_dim(dim) { new_objs.add_thread_dim(dim); }
+    new_objs
+}

--- a/src/search_space/mod.rs
+++ b/src/search_space/mod.rs
@@ -6,7 +6,7 @@ mod operand;
 generated_file!(choices);
 
 pub use self::choices::{Action, Bool, DimKind, Domain, DomainStore, InstFlag, Order,
-                        MemSpace};
+                        MemSpace, ThreadMapping};
 
 use self::choices::{apply_action, DomainDiff, init_domain};
 use std::sync::Arc;

--- a/telamon-utils/src/vec_set.rs
+++ b/telamon-utils/src/vec_set.rs
@@ -114,11 +114,14 @@ where T: Ord
     }
 
     /// Inserts an element in the `VecSet`. This operation has a complexity in
-    /// O(n).
-    pub fn insert(&mut self, item: T) {
+    /// O(n). Returns `false` if the item was already present.
+    pub fn insert(&mut self, item: T) -> bool {
         match self.data.binary_search(&item) {
-            Ok(_) => (),
-            Err(pos) => self.data.insert(pos, item),
+            Ok(_) => false,
+            Err(pos) => {
+                self.data.insert(pos, item);
+                true
+            },
         }
     }
 }

--- a/tests/common/fake.rs
+++ b/tests/common/fake.rs
@@ -85,7 +85,9 @@ pub struct Context {
 impl device::Context for Context {
     fn device(&self) -> &device::Device { &self.device }
 
-    fn evaluate(&self, _: &codegen::Function) -> Result<f64, ()> { Ok(1.0) }
+    fn evaluate(&self, _: &codegen::Function, _: device::EvalMode) -> Result<f64, ()> {
+        Ok(1.0)
+    }
 
     fn benchmark(&self, _: &codegen::Function, num_samples: usize) -> Vec<f64> {
         vec![1.0; num_samples]

--- a/tests/common/fake.rs
+++ b/tests/common/fake.rs
@@ -55,6 +55,8 @@ impl device::Device for Device {
         HwPressure::zero(self)
     }
 
+    fn skipped_pressure(&self) -> HwPressure { HwPressure::zero(self) }
+
     fn bottlenecks(&self) -> &[&'static str] { &["issue", "alu", "mem"] }
 
     fn block_parallelism(&self, _: &SearchSpace) -> u32 { 16 }

--- a/tests/common/fake.rs
+++ b/tests/common/fake.rs
@@ -5,7 +5,7 @@ use telamon::device::{self, ScalarArgument, ArrayArgument};
 use telamon::ir;
 use telamon::explorer::Candidate;
 use telamon::search_space::{SearchSpace, DimKind};
-use telamon::model::{self, HwPressure};
+use telamon::model::{self, HwPressure, BottleneckLevel};
 use std::sync::Arc;
 use std::f64;
 use std::io::Write;
@@ -71,9 +71,13 @@ impl device::Device for Device {
 
     fn thread_rates(&self) -> HwPressure { HwPressure::new(1.0, vec![1.0, 1.0, 1.0]) }
 
-    fn block_rates(&self, _: u64) -> HwPressure { HwPressure::new(1.0, vec![1.0, 1.0, 1.0]) }
+    fn block_rates(&self) -> HwPressure { HwPressure::new(1.0, vec![1.0, 1.0, 1.0]) }
 
-    fn total_rates(&self, _: u64) -> HwPressure { HwPressure::new(1.0, vec![1.0, 1.0, 1.0]) }
+    fn total_rates(&self) -> HwPressure { HwPressure::new(1.0, vec![1.0, 1.0, 1.0]) }
+
+    fn get_waste_ratio(&self, _: BottleneckLevel, _: u64) -> HwPressure {
+        HwPressure::new(1.0, vec![1.0, 1.0, 1.0])
+    }
 }
 
 /// A fake context.

--- a/tests/common/fake.rs
+++ b/tests/common/fake.rs
@@ -5,7 +5,7 @@ use telamon::device::{self, ScalarArgument, ArrayArgument};
 use telamon::ir;
 use telamon::explorer::Candidate;
 use telamon::search_space::{SearchSpace, DimKind};
-use telamon::model::{self, HwPressure, BottleneckLevel};
+use telamon::model::{self, HwPressure};
 use std::sync::Arc;
 use std::f64;
 use std::io::Write;
@@ -55,8 +55,6 @@ impl device::Device for Device {
         HwPressure::zero(self)
     }
 
-    fn skipped_pressure(&self) -> HwPressure { HwPressure::zero(self) }
-
     fn bottlenecks(&self) -> &[&'static str] { &["issue", "alu", "mem"] }
 
     fn block_parallelism(&self, _: &SearchSpace) -> u32 { 16 }
@@ -75,9 +73,7 @@ impl device::Device for Device {
 
     fn total_rates(&self) -> HwPressure { HwPressure::new(1.0, vec![1.0, 1.0, 1.0]) }
 
-    fn get_waste_ratio(&self, _: BottleneckLevel, _: u64) -> HwPressure {
-        HwPressure::new(1.0, vec![1.0, 1.0, 1.0])
-    }
+    fn add_block_overhead(&self, _: u64, _: u64, _: &mut HwPressure) { }
 }
 
 /// A fake context.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,7 +4,7 @@ extern crate env_logger;
 
 pub mod fake;
 
-use telamon::device::Context;
+use telamon::device::{Context, EvalMode};
 use telamon::{explorer, ir, codegen};
 use telamon::search_space::SearchSpace;
 use std::io::sink;
@@ -31,7 +31,7 @@ pub fn check_candidates<F>(space: SearchSpace, ctx: &Context, mut check: F)
         where F: FnMut() {
     explorer::gen_space(ctx, space, |_| (), |candidate| {
         let fun = codegen::Function::build(&candidate.space);
-        ctx.evaluate(&fun).unwrap();
+        ctx.evaluate(&fun, EvalMode::FindBest).unwrap();
         check();
     });
 }

--- a/tests/cuda.rs
+++ b/tests/cuda.rs
@@ -455,14 +455,14 @@ fn dim_map_active() {
     let mut builder = helper::Builder::new(&signature, context.device());
     let size_32 = builder.cst_size(32);
 
-    let d0 = builder.open_dim_ex(size_32.clone(), DimKind::THREAD_X);
-    let d1 = builder.open_dim_ex(size_32.clone(), DimKind::THREAD_Y);
+    let d0 = builder.open_dim_ex(size_32.clone(), DimKind::THREAD);
+    let d1 = builder.open_dim_ex(size_32.clone(), DimKind::THREAD);
         let a = builder.mov(&0f32);
     builder.close_dim(&d0);
     builder.close_dim(&d1);
 
-    let d2 = builder.open_dim_ex(size_32.clone(), DimKind::THREAD_X);
-    let _d3 = builder.open_dim_ex(size_32.clone(), DimKind::THREAD_Y);
+    let d2 = builder.open_dim_ex(size_32.clone(), DimKind::THREAD);
+    let _d3 = builder.open_dim_ex(size_32.clone(), DimKind::THREAD);
     let d4 = builder.open_dim_ex(size_32.clone(), DimKind::UNROLL);
         let op = builder.dim_map(a, &[(&d0, &d2), (&d1, &d4)], ir::DimMapScope::Global);
         builder.mov(&op);
@@ -480,14 +480,14 @@ fn test0() {
     let mut builder = helper::Builder::new(&signature, context.device());
     let size_32 = builder.cst_size(32);
 
-    let d0 = builder.open_dim_ex(size_32.clone(), DimKind::THREAD_X);
+    let d0 = builder.open_dim_ex(size_32.clone(), DimKind::THREAD);
     let d1 = builder.open_dim(size_32.clone());
         let i0 = builder.mov(&0f32);
     builder.close_dim(&d0);
     builder.close_dim(&d1);
 
-    let _d2 = builder.open_dim_ex(size_32.clone(), DimKind::THREAD_X);
-    let d3 = builder.open_dim_ex(size_32.clone(), DimKind::THREAD_Y);
+    let _d2 = builder.open_dim_ex(size_32.clone(), DimKind::THREAD);
+    let d3 = builder.open_dim_ex(size_32.clone(), DimKind::THREAD);
     let d4 = builder.open_dim_ex(size_32.clone(), DimKind::SEQUENTIAL);
     let op = builder.dim_map(i0, &[(&d0, &d3), (&d1, &d4)], ir::DimMapScope::Global);
     let i1 = builder.mov(&op);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -144,7 +144,7 @@ fn block_dims() {
     assert_eq!(space.domain().get_is_iteration_dim(inst.into(), d2), Bool::TRUE);
     assert_eq!(space.domain().get_is_iteration_dim(inst.into(), d3), Bool::TRUE);
     assert_eq!(space.domain().get_dim_kind(d0),
-               DimKind::LOOP | DimKind::THREAD_X | DimKind::UNROLL);
+               DimKind::LOOP | DimKind::THREAD | DimKind::UNROLL);
     assert_eq!(space.domain().get_order(d1.into(), d2.into()), Order::NESTED);
     assert_eq!(space.domain().get_order(d1.into(), d3.into()), Order::NESTED);
     assert_eq!(space.domain().get_order(d2.into(), d3.into()), Order::NESTED);

--- a/tools/bench_perf_model/main.rs
+++ b/tools/bench_perf_model/main.rs
@@ -12,7 +12,7 @@ mod latency;
 mod memory;
 mod tests;
 
-use telamon::device::{ArgMap, Context};
+use telamon::device::{self, ArgMap, Context};
 use telamon::helper;
 use telamon::model::bound;
 use telamon::search_space::Action;
@@ -62,7 +62,7 @@ fn run<T: PerfModelTest>(pattern: &Regex) {
     let fun = builder.get();
     let model_perf = bound(&fun, &context);
     let dev_fun = telamon::codegen::Function::build(&fun);
-    let run_perf = unwrap!(context.evaluate(&dev_fun));
+    let run_perf = unwrap!(context.evaluate(&dev_fun, device::EvalMode::TestBound));
 
     if let Some(early_model_perf) = early_model_perf {
         info!("bound: {}", model_perf);


### PR DESCRIPTION
Changes the encoding of the mapping of thread dimensions to hardware dimensions. Reduces the memory pressure by a factor of 2x and the amount of deadends by a factor of 10x.

Needs  to:
- [x] Fix the computation of global parallelism
- [x] Individualise the waste computation
- [x] Make `bound_order` exploration work on mm
- [x] Assess the effect on bounds accuracy