### PR TITLE
Count number of candidate evaluated

### DIFF
--- a/src/explorer/bandit_arm.rs
+++ b/src/explorer/bandit_arm.rs
@@ -9,14 +9,12 @@ use itertools::Itertools;
 use std;
 use std::f64;
 use std::sync::{Weak, Arc, RwLock};
-use std::sync::atomic::{AtomicUsize, Ordering};
 use utils::*;
 
 /// A search tree to perform a multi-armed bandit search.
 pub struct Tree<'a, 'b> {
     shared_tree: Arc<RwLock<SubTree<'a>>>,
     cut: RwLock<f64>,
-    num_descents: Arc<AtomicUsize>,
     config: &'b BanditConfig,
 }
 
@@ -27,7 +25,6 @@ impl<'a, 'b> Tree<'a, 'b> {
         Tree {
             shared_tree: Arc::new(RwLock::new(root)),
             cut: RwLock::new(std::f64::INFINITY),
-            num_descents: Arc::new(AtomicUsize::new(0)),
             config,
         }
     }
@@ -133,13 +130,6 @@ impl<'a, 'b> Store<'a> for Tree<'a, 'b> {
 
     fn explore(&self, context: &Context) -> Option<(Candidate<'a>, Self::PayLoad)> {
         loop {
-            let num_descents = self.num_descents.fetch_add(1, Ordering::Relaxed);
-            if let Some(max_descents) = self.config.max_descents {
-                if num_descents >= max_descents {
-                    return None
-                }
-            }
-
             let cut: f64 = { *unwrap!(self.cut.read()) };
             let state = unwrap!(self.shared_tree.write()).descend(context, cut);
             if let DescendState::DeadEnd = state { return None; }

--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -171,6 +171,9 @@ pub struct BanditConfig {
     /// If true, does not expand tree until end - instead, starts a montecarlo descend after each
     /// expansion of a node
     pub monte_carlo: bool,
+    /// The maximum number of descents to perform. Exploration will
+    /// stop after that many number of descents.
+    pub max_descents: Option<usize>,
 }
 
 impl BanditConfig {
@@ -198,6 +201,7 @@ impl Default for BanditConfig {
             threshold: 10,
             delta: 1.,
             monte_carlo: true,
+            max_descents: None,
         }
     }
 }

--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -25,6 +25,9 @@ pub struct Config {
     pub stop_bound: Option<f64>,
     /// Indicates the search must be stopped after the given number of minutes.
     pub timeout: Option<u64>,
+    /// Indicates the search must be stopped after the given number of
+    /// candidates have been evaluated.
+    pub max_evaluations: Option<u64>,
     /// A percentage cut indicate that we only care to find a candidate that is in a
     /// certain range above the best Therefore, if cut_under is 20%, we can discard any
     /// candidate whose bound is above 80% of the current best.
@@ -115,6 +118,7 @@ impl Default for Config {
             algorithm: SearchAlgorithm::default(),
             stop_bound: None,
             timeout: None,
+            max_evaluations: None,
             distance_to_best: None,
         }
     }
@@ -171,9 +175,6 @@ pub struct BanditConfig {
     /// If true, does not expand tree until end - instead, starts a montecarlo descend after each
     /// expansion of a node
     pub monte_carlo: bool,
-    /// The maximum number of descents to perform. Exploration will
-    /// stop after that many number of descents.
-    pub max_descents: Option<usize>,
 }
 
 impl BanditConfig {
@@ -201,7 +202,6 @@ impl Default for BanditConfig {
             threshold: 10,
             delta: 1.,
             monte_carlo: true,
-            max_descents: None,
         }
     }
 }

--- a/src/explorer/logger.rs
+++ b/src/explorer/logger.rs
@@ -19,7 +19,7 @@ pub fn log(config: &Config, recv: mpsc::Receiver<LogMessage>) {
                 log_monitor(score, cpt, timestamp, &mut write_buffer);
             }
             LogMessage::Finished(reason) =>{
-                unwrap!(writeln!(write_buffer, "search stoped because {}", reason));
+                unwrap!(writeln!(write_buffer, "search stopped because {}", reason));
             }
             // For now the evaluator is the only one to send logs, so we just ignore any other
             // types of message

--- a/src/explorer/logger.rs
+++ b/src/explorer/logger.rs
@@ -1,13 +1,13 @@
-
 use std::sync::mpsc;
 use std::fs::File;
 use std::io::{Write, BufWriter};
 use explorer::config::Config;
+use explorer::monitor;
 use std::time::Duration;
 
 pub enum LogMessage {
-    NewBest{score: f64, cpt: usize, timestamp: Duration},
-    Timeout,
+    NewBest { score: f64, cpt: usize, timestamp: Duration },
+    Finished(monitor::TerminationReason),
 }
 
 
@@ -18,9 +18,8 @@ pub fn log(config: &Config, recv: mpsc::Receiver<LogMessage>) {
             LogMessage::NewBest{score, cpt, timestamp} =>{
                 log_monitor(score, cpt, timestamp, &mut write_buffer);
             }
-            LogMessage::Timeout =>{
-                let message = format!("Stopped search after reaching timeout\n");
-                unwrap!(write_buffer.write_all(message.as_bytes()));
+            LogMessage::Finished(reason) =>{
+                unwrap!(writeln!(write_buffer, "search stoped because {}", reason));
             }
             // For now the evaluator is the only one to send logs, so we just ignore any other
             // types of message


### PR DESCRIPTION
In order to compare different algorithms, fixing the number of
candidates evaluated provided for a fairer comparison than using a
timeout because it allows comparisons to be done on different
machines (provided they use different GPUs), and relax the constraint
of having the machine unused during benchmarking. Since low execution
time is the final objective, we still track it, notably to ensure that
algorithms don't get too slow at producing candidates. However, even
in that case, it is arguably easier to improve an efficient algorithm
by making it faster rather than directly finding a fast and efficient
algorithm.

Actually limiting the number of evaluations performed is somewhat
tricky given the current architecture, so this currently implements an
approximate limit on the number of descents performed by the bandit
algorithm as a proxy instead, which is lower than the actual number of
evaluations.