### PR TITLE
Store gpu_data on a well-known path on the system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ std-semaphore = "0.1.0"
 rpds = "0.5.0"
 binary-heap-plus = "0.1.4"
 tempfile = "3.0.1"
+xdg = "^2.1"
 
 [dependencies.telamon-utils]
 path = "telamon-utils"

--- a/src/device/cuda/gpu.rs
+++ b/src/device/cuda/gpu.rs
@@ -175,6 +175,9 @@ impl Gpu {
                     let mut config_file = unwrap!(File::create(config_path.clone()));
                     unwrap!(
                         write!(config_file, "{}", include_str!("../../../data/cuda_gpus.json")));
+                    // We return the Path here instead of the already-opened file object because we
+                    // want to ensure that the toplevel `config_path` variable always point to a
+                    // readonly file in order to avoid subtle bugs.
                     config_path
                 },
             }


### PR DESCRIPTION
Currently telamon assumes that a "data/cuda_gpus.json" file is
accessible from the directory where it is run. This is not optimal,
since we may want to run telamon from multiple directories, for
instance to load multiple settings file.

Instead, this makes it so that we use the "cuda_gpus.json" file from
~/.config/telamon/cuda_gpus.json and write a default "cuda_gpus.json"
configuration there if it doesn't exist. We use the `xdg` crate to
find the configuration directory in an appropriate way depending on
the system configuration, and load the default "data/cuda_gpus.json"
into the binary as a static string.

Note that in some cases (e.g. running tests) we may have race issues
if multiple instances of telamon are run at the same time and multiple
of them try to write the ~/.config/telamon/cuda_gpus.json. This would
only happen on the first run and shouldn't be a problem; however if it
ever becomes one we can easily change the behavior to use the bundled
cuda_gpus.json file and provide an additional utility to write the
proper configuration otherwise.