### PR TITLE
Benchmark Decents in the Search Tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ name = "bench-perf-model"
 path = "tools/bench_perf_model/main.rs"
 required-features = ["cuda"]
 
+[[bench]]
+name = "descent"
+harness = false
+
 [build-dependencies]
 cc = "1.0.12"
 
@@ -73,6 +77,7 @@ git = "https://github.com/ulysseB/tokio-timer.git"
 [dev-dependencies]
 gcc = "0.3.54"
 tempdir = "0.3.7"
+criterion = "0.2.4"
 
 [features]
 cuda = []

--- a/benches/descent.rs
+++ b/benches/descent.rs
@@ -1,0 +1,149 @@
+//! Benchmarks how fast it is to decend in the search tree.
+#[macro_use]
+extern crate criterion;
+extern crate env_logger;
+extern crate telamon;
+extern crate rand;
+#[macro_use]
+extern crate lazy_static;
+
+use criterion::Criterion;
+use telamon::{ir, device, explorer, helper};
+use telamon::explorer::choice::ActionEx;
+use telamon::search_space::*;
+use rand::Rng;
+
+/// Configure the bencher.
+fn config_criterion() -> Criterion {
+    Criterion::default()
+        .sample_size(50)
+        .configure_from_args()
+}
+
+lazy_static! {
+    /// A fake GPU description, used only to know which candidates are valid.
+    static ref DEVICE: device::cuda::Gpu = device::cuda::Gpu::dummy();
+
+    static ref MM_SIGNATURE: MMSig = MMSig::signature();
+    static ref MM: SearchSpace<'static> = MM_SIGNATURE.build_body();
+}
+
+/// Stores the signature and the external arrays IDs for matrix-matrix multiplication.
+struct MMSig {
+    signature: ir::Signature,
+    a: ir::mem::Id,
+    b: ir::mem::Id,
+    c: ir::mem::Id,
+}
+
+impl MMSig {
+    fn signature() -> Self {
+        let mut signature = ir::Signature::new("mm".to_string());
+        signature.add_scalar("m".to_string(), ir::Type::I(32));
+        signature.add_scalar("n".to_string(), ir::Type::I(32));
+        signature.add_scalar("k".to_string(), ir::Type::I(32));
+        let a = signature.add_array("a".to_string());
+        let b = signature.add_array("b".to_string());
+        let c = signature.add_array("c".to_string());
+        MMSig { signature, a, b, c }
+    }
+
+    fn build_body(&self) -> SearchSpace {
+        const DATA_TYPE: ir::Type = ir::Type::F(32);
+        let mut builder = helper::Builder::new(&self.signature, &*DEVICE);
+        let m_size = builder.param_size("m");
+        let n_size = builder.param_size("n");
+        let k_size = builder.param_size("k");
+
+        let ld_a_m = builder.open_tiled_dim(m_size, &[16, 4]);
+        let ld_a_k = builder.open_tiled_dim(k_size.clone(), &[16]);
+        let (ptr, pattern) = builder.tensor_access(
+            &"a", self.a, &DATA_TYPE, &[&ld_a_m, &ld_a_k]);
+        let ld_a =  builder.ld_nc(DATA_TYPE.clone(), &ptr, pattern);
+        builder.close_dim(&ld_a_m);
+        builder.close_dim(&ld_a_k);
+
+        let ld_b_k = builder.open_tiled_dim(k_size, &[16]);
+        let ld_b_n = builder.open_tiled_dim(n_size, &[16, 4]);
+        let (ptr, pattern) = builder.tensor_access(
+            &"b", self.b, &DATA_TYPE, &[&ld_b_k, &ld_b_n]);
+        let ld_b = builder.ld_nc(DATA_TYPE, &ptr, pattern);
+        builder.close_dim(&ld_b_k);
+        builder.close_dim(&ld_b_n);
+
+        let init_m = builder.open_mapped_dim(&ld_a_m);
+        let init_n = builder.open_mapped_dim(&ld_b_n);
+        let init = builder.mov(&0f32);
+
+        let acc_m = builder.open_mapped_dim(&init_m);
+        let acc_n = builder.open_mapped_dim(&init_n);
+        let acc_k = builder.open_mapped_dim(&ld_b_k);
+        let a_op = builder.dim_map(ld_a, &[(&ld_a_m, &acc_m), (&ld_a_k, &acc_k)],
+        ir::DimMapScope::Global);
+        let b_op = builder.dim_map(ld_b, &[(&ld_b_k, &acc_k), (&ld_b_n, &acc_n)],
+        ir::DimMapScope::Global);
+        let acc = builder.mad(&a_op, &b_op, &helper::Reduce(init));
+
+        builder.close_dim(&acc_k);
+        let st_m = builder.open_mapped_dim(&acc_m);
+        let st_n = builder.open_mapped_dim(&acc_n);
+        let (ptr, pattern) = builder.tensor_access(
+            &"c", self.c, &DATA_TYPE, &[&st_m, &st_n]);
+        let st = builder.st(&ptr, &acc, pattern);
+        // order for correctness.
+        builder.order(&st, &acc_k, Order::AFTER);
+        builder.get()
+    }
+}
+
+/// Benchmarks full descents in the search tree.
+fn mm_descent(c: &mut Criterion) {
+    let _ = env_logger::try_init();
+    c.bench_function("mm descent", |b| b.iter(|| {
+        let mut space = MM.clone();
+        while let Some(mut choice) = {
+            let choice = explorer::choice::list(&space).next();
+            choice
+        } {
+           let id = rand::thread_rng().gen_range(0, choice.len());
+           let res = match choice.swap_remove(id) {
+                ActionEx::TileSizes(..) => panic!(),
+                ActionEx::Action(action) => space.apply_decisions(vec![action]),
+                ActionEx::LowerLayout { mem, ref st_dims, ref ld_dims } =>
+                    space.lower_layout(mem, st_dims.clone(), ld_dims.clone()),
+           };
+           if res.is_err() { return; }
+        }
+    }));
+}
+
+/// Benchmarks full descents in the search tree, with a copy at each level.
+fn mm_descent_copy(c: &mut Criterion) {
+    let _ = env_logger::try_init();
+    c.bench_function("mm descent with copy", |b| b.iter(|| {
+        let mut spaces = vec![];
+        let mut space = MM.clone();
+        while let Some(mut choice) = {
+            let choice = explorer::choice::list(&space).next();
+            choice
+        } {
+            spaces.push(space.clone());
+            let id = rand::thread_rng().gen_range(0, choice.len());
+            let res = match choice.swap_remove(id) {
+                ActionEx::TileSizes(..) => panic!(),
+                ActionEx::Action(action) => space.apply_decisions(vec![action]),
+                ActionEx::LowerLayout { mem, ref st_dims, ref ld_dims } =>
+                    space.lower_layout(mem, st_dims.clone(), ld_dims.clone()),
+            };
+            if res.is_err() { return; }
+        }
+    }));
+}
+
+criterion_group! {
+    name = benches;
+    config = config_criterion();
+    targets = mm_descent, mm_descent_copy
+}
+
+criterion_main!(benches);

