### PR TITLE
Use a dedicated type for representing sizes in codegen

### DIFF
--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -3,8 +3,9 @@ use ir;
 use ir::prelude::*;
 use itertools::Itertools;
 use search_space::{self, DimKind, Domain, MemSpace, SearchSpace};
-use codegen::{cfg, Cfg, dimension, Dimension, InductionVar, InductionLevel};
+use codegen::{self, cfg, Cfg, dimension, Dimension, InductionVar, InductionLevel};
 use std;
+use utils::*;
 
 /// A function ready to execute on a device, derived from a constrained IR instance.
 pub struct Function<'a> {
@@ -28,16 +29,17 @@ impl<'a> Function<'a> {
         trace!("dims = {:?}", dims);
         let insts = space.ir_instance().insts()
             .map(|inst| Instruction::new(inst, space)).collect_vec();
-        let device_code_args = dims.iter().flat_map(|d| d.host_values(space))
+        let mut device_code_args = dims.iter().flat_map(|d| d.host_values(space))
             .chain(induction_vars.iter().flat_map(|v| v.host_values(space)))
             .chain(insts.iter().flat_map(|i| i.host_values(space)))
             .chain(init_induction_levels.iter().flat_map(|l| l.host_values(space)))
-            .collect_vec();
+            .collect::<HashSet<_>>();
         let (block_dims, thread_dims, cfg) = cfg::build(space, insts, dims);
         let mem_blocks = register_mem_blocks(space, &block_dims);
-        let device_code_args = device_code_args.into_iter()
-            .chain(mem_blocks.iter().flat_map(|x| x.host_values(space, &block_dims)))
-            .unique_by(|x| x.key()).collect();
+        device_code_args.extend(mem_blocks.iter().flat_map(|x| {
+            x.host_values(space, &block_dims)
+        }));
+        let device_code_args = device_code_args.into_iter().collect();
         debug!("compiling cfg {:?}", cfg);
         Function {
             cfg, thread_dims, block_dims, induction_vars, device_code_args, space,
@@ -107,9 +109,9 @@ pub enum ParamVal<'a> {
     /// A parameter given by the caller.
     External(&'a ir::Parameter, ir::Type),
     /// A tiled dimension size computed on the host.
-    Size(&'a ir::Size<'a>),
+    Size(codegen::Size<'a>),
     /// A pointer to a global memory block, allocated by the wrapper.
-    GlobalMem(ir::mem::InternalId, ir::Size<'a>, ir::Type),
+    GlobalMem(ir::mem::InternalId, codegen::Size<'a>, ir::Type),
 }
 
 impl<'a> ParamVal<'a> {
@@ -120,18 +122,17 @@ impl<'a> ParamVal<'a> {
                 let t = unwrap!(space.ir_instance().device().lower_type(p.t, space));
                 Some(ParamVal::External(p, t))
             }
-            ir::Operand::Size(ref s) => Self::from_size(s),
             _ => None,
         }
     }
 
     /// Builds the `ParamVal` needed to get a size value, if any.
-    pub fn from_size(size: &'a ir::Size) -> Option<Self> {
+    pub fn from_size(size: &codegen::Size<'a>) -> Option<Self> {
         match *size.dividend() {
             [] => None,
             [p] if size.factor() == 1 && size.divisor() == 1 =>
                 Some(ParamVal::External(p, ir::Type::I(32))),
-            _ => Some(ParamVal::Size(size)),
+            _ => Some(ParamVal::Size(size.clone())),
         }
     }
 
@@ -153,20 +154,22 @@ impl<'a> ParamVal<'a> {
     }
 
     /// Returns a unique identifier for the `ParamVal`.
-    pub fn key(&self) -> ParamValKey<'a> {
+    pub fn key(&self) -> ParamValKey {
         match *self {
             ParamVal::External(p, _) => ParamValKey::External(p),
-            ParamVal::Size(s) => ParamValKey::Size(s),
+            ParamVal::Size(ref s) => ParamValKey::Size(s),
             ParamVal::GlobalMem(mem, ..) => ParamValKey::GlobalMem(mem),
         }
     }
 }
 
+hash_from_key!(ParamVal<'a>, ParamVal::key, 'a);
+
 /// Uniquely identifies a `ParamVal`.
 #[derive(PartialEq, Eq, Hash, Copy, Clone)]
 pub enum ParamValKey<'a> {
     External(&'a ir::Parameter),
-    Size(&'a ir::Size<'a>),
+    Size(&'a codegen::Size<'a>),
     GlobalMem(ir::mem::InternalId),
 }
 
@@ -189,8 +192,8 @@ fn register_mem_blocks<'a>(space: &'a SearchSpace<'a>, block_dims: &[Dimension<'
 /// A memory block allocated by the kernel.
 pub struct InternalMemBlock<'a> {
     id: ir::mem::InternalId,
-    size: &'a ir::Size<'a>,
-    num_private_copies: Option<ir::Size<'a>>,
+    size: codegen::Size<'a>,
+    num_private_copies: Option<codegen::Size<'a>>,
     mem_space: MemSpace,
     ptr_type: ir::Type,
 }
@@ -202,11 +205,11 @@ pub enum AllocationScheme { Global, PrivatisedGlobal, Shared }
 impl<'a> InternalMemBlock<'a> {
     /// Creates a new InternalMemBlock from an `ir::mem::Internal`.
     pub fn new(block: &'a ir::mem::InternalBlock<'a>,
-               num_threads_groups: &Option<ir::Size<'a>>,
+               num_threads_groups: &Option<codegen::Size<'a>>,
                space: &'a SearchSpace<'a>) -> Self {
         let mem_space = space.domain().get_mem_space(block.mem_id());
         assert!(mem_space.is_constrained());
-        let size = block.size();
+        let size = codegen::Size::from_ir(block.size(), space);
         let num_private_copies = if block.is_private() && mem_space == MemSpace::GLOBAL {
             num_threads_groups.clone()
         } else { None };
@@ -224,7 +227,8 @@ impl<'a> InternalMemBlock<'a> {
             vec![ParamVal::GlobalMem(self.id, self.alloc_size(), t)]
         } else { vec![] };
         let size = if self.num_private_copies.is_some() {
-            Some(block_dims[1..].iter().map(|d| d.size()).chain(std::iter::once(self.size))
+            Some(block_dims[1..].iter().map(|d| d.size().clone())
+                 .chain(std::iter::once(self.size.clone()))
                 .map(ParamVal::Size))
         } else { None };
         out.extend(size.into_iter().flat_map(|x| x));
@@ -246,14 +250,14 @@ impl<'a> InternalMemBlock<'a> {
     }
 
     /// Generates the size of the memory to allocate.
-    pub fn alloc_size(&self) -> ir::Size<'a> {
+    pub fn alloc_size(&self) -> codegen::Size<'a> {
         let mut out = self.size.clone();
         if let Some(ref s) = self.num_private_copies { out *= s }
         out
     }
 
     /// Returns the size of the part of the allocated memory accessible by each thread.
-    pub fn local_size(&self) -> &'a ir::Size<'a> { self.size }
+    pub fn local_size(&self) -> &codegen::Size<'a> { &self.size }
 
     /// Returns the memory space the block is allocated in.
     pub fn mem_space(&self) -> MemSpace { self.mem_space }
@@ -277,7 +281,8 @@ impl<'a> Instruction<'a> {
             let kind = space.domain().get_dim_kind(dim);
             unwrap!(kind.is(DimKind::VECTOR | DimKind::UNROLL).as_bool())
         }).map(|&dim| {
-            (dim, unwrap!(space.ir_instance().dim(dim).size().as_int()))
+            let size = space.ir_instance().dim(dim).size();
+            (dim, unwrap!(codegen::Size::from_ir(size, space).as_int()))
         }).collect();
         let mem_flag = instruction.as_mem_inst()
             .map(|inst| space.domain().get_inst_flag(inst.id()));

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -4,12 +4,14 @@ mod dimension;
 mod function;
 mod namer;
 mod printer;
+mod size;
 
 pub use self::cfg::Cfg;
 pub use self::dimension::{Dimension, InductionLevel, InductionVar};
 pub use self::function::*;
 pub use self::namer::{Namer, NameMap, Value};
 pub use self::printer::{MulMode, Printer};
+pub use self::size::Size;
 
 // TODO(cleanup): refactor function
 // - extend instructions with additional information: vector factor, flag, instantiated dims

--- a/src/codegen/size.rs
+++ b/src/codegen/size.rs
@@ -1,0 +1,70 @@
+use ir;
+use num;
+use std;
+use search_space::SearchSpace;
+
+/// The size of an iteration dimension. The size is of the form:
+/// `(factor * dividend_0 * dividend_1 * ...)) / divisor`
+/// where the reminder of the division is null.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct Size<'a> {
+    factor: u32,
+    dividend: Vec<&'a ir::Parameter>,
+    divisor: u32,
+}
+
+impl<'a> Size<'a> {
+    /// Creates a new 'Size'.
+    pub fn new(factor: u32, dividend: Vec<&'a ir::Parameter>, divisor: u32) -> Self {
+        assert!(factor != 0);
+        assert!(divisor != 0);
+        let mut new = Size { factor, dividend, divisor };
+        new.simplify();
+        new
+    }
+
+    /// Converts an `ir::Size` to `Self`.
+    pub fn from_ir(size: &ir::Size<'a>, _: &SearchSpace) -> Self {
+        Size::new(size.factor(),
+                  size.dividend().iter().cloned().collect(),
+                  size.divisor())
+    }
+
+    /// Returns the size of a dimension if it is staticaly known.
+    pub fn as_int(&self) -> Option<u32> {
+        if self.dividend.is_empty() { Some(self.factor) } else { None }
+    }
+
+    /// Returns the dividends.
+    pub fn dividend(&self) -> &[&'a ir::Parameter] { &self.dividend }
+
+    /// Returns the divisor.
+    pub fn divisor(&self) -> u32 { self.divisor }
+
+    /// Returns the factor.
+    pub fn factor(&self) -> u32 { self.factor }
+
+    /// Simplifies the fraction factor/divisor.
+    fn simplify(&mut self) {
+        let gcd = num::integer::gcd(self.factor, self.divisor);
+        self.factor /= gcd;
+        self.divisor /= gcd;
+    }
+}
+
+impl<'a, 'b> std::ops::MulAssign<&'b Size<'a>> for Size<'a> {
+    fn mul_assign(&mut self, rhs: &'b Size<'a>) {
+        self.factor *= rhs.factor;
+        self.dividend.extend(rhs.dividend.iter().cloned());
+        self.divisor *= rhs.divisor;
+        self.simplify();
+    }
+}
+
+// TODO(cleanup): remove the temporary implementation of From<ir::Size> for codgen::Size.
+// This is only needed until we have mechanism in `model::*` to handle sizes.
+impl<'a> From<ir::Size<'a>> for Size<'a> {
+    fn from(s: ir::Size<'a>) -> Size<'a> {
+        Size::new(s.factor(), s.dividend().iter().cloned().collect(), s.divisor())
+    }
+}

--- a/src/device/context.rs
+++ b/src/device/context.rs
@@ -1,6 +1,6 @@
 //! Describes the context for which a function must be optimized.
 use device::{Device, ScalarArgument, ArrayArgument};
-use codegen::Function;
+use codegen::{self, Function};
 use explorer::Candidate;
 use ir;
 use num;
@@ -29,7 +29,7 @@ pub trait Context: Sync {
     fn param_as_size(&self, name: &str) -> Option<u32>;
 
     /// Evaluate a size.
-    fn eval_size(&self, size: &ir::Size) -> u32 {
+    fn eval_size(&self, size: &codegen::Size) -> u32 {
         let mut dividend: u32 = size.factor();
         for p in size.dividend() {
             dividend *= unwrap!(self.param_as_size(&p.name));

--- a/src/device/cuda/kernel.rs
+++ b/src/device/cuda/kernel.rs
@@ -83,7 +83,7 @@ impl<'a, 'b> Kernel<'a, 'b> {
         let mut tmp_arrays = vec![];
         let params = self.function.device_code_args().map(|x| match *x {
             ParamVal::External(p, _) => ThunkArg::ArgRef(args.get_param(&p.name)),
-            ParamVal::Size(s) => ThunkArg::Size(args.eval_size(s) as i32),
+            ParamVal::Size(ref s) => ThunkArg::Size(args.eval_size(s) as i32),
             ParamVal::GlobalMem(_, ref size, _) => {
                 tmp_arrays.push(args.eval_size(size) as usize);
                 ThunkArg::TmpArray(tmp_arrays.len() - 1)

--- a/src/device/cuda/mem_model.rs
+++ b/src/device/cuda/mem_model.rs
@@ -146,7 +146,9 @@ fn tensor_thread_dims(space: &SearchSpace,
         }
     }).chain(external_dims).map(|(id, is_active_thread)| {
         let size = sizes[&id];
-        let stride = tensor_dims.get(&id).map(|s| ctx.eval_size(s) as u64).unwrap_or(0);
+        let stride = tensor_dims.get(&id).map(|s| {
+            ctx.eval_size(&s.clone().into()) as u64
+        }).unwrap_or(0);
         ThreadDimInfo {
             size: u64::from(size),
             stride, id, is_active_thread,

--- a/src/device/cuda/printer.rs
+++ b/src/device/cuda/printer.rs
@@ -2,7 +2,7 @@
 use device::cuda::{Gpu, Namer};
 use codegen::Printer;
 use codegen::*;
-use ir::{self, op, Size, Type};
+use ir::{self, op, Type};
 use itertools::Itertools;
 use search_space::{DimKind, Domain, InstFlag};
 use std;
@@ -192,7 +192,7 @@ impl CudaPrinter {
             for dim in function.dimensions() {
                 if !dim.kind().intersects(DimKind::UNROLL | DimKind::LOOP) { continue; }
                 for level in dim.induction_levels() {
-                    if let Some((_, incr)) = level.increment {
+                    if let Some((_, ref incr)) = level.increment {
                         let name = name_map.declare_size_cast(incr, level.t());
                         if let Some(name) = name {
                             let old_name = name_map.name_size(incr, Type::I(32));
@@ -235,7 +235,7 @@ impl CudaPrinter {
         let mut extra_cleanup = vec![];
         let params = fun.device_code_args().map(|p| match *p {
             ParamVal::External(p, _) => format!("&{}", p.name),
-            ParamVal::Size(size) => {
+            ParamVal::Size(ref size) => {
                 let extra_var = format!("_extra_{}", next_extra_var_id);
                 next_extra_var_id += 1;
                 extra_def.push(format!("int32_t {} = {};", extra_var, Self::host_size(size)));

--- a/src/device/x86/printer.rs
+++ b/src/device/x86/printer.rs
@@ -97,7 +97,7 @@ impl X86printer {
             for dim in function.dimensions() {
                 if !dim.kind().intersects(DimKind::UNROLL | DimKind::LOOP) { continue; }
                 for level in dim.induction_levels() {
-                    if let Some((_, incr)) = level.increment {
+                    if let Some((_, ref incr)) = level.increment {
                         let name = name_map.declare_size_cast(incr, level.t());
                         if let Some(name) = name {
                             let old_name = name_map.name_size(incr, Type::I(32));
@@ -217,7 +217,6 @@ impl X86printer {
         loop_init = loop_decl,
         tid_struct = tid_struct,
         loop_jump = loop_jmp)
-
     }
 
     /// Prints code that joins all previously generated threads

--- a/src/ir/operand.rs
+++ b/src/ir/operand.rs
@@ -28,8 +28,6 @@ pub enum Operand<'a> {
     Inst(InstId, Type, DimMap, DimMapScope),
     /// The current index in a loop.
     Index(dim::Id),
-    /// The size of a dimension.
-    Size(ir::Size<'a>),
     /// A parameter of the function.
     Param(&'a Parameter),
     /// The address of a memory block.
@@ -47,8 +45,7 @@ impl<'a> Operand<'a> {
             Int(_, n_bit) => Type::I(n_bit),
             Float(_, n_bit) => Type::F(n_bit),
             Addr(mem) => ir::Type::PtrTo(mem.into()),
-            Index(..) |
-            Size(..) => Type::I(32),
+            Index(..) => Type::I(32),
             Param(p) => p.t,
             Inst(_, t, ..) | Reduce(_, t, ..) | InductionVar(_, t) => t,
         }
@@ -111,7 +108,7 @@ impl<'a> Operand<'a> {
     /// Indicates if the operand stays constant during the execution.
     pub fn is_constant(&self) -> bool {
         match *self {
-            Int(..) | Float(..) | Addr(..) | Size(..) | Param(..) => true,
+            Int(..) | Float(..) | Addr(..) | Param(..) => true,
             Index(..) | Inst(..) | Reduce(..) | InductionVar(..) => false,
         }
     }

--- a/src/model/local_info.rs
+++ b/src/model/local_info.rs
@@ -30,7 +30,7 @@ impl LocalInfo {
     /// Compute the local information for the given search space, in the context.
     pub fn compute(space: &SearchSpace, context: &Context) -> Self {
         let dim_sizes = space.ir_instance().dims()
-            .map(|d| (d.id(), context.eval_size(d.size()))).collect();
+            .map(|d| (d.id(), context.eval_size(&d.size().clone().into()))).collect();
         let nesting: HashMap<_, _> = space.ir_instance().blocks().map(|bb| {
             (bb.bb_id(), Nesting::compute(space, bb.bb_id(), &dim_sizes))
         }).collect();

--- a/src/search_space/operand.rs
+++ b/src/search_space/operand.rs
@@ -6,7 +6,7 @@ use search_space::choices::{Action, DimKind, DimMapping, Order};
 /// Generates actions to enforce operands invariants.
 pub fn invariants(fun: &ir::Function, op: &ir::Operand, user: ir::BBId) -> Vec<Action> {
     match *op {
-        Int(..) | Float(..) | Size(..) | Param(..) | Addr(..) => vec![],
+        Int(..) | Float(..) | Param(..) | Addr(..) => vec![],
         Inst(src, _, ref dim_map, scope) => {
             // Order dimensions in the dim map.
             let order = Order::BEFORE | Order::MERGED;


### PR DESCRIPTION
Use a dedicated type to represent sizes in code generation. Currently, this type is equivalent to `ir::Size`. Latter, it will allow us to change `ir::Size` without changing `codegen::Size`.