### PR TITLE
Improve the performance of constraint propagation

### DIFF
--- a/telamon-gen/src/ir/mod.rs
+++ b/telamon-gen/src/ir/mod.rs
@@ -118,7 +118,8 @@ impl IrDesc {
             .map(|(v, set)| (v, set_constraints.find_set(v).unwrap_or(set).clone()))
             .collect::<HashMap<_, _>>();
         // If the changed choice is symmetric, the inverse filter should also be called.
-        if self.get_choice(&changed.choice).arguments().is_symmetric() {
+        if self.get_choice(&changed.choice).arguments().is_symmetric() &&
+            !self.get_choice(filtered).arguments().is_symmetric() {
             let vars = vec![changed.vars[1], changed.vars[0]];
             let ref changed = ChoiceInstance { choice: changed.choice.clone(), vars };
             let action = self.gen_filter_call_action(

--- a/telamon-gen/src/ir/mod.rs
+++ b/telamon-gen/src/ir/mod.rs
@@ -118,8 +118,7 @@ impl IrDesc {
             .map(|(v, set)| (v, set_constraints.find_set(v).unwrap_or(set).clone()))
             .collect::<HashMap<_, _>>();
         // If the changed choice is symmetric, the inverse filter should also be called.
-        if self.get_choice(&changed.choice).arguments().is_symmetric() &&
-            !self.get_choice(filtered).arguments().is_symmetric() {
+        if self.get_choice(&changed.choice).arguments().is_symmetric() {
             let vars = vec![changed.vars[1], changed.vars[0]];
             let ref changed = ChoiceInstance { choice: changed.choice.clone(), vars };
             let action = self.gen_filter_call_action(

--- a/telamon-gen/src/lib.rs
+++ b/telamon-gen/src/lib.rs
@@ -136,7 +136,9 @@ pub fn process<'a, T: io::Write>(
 //     - changed is symmetric
 //          > can be solved by checking both changed and filtered are symmetric
 //     - changed appears multiple times in the arguments
-//          > how to 
+//          - can be detected directly when declaring the filter
+//          > how to detect this ?
+//
 // * How to fix it ?
 // - normalize filter calls
 //   -> can inverse lhs and rhs in symmetric, be careful if self is symmetric

--- a/telamon-gen/src/lib.rs
+++ b/telamon-gen/src/lib.rs
@@ -130,6 +130,14 @@ pub fn process<'a, T: io::Write>(
 // TODO(filter): generate negative filter when there is at most one input.
 // TODO(filter): merge filters even if one input requires a type constraint
 // TODO(cc_perf): remove duplicates on_change filter actions
+// * Why does this happens ?
+//   > only on filters
+//   > when the filtered choice is symmetric, either when
+//     - changed is symmetric
+//          > can be solved by checking both changed and filtered are symmetric
+//     - changed appears multiple times in the arguments
+//          > how to 
+// * How to fix it ?
 // - normalize filter calls
 //   -> can inverse lhs and rhs in symmetric, be careful if self is symmetric
 // - detect duplicates and remove them
@@ -140,15 +148,15 @@ pub fn process<'a, T: io::Write>(
 // TODO(cc_perf): in truth table, intersect rules with rules with weaker conditions,
 
 // FIXME: fix counters:
-// * Discard full counters. Might re-enable them later if we can find a way to make lowerings
-//  commute
-// * Fordid resrtricting the FALSE value of the repr flag from conditions that involve other decisions
-// > this makes lowering commute. Otherwise we can force the counter to be >0, which can be true or
-//   not depending if another lowering has already occured.
-// * Charaterise the effect of fragile values on performance
-// FIXME: make sure the quotient set works correctly with things that force the repr flag to TRUE
-// (for example the constraint on reduction). One problem might be that the flag is forced to FALSE
-// but can be merged with a dim whose flag can be set to TRUE. The solutions for this may be to
-// ensure:
+// * Discard full counters. Might re-enable them later if we can find a way to make
+//   lowerings commute
+// * Fordid resrtricting the FALSE value of the repr flag from conditions that involve
+//   other decisions
+// > this makes lowering commute. Otherwise we can force the counter to be >0, which can
+//   be true or not depending if another lowering has already occured.
+// FIXME: make sure the quotient set works correctly with things that force the repr flag
+// to TRUE (for example the constraint on reduction). One problem might be that the flag
+// is forced to FALSE but can be merged with a dim whose flag can be set to TRUE. The
+// solutions for this may be to ensure:
 // - conditions on flags are uniform for merged dims
 // - the flag has a third state "ok to be true, but onyl if merged to another"

--- a/telamon-gen/src/lib.rs
+++ b/telamon-gen/src/lib.rs
@@ -129,24 +129,8 @@ pub fn process<'a, T: io::Write>(
 // TODO(filter): group filters if one iterates on a subtype of the other
 // TODO(filter): generate negative filter when there is at most one input.
 // TODO(filter): merge filters even if one input requires a type constraint
-// TODO(cc_perf): remove duplicates on_change filter actions
-// * Why does this happens ?
-//   > only on filters
-//   > when the filtered choice is symmetric, either when
-//     - changed is symmetric
-//          > can be solved by checking both changed and filtered are symmetric
-//     - changed appears multiple times in the arguments
-//          - can be detected directly when declaring the filter
-//          > how to detect this ?
-//
-// * How to fix it ?
-// - normalize filter calls
-//   -> can inverse lhs and rhs in symmetric, be careful if self is symmetric
-// - detect duplicates and remove them
-// - IS A X2 LIMITING FACTOR
-// > couldn't we do this during merging ?
-// TODO(cc_perf): Only iterate on the lower triangular part of symmetric domains in
-// on_change
+// TODO(cc_perf): Only iterate on the lower triangular part of symmetric rather than
+//  dynamically filtering out half of the cases
 // TODO(cc_perf): in truth table, intersect rules with rules with weaker conditions,
 
 // FIXME: fix counters:

--- a/telamon-gen/src/print/choice.rs
+++ b/telamon-gen/src/print/choice.rs
@@ -202,6 +202,7 @@ enum ChoiceAction<'a> {
     FilterSelf,
     Filter {
         choice: &'a str,
+        is_symmetric: bool,
         filter_call: FilterCall<'a>,
         choice_full_type: ast::ValueType,
         arguments: Vec<(ast::Variable<'a>, ast::Set<'a>)>,
@@ -252,6 +253,7 @@ impl<'a> ChoiceAction<'a> {
                 let adaptator = ir::Adaptator::from_arguments(&choice_instance.vars);
                 let full_type = choice.value_type().full_type().adapt(&adaptator);
                 ChoiceAction::Filter {
+                    is_symmetric: choice.arguments().is_symmetric(),
                     choice: choice.name(),
                     choice_full_type: ast::ValueType::new(full_type, ctx),
                     filter_call, arguments,

--- a/telamon-gen/src/print/template/choice_filter.rs
+++ b/telamon-gen/src/print/template/choice_filter.rs
@@ -1,5 +1,13 @@
-// Generates an action to filter a choice if needed.
-let mut values = {{>value_type.full_domain choice_full_type}};
-{{>filter_call filter_call}}
-trace!("call restrict from {}, line {}", file!(), line!());
-{{choice}}::restrict({{>choice.arg_ids}}ir_instance, store, values, diff)?;
+{{~#if is_symmetric}}
+    // The filtered choice is symmetric, so only the lower triangular part needs to be
+    // filtered.
+    if {{>set.id_getter arguments.[0].[1] item=arguments.[0].[0]}} <
+        {{>set.id_getter arguments.[1].[1] item=arguments.[1].[0]}} {
+{{/if}}
+    let mut values = {{>value_type.full_domain choice_full_type}};
+    {{>filter_call filter_call}}
+    trace!("call restrict from {}, line {}", file!(), line!());
+    {{choice}}::restrict({{>choice.arg_ids}}ir_instance, store, values, diff)?;
+{{~#if is_symmetric}}
+}
+{{/if}}


### PR DESCRIPTION
Constraint propagation is the main bottleneck appart from evaluation on the targeted device. This PR improves performance by avoiding calling multiple times the same propagator, improving performance by 30%.

In details, it ensure filters are only called on the lower triangular part of symmetric decisons since the upper triangular part is fowarded to the lower triangular part.