### PR TITLE
Add a method to compute the complement of an Action

### DIFF
--- a/telamon-gen/cc_tests/src/main.rs
+++ b/telamon-gen/cc_tests/src/main.rs
@@ -37,6 +37,9 @@ mod single_enum {
         assert_eq!(x, Foo::AB);
         x &= Foo::BC;
         assert_eq!(x, Foo::B);
+        // Test complement.
+        let fun = ir::Function::default();
+        assert_eq!(Action::Foo(Foo::A).complement(&fun), Some(Action::Foo(Foo::BC)));
 
         // Ensure `failed`, `all` and `is_failed` are working.
         assert!(Foo::FAILED.is_failed());
@@ -82,6 +85,11 @@ mod single_enum {
         let mut all0_2 = all0;
         all0_2.insert(all0);
         assert_eq!(all0_2, all0);
+
+        // Test action complement.
+        let fun = ir::Function::default();
+        assert_eq!(Action::Bar(NumericSet::all(&[1, 4])).complement(&fun),
+                   Some(Action::Bar(NumericSet::all(&[2, 8]))));
 
         // Test comparison operators.
         assert!(all0.lt(Range::new_eq(&Range::ALL, 9)));

--- a/telamon-gen/cc_tests/src/single_enum.exh
+++ b/telamon-gen/cc_tests/src/single_enum.exh
@@ -9,3 +9,5 @@ define enum foo():
   alias AB = A | B:
   alias BC = B | C:
 end
+
+define integer bar(): "&[1, 2, 4, 8]" end

--- a/telamon-gen/src/print/mod.rs
+++ b/telamon-gen/src/print/mod.rs
@@ -69,6 +69,7 @@ lazy_static! {
         register_template!(engine, choice/arg_names);
         register_template!(engine, choice/arg_defs);
         register_template!(engine, choice/arg_ids);
+        register_template!(engine, choice/complement);
         register_template!(engine, choice/getter);
         register_template!(engine, compute_counter);
         register_template!(engine, conflict);

--- a/telamon-gen/src/print/template/actions.rs
+++ b/telamon-gen/src/print/template/actions.rs
@@ -8,6 +8,21 @@ pub enum Action {
     {{/each~}}
 }
 
+impl Action {
+    /// Returns the action performing the complementary decision.
+    pub fn complement(&self, ir_instance: &ir::Function) -> Option<Self> {
+        match *self {
+            {{~#each choices}}
+                Action::{{to_type_name name}}({{>choice.arg_names}}domain) =>
+                {{~#if choice_def.Counter}}None{{else}}Some(
+                    Action::{{to_type_name name}}({{>choice.arg_names}}
+                                                  {{>choice.complement value="domain"}})
+                ){{~/if}},
+            {{~/each}}
+        }
+    }
+}
+
 /// Applies an action to the domain.
 pub fn apply_action(action: Action, store: &mut DomainStore, diff: &mut DomainDiff)
         -> Result<(), ()> {

--- a/telamon-gen/src/print/template/choice/complement.rs
+++ b/telamon-gen/src/print/template/choice/complement.rs
@@ -1,0 +1,10 @@
+{{#ifeq choice_def "Enum"}}!{{value}}{{/ifeq~}}
+{{#ifeq choice_def "Integer"}}
+    {
+        {{~#each arguments}}
+            let {{this.[0]}} = {{>set.item_getter this.[1] id=this.[0]}};
+        {{~/each}}
+        {{~value}}.complement({{>value_type.univers value_type}})
+    }
+{{~/ifeq~}}
+

--- a/telamon-gen/src/print/template/main.rs
+++ b/telamon-gen/src/print/template/main.rs
@@ -385,6 +385,23 @@ impl NumericSet {
         }
         self.len = new_lhs;
     }
+
+    fn complement(&self, universe: &[u16]) -> Self {
+        let mut values = [0; Self::MAX_LEN];
+        let mut self_idx = 0;
+        let mut new_idx = 0;
+        for &item in universe {
+            if self_idx >= self.len || item < self.values[self_idx] {
+                values[new_idx] = item;
+                new_idx += 1;
+            } else if item > self.values[self_idx] {
+                panic!("self should be contained in universe")
+            } else {
+                self_idx += 1;
+            }
+        }
+        NumericSet { values, len: new_idx }
+    }
 }
 
 impl Domain for NumericSet {


### PR DESCRIPTION
This PR modifies telamon-gen's printer to add a method in the definition of Action. It computes the decisions that are discarded by a given action.