### PR TITLE
Count the evaluated candidates in the monitor

### DIFF
--- a/src/device/context.rs
+++ b/src/device/context.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use boxfnonce::SendBoxFnOnce;
 
 /// A callback that is called after evaluating a kernel.
-pub type AsyncCallback<'a, 'b> = SendBoxFnOnce<'b, (Candidate<'a>, f64, usize)>;
+pub type AsyncCallback<'a, 'b> = SendBoxFnOnce<'b, (Candidate<'a>, f64)>;
 
 /// Describes the context for which a function must be optimized.
 pub trait Context: Sync {

--- a/src/device/cuda/context.rs
+++ b/src/device/cuda/context.rs
@@ -126,10 +126,8 @@ impl<'a> device::Context for Context<'a> {
             // Start the evaluation thread.
             let eval_thread_name = "Telamon - GPU Evaluation Thread".to_string();
             let res = scope.builder().name(eval_thread_name).spawn(move || {
-                let mut cpt_candidate = 0;
                 let mut best_eval = std::f64::INFINITY;
                 while let Ok((candidate, thunk, callback)) = recv.recv() {
-                    cpt_candidate += 1;
                     let bound = candidate.bound.value();
                     let eval = if best_eval > bound || mode == EvalMode::TestBound {
                         thunk.execute().map(|t| t as f64 / clock_rate)
@@ -144,7 +142,7 @@ impl<'a> device::Context for Context<'a> {
                     if eval < best_eval {
                         best_eval = eval;
                     }
-                    callback.call(candidate, eval, cpt_candidate);
+                    callback.call(candidate, eval);
                 }
             });
             unwrap!(res);

--- a/src/device/x86/context.rs
+++ b/src/device/x86/context.rs
@@ -119,11 +119,9 @@ impl device::Context for Context {
             // Start the evaluation thread.
             let eval_thread_name = "Telamon - CPU Evaluation Thread".to_string();
             unwrap!(scope.builder().name(eval_thread_name).spawn(move || {
-                let mut cpt_candidate = 0;
                 while let Ok((candidate, fun_str, code_args, callback)) = recv.recv() {
-                    cpt_candidate += 1;
                     let eval = function_evaluate(&fun_str, &code_args).unwrap();
-                    callback.call(candidate, eval, cpt_candidate);
+                    callback.call(candidate, eval);
                 }
             }));
         });

--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -27,7 +27,7 @@ pub struct Config {
     pub timeout: Option<u64>,
     /// Indicates the search must be stopped after the given number of
     /// candidates have been evaluated.
-    pub max_evaluations: Option<u64>,
+    pub max_evaluations: Option<usize>,
     /// A percentage cut indicate that we only care to find a candidate that is in a
     /// certain range above the best Therefore, if cut_under is 20%, we can discard any
     /// candidate whose bound is above 80% of the current best.

--- a/src/explorer/mod.rs
+++ b/src/explorer/mod.rs
@@ -95,10 +95,9 @@ fn explore_space<'a, T>(config: &Config,
         while let Some((cand, payload)) = candidate_store.explore(context) {
             let space = fix_order(cand.space);
             let eval_sender = eval_sender.clone();
-            let callback = move |leaf, eval, cpt| {
-                if let Err(err) = block_on(eval_sender.send((leaf, eval, cpt, payload))
-                                 .map(|_| ())
-                                 ) 
+            let callback = move |leaf, eval| {
+                if let Err(err) = block_on(eval_sender.send((leaf, eval, payload))
+                                           .map(|_| ()))
                 { warn!("Got disconnected , {:?}", err);}
             };
             evaluator.add_kernel(Candidate {space, .. cand }, SendBoxFnOnce::from(callback));


### PR DESCRIPTION
Previously we were counting the number of evaluated candidates in the
context through a callback parameter. Since 03526bcf, we are also
counting the number of evaluated candidates directly in the monitor in
order to stop evaluation after a possible maximum number of
candidates.

We should have a single place where we count that number of evaluated
candidates, and that place should be in the monitor because it doesn't
make sense to require each context to manually count the number of
evaluated candidates. In addition, this makes it easier to instantiate
multiple evaluators in the future if we have several identical
accelerators and let the monitor take care of the synchronization and
counting problems.