### PR TITLE
Add ability to configure matmul tilings from the Python API

### DIFF
--- a/kernels/src/kernel.rs
+++ b/kernels/src/kernel.rs
@@ -20,7 +20,7 @@ const MAX_DEADEND_RATIO: usize = 20;
 /// A kernel that can be compiled, benchmarked and used for correctness tests.
 pub trait Kernel<'a>: Sized {
     /// The input parameters of the kernel.
-    type Parameters: Copy;
+    type Parameters;
     /// The values to expect as output.
     type ExpectedOutput;
 

--- a/kernels/src/linalg.rs
+++ b/kernels/src/linalg.rs
@@ -337,20 +337,14 @@ impl<'a, S: Scalar> Kernel<'a> for MatMul<'a, S> {
     fn build_body<'b>(&self, signature: &'b ir::Signature, ctx: &'b device::Context)
         -> Vec<Candidate<'b>>
     {
-        let k_tiles = if let Some(ref tiles) = self.params.k_tiling {
-            vec![tiles.clone()]
-        } else {
-            ::generate_tile_sizes(self.params.k as u32, &[64])
-        };
-        let m_tiles = if let Some(ref tiles) = self.params.m_tiling {
-            vec![tiles.clone()]
-        } else {
+        let m_tiles = self.params.m_tiling.clone().map(Vec::new).unwrap_or_else(|| {
             ::generate_tile_sizes(self.params.m as u32, &[64, 8])
         };
-        let n_tiles = if let Some(ref tiles) = self.params.k_tiling {
-            vec![tiles.clone()]
-        } else {
+        let n_tiles = self.params.n_tiling.clone().map(Vec::new).unwrap_or_else(|| {
             ::generate_tile_sizes(self.params.n as u32, &[64, 8])
+        };
+        let k_tiles = self.params.k_tiling.clone().map(Vec::new).unwrap_or_else(|| {
+            ::generate_tile_sizes(self.params.k as u32, &[64])
         };
         let tilings = ::par_iter_product(::par_iter_product(m_tiles, n_tiles), k_tiles);
 

--- a/kernels/src/linalg.rs
+++ b/kernels/src/linalg.rs
@@ -339,13 +339,13 @@ impl<'a, S: Scalar> Kernel<'a> for MatMul<'a, S> {
     {
         let m_tiles = self.params.m_tiling.clone().map(Vec::new).unwrap_or_else(|| {
             ::generate_tile_sizes(self.params.m as u32, &[64, 8])
-        };
+        });
         let n_tiles = self.params.n_tiling.clone().map(Vec::new).unwrap_or_else(|| {
             ::generate_tile_sizes(self.params.n as u32, &[64, 8])
-        };
+        });
         let k_tiles = self.params.k_tiling.clone().map(Vec::new).unwrap_or_else(|| {
             ::generate_tile_sizes(self.params.k as u32, &[64])
-        };
+        });
         let tilings = ::par_iter_product(::par_iter_product(m_tiles, n_tiles), k_tiles);
 
         tilings.map(|((m_tiling, n_tiling), k_tiling)| {

--- a/kernels/src/linalg.rs
+++ b/kernels/src/linalg.rs
@@ -337,13 +337,13 @@ impl<'a, S: Scalar> Kernel<'a> for MatMul<'a, S> {
     fn build_body<'b>(&self, signature: &'b ir::Signature, ctx: &'b device::Context)
         -> Vec<Candidate<'b>>
     {
-        let m_tiles = self.params.m_tiling.clone().map(Vec::new).unwrap_or_else(|| {
+        let m_tiles = self.params.m_tiling.clone().map(|x| vec![x]).unwrap_or_else(|| {
             ::generate_tile_sizes(self.params.m as u32, &[64, 8])
         });
-        let n_tiles = self.params.n_tiling.clone().map(Vec::new).unwrap_or_else(|| {
+        let n_tiles = self.params.n_tiling.clone().map(|x| vec![x]).unwrap_or_else(|| {
             ::generate_tile_sizes(self.params.n as u32, &[64, 8])
         });
-        let k_tiles = self.params.k_tiling.clone().map(Vec::new).unwrap_or_else(|| {
+        let k_tiles = self.params.k_tiling.clone().map(|x| vec![x]).unwrap_or_else(|| {
             ::generate_tile_sizes(self.params.k as u32, &[64])
         });
         let tilings = ::par_iter_product(::par_iter_product(m_tiles, n_tiles), k_tiles);

--- a/telamon-capi/Cargo.toml
+++ b/telamon-capi/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib"]
 cbindgen = "0.6"
 
 [dependencies]
+env_logger = "0.5.9"
 libc = "0.2"
 
 [dependencies.telamon]

--- a/telamon-capi/src/lib.rs
+++ b/telamon-capi/src/lib.rs
@@ -20,7 +20,7 @@ pub use telamon_kernels::{linalg, Kernel};
 /// Initializes the logger.
 #[no_mangle]
 pub extern "C" fn env_logger_try_init() {
-    env_logger::try_init();
+    let _ = env_logger::try_init();
 }
 
 /// Supported device types for running kernels.

--- a/telamon-py/.gitignore
+++ b/telamon-py/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.egg-info
 _capi*.py
 *.so
+dist/

--- a/telamon-py/examples/search.py
+++ b/telamon-py/examples/search.py
@@ -1,0 +1,27 @@
+import argparse
+import os
+import telamon as tl
+import toml
+
+KERNELS = {
+    'matmul': tl.MatMul(1024, 1024, 1024),
+    'matmul-m-32-4-n-32-4-k-32': tl.MatMul(1024, 1024, 1024, m_tiles=[32, 4], n_tiles=[32, 4], k_tiles=[32]),
+}
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--kernel', choices=list(KERNELS), default='matmul')
+    parser.add_argument('--device', choices=('cpu', 'gpu'), default='gpu')
+    parser.add_argument('--config', default=None)
+
+    ns = parser.parse_args()
+
+    config = None
+    if ns.config is not None:
+        with open(ns.config) as f:
+            config = toml.load(f)
+
+    kernel = KERNELS[ns.kernel]
+
+    with tl.device(ns.device.upper()):
+        kernel.optimize(config)

--- a/telamon-py/setup.py
+++ b/telamon-py/setup.py
@@ -10,12 +10,12 @@ def build_capi(spec):
         print('CUDA build enabled.')
         cmd.extend(['--features', 'cuda'])
 
-    build = spec.add_external_build(cmd=cmd, path='..')
+    build = spec.add_external_build(cmd=cmd, path='../telamon-capi')
 
     spec.add_cffi_module(
         module_path='telamon._capi',
-        dylib=lambda: build.find_dylib('telamon_capi', in_path='target/release'),
-        header_filename=lambda: build.find_header('telamon.h', in_path='telamon-capi/include'),
+        dylib=lambda: build.find_dylib('telamon_capi', in_path='../target/release'),
+        header_filename=lambda: build.find_header('telamon.h', in_path='include'),
         rtld_flags=['NOW', 'NODELETE'],
     )
 


### PR DESCRIPTION
This allows manually overriding the tiling configuration for the MatMul
kernel through parameters in MatMulP and exposes that configuration
through the C and Python API.

In addition, a new Python example script is included which runs an
optimal candidate search from Python with a couple options (e.g. kernel
and device selection) which can be used as a starting point for further
experiments.