### PR TITLE
Add a Symmetric Difference method to `VecSet`.

### DIFF
--- a/telamon-utils/src/vec_set.rs
+++ b/telamon-utils/src/vec_set.rs
@@ -372,10 +372,10 @@ mod tests {
     }
 
     #[test]
-    fn symmetric_difference() {
+    fn relative_difference() {
         let v0 = VecSet::new(vec![0, 2, 3, 5]);
         let v1 = VecSet::new(vec![0, 1, 2, 4, 6]);
-        let (d0, d1) = v0.symmetric_difference(v1);
+        let (d0, d1) = v0.relative_difference(v1);
         assert_eq!(d0, VecSet::new(vec![3, 5]));
         assert_eq!(d1, VecSet::new(vec![1, 4, 6]))
     }


### PR DESCRIPTION
This PR adds a method to perform a symmetric difference on sets backed by vectors. It uses unsafe code to perform the operation in-place.

The unsafe code is required because with have temporary holes in the vectors we process: the data inside the holes is either droped or moved and we so we don't want it to be dropped a second time if a panic occurs (for example in the comparison function, potentially defined by the user, for the data type).

The trick is to set the lenght of arrays at 0 during the processing and set it back at the real lengh at the end. This way, if an unwinding occurs, it will not drop the content of the array and will only leak memory instead of accessing freed memory.