### PR TITLE
Improve the way we test if a dimension is vectorizable.

### DIFF
--- a/src/device/cuda/gpu.rs
+++ b/src/device/cuda/gpu.rs
@@ -396,29 +396,15 @@ impl device::Device for Gpu {
 
     fn max_unrolling(&self) -> u32 { 512 }
 
-    fn can_vectorize(&self, dim: &ir::Dimension, op: &ir::Operator) -> bool {
-        // TODO(search_space): compute vectorizable info for tmp Ld/St. On vectorization,
-        // the layout must be constrained.
+    fn vectorization_factors(&self, dim: &ir::Dimension, op: &ir::Operator) -> &[u32] {
+        const LD_ST_FACTORS: [u32; 2] = [2, 4];
         match *op {
-            Operator::St(_, ref operand, _, ref pattern) => {
-                if let Some(type_len) = operand.t().len_byte() {
-                    dim.size().as_int().into_iter().any(|x| x == 2 || x == 4) &&
-                        pattern.stride(dim.id()) == ir::Stride::Int(type_len as i32)
-                } else { false }
-            },
-            Operator::Ld(ref t, _, ref pattern) => {
-                if let Some(type_len) = t.len_byte() {
-                    dim.size().as_int().into_iter().any(|x| x == 2 || x == 4) &&
-                        pattern.stride(dim.id()) == ir::Stride::Int(type_len as i32)
-                } else { false }
-            },
-            Operator::BinOp(..) |
-                Operator::Mul(..) |
-                Operator::Mad(..) |
-                Operator::Mov(..) |
-                Operator::Cast(..) => false,
-                Operator::TmpLd(..) |
-                    Operator::TmpSt(..) => dim.size().as_int().into_iter().any(|x| x == 2 || x == 4),
+            Operator::TmpLd(..) | Operator::TmpSt(..) => &LD_ST_FACTORS,
+            Operator::Ld(ref t, _, ref pattern) if pattern.is_consecutive(dim.id(), t) =>
+                &LD_ST_FACTORS,
+            Operator::St(_, ref operand, _, ref pattern)
+                if pattern.is_consecutive(dim.id(), &operand.t()) => &LD_ST_FACTORS,
+            _ => &[],
         }
     }
 

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -17,9 +17,6 @@ use std::io::Write;
 use model::{HwPressure, Nesting};
 use utils::*;
 
-// TODO(perf): in PTX, shared and local pointers can have a 32-bit size, even in 64-bit
-// mode. 32bits ops are potentialy faster than 64bits ops.
-
 /// Holds the specifications of a target.
 pub trait Device: Sync {
     /// Prints the code corresponding to a device `Function`.
@@ -32,8 +29,9 @@ pub trait Device: Sync {
     fn max_threads(&self) -> u32;
     /// Returns the maximal unrolling factor.
     fn max_unrolling(&self) -> u32;
-    /// Indicates if vectorization is possible on a loop with size Size on this instruction.
-    fn can_vectorize(&self, dim: &ir::Dimension, op: &ir::Operator) -> bool;
+    /// Indicates the valid vectorization factors for the given operator, on the given
+    /// dimension.
+    fn vectorization_factors(&self, dim: &ir::Dimension, op: &ir::Operator) -> &[u32];
     /// Returns the amount of shared memory available for each thread block.
     fn shared_mem(&self) -> u32;
     /// Indicates if the device supports non-coherent memory accesses.

--- a/src/device/x86/cpu.rs
+++ b/src/device/x86/cpu.rs
@@ -43,7 +43,7 @@ impl device::Device for Cpu {
 
     fn max_unrolling(&self) -> u32 { 512 }
 
-    fn can_vectorize(&self, _dim: &ir::Dimension, _op: &ir::Operator) -> bool {false}
+    fn vectorization_factors(&self, _: &ir::Dimension, _: &ir::Operator) -> &[u32] { &[] }
 
     fn shared_mem(&self) -> u32 {0}
 

--- a/src/ir/access_pattern.rs
+++ b/src/ir/access_pattern.rs
@@ -11,17 +11,7 @@ pub enum Stride {
     Unknown,
 }
 
-impl Stride {
-    /// Unwrap the stride or return the given value.
-    pub fn unwrap_or(self, default: i32) -> i32 {
-        match self {
-            Stride::Int(stride) => stride,
-            Stride::Unknown => default,
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub enum AccessPattern<'a> {
     /// Unknown access pattern.
     Unknown { mem_id: ir::mem::Id },
@@ -31,14 +21,14 @@ pub enum AccessPattern<'a> {
 }
 
 impl<'a> AccessPattern<'a> {
-    /// Returns the stride on a given dimension.
-    pub fn stride(&self, dim: ir::dim::Id) -> Stride {
-        match *self {
-            AccessPattern::Unknown { .. } => Stride::Unknown,
-            AccessPattern::Tensor { ref dims, .. } => {
-                dims.get(&dim).map(|s| {
-                    s.as_int().map(|x| Stride::Int(x as i32)).unwrap_or(Stride::Unknown)
-                }).unwrap_or(Stride::Int(0))
+    /// Indicates if emory accesses access to consecutive elements on the given dimension.
+    pub fn is_consecutive(&self, dim: ir::dim::Id, t: &ir::Type) -> bool {
+        match self {
+            AccessPattern::Unknown { .. } => false,
+            AccessPattern::Tensor { dims, .. } => {
+                dims.get(&dim).and_then(|s| s.as_int())
+                    .map(|s| Some(s) == t.len_byte())
+                    .unwrap_or(false)
             },
         }
     }

--- a/src/ir/access_pattern.rs
+++ b/src/ir/access_pattern.rs
@@ -40,4 +40,20 @@ impl<'a> AccessPattern<'a> {
             AccessPattern::Tensor { mem_id, .. } => mem_id,
         }
     }
+
+    /// Ensure the access pattern is valid for an instruction declared in the given
+    /// dimensions.
+    pub fn check(&self, iter_dims: &HashSet<ir::dim::Id>) -> Result<(), ir::Error> {
+        match self {
+            AccessPattern::Unknown { .. } => Ok(()),
+            AccessPattern::Tensor { dims, .. } => {
+                for (&dim, _) in dims {
+                    if !iter_dims.contains(&dim) {
+                        return Err(ir::Error::InvalidDimInPattern { dim });
+                    }
+                }
+                Ok(())
+            },
+        }
+    }
 }

--- a/src/ir/error.rs
+++ b/src/ir/error.rs
@@ -65,6 +65,8 @@ pub enum Error {
     InvalidDimSize,
     #[fail(display="dimension {} appears twice in the increment list", dim)]
     DuplicateIncrement { dim: ir::dim::Id },
+    #[fail(display="the access pattern references dimension {}, but is not nested inside", dim)]
+    InvalidDimInPattern { dim: ir::dim::Id },
 }
 
 impl From<TypeError> for Error {

--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -26,7 +26,7 @@ impl<'a> Instruction<'a> {
     /// Creates a new instruction and type-check the operands.
     pub fn new(operator: Operator<'a>, id: InstId, iter_dims: HashSet<ir::dim::Id>,
                device: &Device) -> Result<Instruction<'a>, ir::Error> {
-        operator.type_check(device)?;
+        operator.check(&iter_dims, device)?;
         Ok(Instruction { operator, id, iter_dims })
     }
 

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -110,7 +110,9 @@ define enum dim_kind($dim in Dimensions):
     requires forall $other_dim in Dimensions:
       order($dim, $other_dim) is not OUTER
     requires forall $inst in Instructions:
-      order($dim, $inst) is not OUTER || "$fun.device().can_vectorize($dim, $inst.operator())"
+      order($dim, $inst) is not OUTER || "$dim.size().as_int().map(|s| \
+        $fun.device().vectorization_factors($dim, $inst.operator()).contains(&s)) \
+        .unwrap_or(false)"
   /// The dimension is mapped to a block dimension on the device.
   value BLOCK:
     requires forall $other_dim in Dimensions:

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -109,6 +109,12 @@ define enum dim_kind($dim in Dimensions):
     requires "$dim.size().is_constant()"
     requires forall $other_dim in Dimensions:
       order($dim, $other_dim) is not OUTER
+    // This constraint effectively forbids VECTOR dimensions to be merged as dimensions
+    // that originates from other loop nests will not be declared in the access pattern
+    // and thus will have no possible vectorization factors.
+    //
+    // If we ever want to merge VECTOR dimensions, we will need to restric this constraint
+    // to iteration dimensions.
     requires forall $inst in Instructions:
       order($dim, $inst) is not OUTER || "$dim.size().as_int().map(|s| \
         $fun.device().vectorization_factors($dim, $inst.operator()).contains(&s)) \

--- a/src/search_space/dim_map.rs
+++ b/src/search_space/dim_map.rs
@@ -12,6 +12,10 @@ pub fn lower_layout(fun: &mut ir::Function, mem: ir::mem::InternalId,
     debug!("lower_layout({:?}) triggered", mem);
     let mut actions = Vec::new();
     // TODO(automate): vectorization disabled -> express as an additional constraint
+    // We need to manually set every dimension except the innermost as non-vectorizable
+    // because temporary loads and stores do not restrict vectorization automatically
+    // since they are not aware of the access pattern. The constraint propagation is not
+    // aware we just specified the access pattern and so doesn't re-run the constraints.
     for (&st_dim, &ld_dim) in st_dims.iter().rev().zip_eq(ld_dims.iter().rev()).skip(1) {
         let not_vec = !DimKind::VECTOR;
         actions.extend(dim_kind::restrict_delayed(st_dim, fun, domain, not_vec)?);

--- a/tests/common/fake.rs
+++ b/tests/common/fake.rs
@@ -30,32 +30,18 @@ impl device::Device for Device {
 
     fn max_unrolling(&self) -> u32 { 256 }
 
-    fn can_vectorize(&self, dim: &ir::Dimension, op: &ir::Operator) -> bool {
-        // TODO(search_space): compute vectorizable info for tmp Ld/St. On vectorization,
-        // the layout must be constrained.
+    fn vectorization_factors(&self, dim: &ir::Dimension, op: &ir::Operator) -> &[u32] {
+        const LD_ST_FACTORS: [u32; 2] = [2, 4];
+        const OTHER_FACTORS: [u32; 0] = [];
         match *op {
-            Operator::St(_, ref operand, _, ref pattern) => {
-                if let Some(type_len) = operand.t().len_byte() {
-                    dim.size().as_int().into_iter().any(|x| x == 2 || x == 4) &&
-                        pattern.stride(dim.id()) == ir::Stride::Int(type_len as i32)
-                } else { false }
-            },
-            Operator::Ld(ref t, _, ref pattern) => {
-                if let Some(type_len) = t.len_byte() {
-                    dim.size().as_int().into_iter().any(|x| x == 2 || x == 4) &&
-                        pattern.stride(dim.id()) == ir::Stride::Int(type_len as i32)
-                } else { false }
-            },
-            Operator::BinOp(..) |
-                Operator::Mul(..) |
-                Operator::Mad(..) |
-                Operator::Mov(..) |
-                Operator::Cast(..) => false,
-                Operator::TmpLd(..) |
-                    Operator::TmpSt(..) => dim.size().as_int().into_iter().any(|x| x == 2 || x == 4),
+            Operator::TmpLd(..) | Operator::TmpSt(..) => &LD_ST_FACTORS,
+            Operator::Ld(ref t, _, ref pattern) if pattern.is_consecutive(dim.id(), t) =>
+                &LD_ST_FACTORS,
+            Operator::St(_, ref operand, _, ref pattern)
+                if pattern.is_consecutive(dim.id(), &operand.t()) => &LD_ST_FACTORS,
+            _ => &OTHER_FACTORS,
         }
     }
-
 
     fn max_block_dims(&self) -> u32 { 3 }
 


### PR DESCRIPTION
This PR improves the way we check if a dimension is vectorizable. Instead of calling an opaque method, we compute the list vectorization factors possible for each pair of dimension and instruction. We then check is the size of the dimension is in the list. This will later allow us to add a decision to choose the size of dimensions.

This PR also simplifies the access pattern structure to fit our new needs and add checks and comments.

Fixes #76 .