--- a/src/device/cuda/gpu.rs
+++ b/src/device/cuda/gpu.rs
@@ -189,6 +189,60 @@ impl Gpu {
         gpus.into_iter().find(|x| x.name == name)
     }
 
+    /// Creates a dummy GPU, to use for tests and benchmarks without evaluation.
+    pub fn dummy() -> Self {
+        Gpu {
+            name: "dummy".to_string(),
+            sm_major: 0,
+            sm_minor: 0,
+            addr_size: 64,
+            shared_mem_per_smx: 49152,
+            shared_mem_per_block: 49152,
+            allow_nc_load: true,
+            allow_l1_for_global_mem: false,
+            wrap_size: 32,
+            thread_per_smx: 2048,
+            l1_cache_size: 16348,
+            l1_cache_line: 128,
+            l2_cache_size: 393216,
+            l2_cache_line: 32,
+            shared_bank_stride: 8,
+            num_smx: 4,
+            max_block_per_smx: 16,
+
+            smx_clock: -1.,
+            load_l2_latency: -1.,
+            load_ram_latency: -1.,
+            load_shared_latency: -1.,
+            loop_end_latency: -1.,
+
+            thread_rates: InstDesc::default(),
+            smx_rates: InstDesc::default(),
+            gpu_rates: InstDesc::default(),
+            add_f32_inst: InstDesc::default(),
+            add_f64_inst: InstDesc::default(),
+            add_i32_inst: InstDesc::default(),
+            add_i64_inst: InstDesc::default(),
+            mul_f32_inst: InstDesc::default(),
+            mul_f64_inst: InstDesc::default(),
+            mul_i32_inst: InstDesc::default(),
+            mul_i64_inst: InstDesc::default(),
+            mul_wide_inst: InstDesc::default(),
+            mad_f32_inst: InstDesc::default(),
+            mad_f64_inst: InstDesc::default(),
+            mad_i32_inst: InstDesc::default(),
+            mad_i64_inst: InstDesc::default(),
+            mad_wide_inst: InstDesc::default(),
+            div_f32_inst: InstDesc::default(),
+            div_f64_inst: InstDesc::default(),
+            div_i32_inst: InstDesc::default(),
+            div_i64_inst: InstDesc::default(),
+            syncthread_inst: InstDesc::default(),
+            loop_init_overhead: InstDesc::default(),
+            loop_iter_overhead: InstDesc::default(),
+        }
+    }
+
     /// Returns the PTX code for a Function.
     pub fn print_ptx(&self, fun: &Function) -> String {
         let mut printer = CudaPrinter::new();

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -27,6 +27,26 @@ pub struct Signature {
     pub mem_blocks: u32,
 }
 
+impl Signature {
+    /// Creates a new signature without any parameter.
+    pub fn new(name: String) -> Self {
+        Signature { name, params: vec![], mem_blocks: 0 }
+    }
+
+    /// Adds a scalar parameter.
+    pub fn add_scalar(&mut self, name: String, t: ir::Type) {
+        self.params.push(Parameter { name, t });
+    }
+
+    /// Adds a parameter with the given name and type to the signature.
+    pub fn add_array(&mut self, name: String) -> ir::mem::Id {
+        let id = mem::Id::External(self.mem_blocks);
+        self.mem_blocks += 1;
+        self.params.push(Parameter { name, t: ir::Type::PtrTo(id) });
+        id
+    }
+}
+
 /// Describes a function and the set of its possible implementation.
 #[derive(Clone)]
 pub struct Function<'a> {


### PR DESCRIPTION
This PR adds a benchmark to measure the time it takes to descend in the search tree. The benchmarks are based on the criterion framework and measure the performance of a descent when generating code for GPUs.

We measure both decents with and without saving the encountered candidates to measure the impact of copies on the runtime. These benchmarks meant to measure the whole descent, individual benchmarks for specific telamon-gen features will later be needed but not part of this PR.

Fixes #7