### PR TITLE
Actually prevent use-after-free in Python API

### DIFF
--- a/telamon-py/setup.py
+++ b/telamon-py/setup.py
@@ -28,6 +28,6 @@ setup(
     packages=["telamon"],
     zip_safe=False,
     setup_requires=["milksnake"],
-    install_requires=["milksnake"],
+    install_requires=["milksnake", "toml", "numpy"],
     milksnake_tasks=[build_capi],
 )


### PR DESCRIPTION
Storing a <cdata> pointer, as we were doing, into another <cdata>
structure *does not* count as a reference; the Python <cdata> object
must be kept alive for the pointed-to C memory to be valid.

Instead, we will now fully allocate the memory from Rust and use a
temporary NumPy array to copy the data from. This means we are currently
performing three copies from a Python list to a Rust Vec: one copy to
the NumPy array, then a second copy from the NumPy array to the kernel
parameters structure. Users can avoid the first copy by passing in an
existing NumPy array instead of a list, in which case we read from that
array's buffer directly. The second copy is required because we cannot
transfer ownership from Python to Rust due to different allocators.