### PR TITLE
WIP: Expose data-flow information in Telamon

### DIFF
--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -39,6 +39,7 @@ pub struct Function<'a> {
     mem_blocks: mem::BlockMap<'a>,
     layouts_to_lower: Vec<ir::mem::InternalId>,
     induction_vars: Vec<ir::InductionVar<'a>>,
+    values: Vec<ir::Value>,
 }
 
 impl<'a> Function<'a> {
@@ -55,6 +56,7 @@ impl<'a> Function<'a> {
             mem_blocks,
             layouts_to_lower: Vec::new(),
             induction_vars: Vec::new(),
+            values: Vec::new(),
         }
     }
 
@@ -112,6 +114,11 @@ impl<'a> Function<'a> {
         self.insts.iter().map(|x| x as _).chain(self.dims.iter().map(|x| x as _))
     }
 
+    /// Returns the list of values.
+    pub fn values(&self) -> std::slice::Iter<ir::Value> {
+        self.values.iter()
+    }
+
     /// Returns the list of thread dimensions.
     pub fn thread_dims(&self) -> impl Iterator<Item=&Dimension<'a>> {
         self.thread_dims.iter().map(move |&d| self.dim(d))
@@ -140,6 +147,9 @@ impl<'a> Function<'a> {
             BBId::Dim(id) => self.dim(id),
         }
     }
+
+    /// Returns a `Value` given its id.
+    pub fn value(&self, id: ir::ValueId) -> &ir::Value { &self.values[id.0 as usize] }
 
     /// Returns the list of memory blocks. The block with id `i` is in i-th position.
     pub fn mem_blocks<'b>(&'b self) -> impl Iterator<Item=&'b mem::Block> {

--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -1,6 +1,7 @@
 //! Describes the instructions.
 use device::Device;
 use ir::{self, BasicBlock, BBId, Operand, Operator, Type, DimMapScope};
+use std;
 use std::hash::{Hash, Hasher};
 use utils::*;
 
@@ -14,6 +15,7 @@ pub struct Instruction<'a> {
     operator: Operator<'a>,
     id: InstId,
     iter_dims: HashSet<ir::dim::Id>,
+    value: Option<ir::ValueId>,
 }
 
 impl<'a> Instruction<'a> {
@@ -21,7 +23,7 @@ impl<'a> Instruction<'a> {
     pub fn new(operator: Operator<'a>, id: InstId, iter_dims: HashSet<ir::dim::Id>,
                device: &Device) -> Instruction<'a> {
         operator.type_check(device);
-        Instruction { operator, id, iter_dims }
+        Instruction { operator, id, iter_dims, value: None }
     }
 
     /// Returns the list of operands of an `Instruction`.
@@ -108,6 +110,15 @@ impl<'a> Instruction<'a> {
     /// iteration dimension.
     pub fn add_iteration_dimension(&mut self, dim: ir::dim::Id) -> bool {
         self.iter_dims.insert(dim)
+    }
+
+    /// Returns the `Value` holding the result of this instruction.
+    pub fn result_value(&self) -> Option<ir::ValueId> { self.value }
+
+    /// Sets the `Value` holdings the result of this instruction.
+    pub fn set_result_value(&mut self, value: ir::ValueId) {
+        // An instruction value cannot be set twice.
+        assert_eq!(std::mem::replace(&mut self.value, Some(value)), None);
     }
 }
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -10,6 +10,7 @@ mod operand;
 mod operator;
 mod size;
 mod types;
+mod value;
 
 pub use self::access_pattern::{Stride, AccessPattern};
 pub use self::basic_block::{BasicBlock, BBId};
@@ -22,6 +23,7 @@ pub use self::operand::{Operand, DimMapScope};
 pub use self::operator::{BinOp, Operator};
 pub use self::size::Size;
 pub use self::types::Type;
+pub use self::value::{Value, ValueId, ValueDef};
 
 pub mod mem;
 

--- a/src/ir/value.rs
+++ b/src/ir/value.rs
@@ -1,0 +1,49 @@
+//! Encodes the data-flow information.
+use ir;
+
+/// Uniquely identifies values.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct ValueId(pub u16);
+
+/// A value produced by the code.
+#[derive(Clone, Debug)]
+pub struct Value {
+    id: ValueId,
+    t: ir::Type,
+    def: ValueDef,
+}
+
+impl Value {
+    /// Return the unique identifiers of the `Value`.
+    pub fn id(&self) -> ValueId { self.id }
+
+    /// Specifies how the value is defined.
+    pub fn def(&self) -> &ValueDef { &self.def }
+
+    /// Indicates the type of the value.
+    pub fn t(&self) -> &ir::Type { &self.t }
+}
+
+/// Specifies how is a `Value` defined.
+#[derive(Clone, Debug)]
+pub enum ValueDef {
+    /// Takes the value produced by an instruction.
+    Inst(ir::InstId),
+    // TODO(value):
+    // - Last
+    // - Dim Map
+    // - Fby
+    // - ExternalMem
+}
+
+// FIXME: value creation
+// - allocate an id
+// - register in the instruction
+// - retrieve the type
+// FIXME: def point
+// FIXME: use points
+// FIXME: def dims
+//  - use is in def dims ?
+//  - use is before def
+// FIXME: value in operand position
+


### PR DESCRIPTION
Telamon's IR currently represents values as instruction inputs with `ir::Operand`.
Unfortunately, this does not allows us to manipulate decisions about operands and to
reason about the data flow in the program. This PR introduces a new type `ir::Value`
that represents a value stored in a variable. It lays the foundations for #41.

**This PR is a work in progress, do not merge**