### PR TITLE
Expose the set of dimensions with a static size.

### DIFF
--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -53,10 +53,10 @@ impl<'a> Cfg<'a> {
                 Box::new(levels) as Box<Iterator<Item=_>>
             }
             Cfg::Root(ref body) =>
-                Box::new(body.iter().flat_map(|c| c.induction_levels())), 
+                Box::new(body.iter().flat_map(|c| c.induction_levels())),
             Cfg::Loop(ref dim, ref body) =>
                 Box::new(body.iter().flat_map(|c| c.induction_levels())
-                         .chain(dim.induction_levels())), 
+                         .chain(dim.induction_levels())),
             Cfg::Instruction(..) => Box::new(std::iter::empty())
         }
     }

--- a/src/device/cuda/mem_model.rs
+++ b/src/device/cuda/mem_model.rs
@@ -165,6 +165,7 @@ fn external_thread_dims<'a>(inst: &'a ir::Instruction, space: &'a SearchSpace)
 {
     space.ir_instance().thread_dims().flat_map(move |dim| {
         let is_mapped = inst.iteration_dims().iter().map(|&other| {
+            if dim.possible_sizes().is_none() { return Trivalent::False; }
             if dim.id() == other { return Trivalent::True; }
             let mapping = space.domain().get_thread_mapping(dim.id(), other);
             mapping.is(ThreadMapping::MAPPED)
@@ -181,7 +182,7 @@ fn external_thread_dims<'a>(inst: &'a ir::Instruction, space: &'a SearchSpace)
 /// respect dependencies since we don't know the exact order and it would be too costly to
 /// explore all of them (exponential). Instead we compute the minimal number of inner
 /// thread dimension for each dimension and ensure this amount is respected.
-/// 
+///
 /// Because we only support tensor accesses, bigger strides are multiples of smaller
 /// strides. Thus smaller stride will lead to less replays.
 fn sort_thread_dims(dims: Vec<ThreadDimInfo>,

--- a/src/device/cuda/mem_model.rs
+++ b/src/device/cuda/mem_model.rs
@@ -165,7 +165,9 @@ fn external_thread_dims<'a>(inst: &'a ir::Instruction, space: &'a SearchSpace)
 {
     space.ir_instance().thread_dims().flat_map(move |dim| {
         let is_mapped = inst.iteration_dims().iter().map(|&other| {
-            if dim.possible_sizes().is_none() { return Trivalent::False; }
+            if space.ir_instance().dim(other).possible_sizes().is_none() {
+                return Trivalent::False;
+            }
             if dim.id() == other { return Trivalent::True; }
             let mapping = space.domain().get_thread_mapping(dim.id(), other);
             mapping.is(ThreadMapping::MAPPED)

--- a/src/explorer/choice.rs
+++ b/src/explorer/choice.rs
@@ -28,8 +28,8 @@ pub fn list<'a>(space: &'a SearchSpace<'a>) -> impl Iterator<Item=Choice> + 'a {
     }).chain(fun.dims().flat_map(move |dim| {
         let kinds = space.domain().get_dim_kind(dim.id());
         gen_choice(kinds.list(), &|k| Action::DimKind(dim.id(), k))
-    })).chain(fun.dims().enumerate().flat_map(move |(i, lhs)| {
-        fun.dims().take(i).flat_map(move |rhs| {
+    })).chain(fun.static_dims().enumerate().flat_map(move |(i, lhs)| {
+        fun.static_dims().take(i).flat_map(move |rhs| {
             let mappings = space.domain().get_thread_mapping(lhs.id(), rhs.id());
             gen_choice(mappings.list(), &|m| Action::ThreadMapping(lhs.id(), rhs.id(), m))
         })

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -51,6 +51,7 @@ pub mod prelude {
 pub struct NewObjs {
     pub instructions: Vec<InstId>,
     pub dimensions: Vec<DimId>,
+    pub static_dims: Vec<DimId>,
     pub basic_blocks: Vec<BBId>,
     pub mem_blocks: Vec<MemId>,
     pub internal_mem_blocks: Vec<mem::InternalId>,
@@ -77,6 +78,7 @@ impl NewObjs {
     pub fn add_dimension(&mut self, dim: &Dimension) {
         self.add_bb(dim);
         self.dimensions.push(dim.id());
+        if dim.possible_sizes().is_some() { self.static_dims.push(dim.id()); }
         if dim.is_thread_dim() { self.add_thread_dim(dim.id()); }
     }
 

--- a/src/model/local_info.rs
+++ b/src/model/local_info.rs
@@ -164,6 +164,9 @@ impl Nesting {
         let num_unmapped_threads = space.ir_instance().thread_dims().filter(|dim| {
             !outer_dims.iter().any(|&other| {
                 if dim.id() == other { return true; }
+                if space.ir_instance().dim(other).possible_sizes().is_none() {
+                    return false;
+                }
                 let mapping = space.domain().get_thread_mapping(dim.id(), other);
                 mapping.intersects(ThreadMapping::MAPPED)
             })

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -93,7 +93,7 @@ quotient IterationDims($inst in Instructions) of $dim in Dimensions:
   add_to_set = "::search_space::add_iteration_dim($fun, $inst, $item)"
 end
 
-quotient ThreadDims of $dim in Dimensions:
+quotient ThreadDims of $dim in StaticDims:
   is_thread_dim = dim_kind($dim) is THREAD / thread_mapping is MAPPED
   item_type = "ir::Dimension"
   id_type = "ir::DimId"
@@ -112,13 +112,13 @@ define enum dim_kind($dim in Dimensions):
   value LOOP:
   /// The dimension is fully unrolled.
   value UNROLL:
-    requires "$dim.size().is_constant()"
+    requires "$dim.possible_sizes().is_some()"
     // It doesn't makes sens to unroll outer loops.
     requires forall $other_dim in Dimensions:
       order($other_dim, $dim) is not INNER || dim_kind($other_dim) is VECTOR | UNROLL
   /// The dimension is implemented by using a vector instruction.
   value VECTOR:
-    requires "$dim.size().is_constant()"
+    requires "$dim.possible_sizes().is_some()"
     requires forall $other_dim in Dimensions:
       order($dim, $other_dim) is not OUTER
     // This constraint effectively forbids VECTOR dimensions to be merged as dimensions
@@ -139,7 +139,7 @@ define enum dim_kind($dim in Dimensions):
       order($dim, $other) is NESTED | MERGED
   /// The dimension is mapped to a thread dimension on the device.
   value THREAD:
-    requires "$dim.size().as_int().is_some()"
+    requires "$dim.possible_sizes().is_some()"
   /// The dimension is parallel.
   alias PARALLEL = BLOCK | THREAD | VECTOR:
   /// The dimension is sequential.
@@ -260,6 +260,7 @@ define enum dim_mapping($lhs in Dimensions, $rhs in Dimensions):
 end
 
 /// Indicates how are thread dimensions mapped on the GPU.
+// FIXME: restrict to static dimensions
 define enum thread_mapping($lhs in Dimensions, $rhs in Dimensions):
   antisymmetric:
     MAPPED_OUT -> MAPPED_IN
@@ -285,9 +286,9 @@ define enum thread_mapping($lhs in Dimensions, $rhs in Dimensions):
 end
 
 // Enforce coherence between threads activations.
-require forall $lhs in Dimensions:
-  forall $rhs in Dimensions:
-    forall $other in Dimensions:
+require forall $lhs in StaticDims:
+  forall $rhs in StaticDims:
+    forall $other in StaticDims:
       thread_mapping($lhs, $rhs) is not MAPPED ||
         thread_mapping($lhs, $other) == thread_mapping($rhs, $other)
       thread_mapping($lhs, $other) is not MAPPED_OUT ||
@@ -295,40 +296,51 @@ require forall $lhs in Dimensions:
         thread_mapping($lhs, $rhs) is MAPPED_OUT
 
 // Thread dimensions are grouped together
-require forall $outer in Dimensions:
-  forall $inner in Dimensions:
+require forall $outer in StaticDims:
+  forall $inner in StaticDims:
     forall $mid in Dimensions:
       order($outer, $mid) is not OUTER || order($mid, $inner) is not OUTER
         || dim_kind($outer) is not THREAD || dim_kind($inner) is not THREAD
         || dim_kind($mid) is THREAD
 
 // outer thread dimensions are limited to a size of 64.
-require forall $outer in Dimensions:
-  forall $inner in Dimensions:
+require forall $outer in StaticDims:
+  forall $inner in StaticDims:
     thread_mapping($outer, $inner) is not MAPPED_OUT
-      || "$outer.size().as_int().unwrap_or(1) <= 64"
+      || "unwrap!($outer.size().as_int()) <= 64"
 
 // A basic block nested with a thread dimension is nested or merged with the other
 require forall $bb in BasicBlocks:
-  forall $nested_thread in Dimensions:
-    forall $other_thread in Dimensions:
+  forall $nested_thread in StaticDims:
+    forall $other_thread in StaticDims:
       order($bb, $nested_thread) is not NESTED || dim_kind($nested_thread) is not THREAD
         || order($other_thread, $nested_thread) is not NESTED
         || dim_kind($other_thread) is not THREAD
         || order($bb, $other_thread) is not ORDERED
 
 /// Limits the number of threads.
+///
+/// The counter iterates on `StaticDims` instead of just `ThreadDims` because we want the
+/// constraint `num_threads() <= "$fun.device().max_threads()"` to propagate to dimensions
+/// that still have the possibility of not being thread dimensions. Otherwise the
+/// constraint would only apply to dimensions for wich we already took the decision they
+/// were threads.
 define half counter num_threads():
-  forall $dim in Dimensions:
-    mul "$dim.size().as_int().unwrap_or(1)" when:
+  forall $dim in StaticDims:
+    mul "unwrap!($dim.size().as_int())" when:
       is_thread_dim($dim) is TRUE
 end
 
 require num_threads() <= "$fun.device().max_threads()"
 
 /// Limits the number of thread dimensions.
+///
+/// The counter iterates on `StaticDims` instead of just `ThreadDims` because we want the
+/// constraint `num_thread_dims() <= 3` to propagate to dimensions that still have the
+/// possibility of not being thread dimensions. Otherwise the constraint would only apply
+/// to dimensions for wich we already took the decision they were threads.
 define half counter num_thread_dims():
-  forall $dim in Dimensions:
+  forall $dim in StaticDims:
     sum "1" when: is_thread_dim($dim) is TRUE
 end
 
@@ -336,8 +348,8 @@ require num_thread_dims() <= "3"
 
 /// Limits the number of nested unrolled loop.
 define half counter unroll_factor($inst in Instructions):
-  forall $dim in Dimensions:
-    mul "$dim.size().as_int().unwrap_or(1)" when:
+  forall $dim in StaticDims:
+    mul "unwrap!($dim.size().as_int())" when:
       is_iteration_dim($inst, $dim) is TRUE
       dim_kind($dim) is UNROLL
 end
@@ -355,13 +367,13 @@ require forall $inst in Instructions:
   num_block_dims($inst) <= "$fun.device().max_block_dims()"
 
 /// Counts the number on instructions nested in each dimension.
-define half counter num_nested_inst($dim in Dimensions):
+define half counter num_nested_inst($dim in StaticDims):
   forall $inst in Instructions:
     sum "1" when:
       order($dim, $inst) is OUTER
 end
 
-require forall $dim in Dimensions:
+require forall $dim in StaticDims:
   dim_kind($dim) is not VECTOR || num_nested_inst($dim) <= "1"
 
 require forall $dim in Dimensions:

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -49,7 +49,7 @@ end
 /// The set of dimensions for which the sizes it can take is statically known.
 set StaticDims subsetof Dimensions:
   item_type = "ir::Dimension"
-  id_type = "ir::dim::Id"
+  id_type = "ir::DimId"
   item_getter = "$fun.dim($id)"
   id_getter = "$item.id()"
   iterator = "$fun.static_dims()"

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -253,15 +253,17 @@ define enum dim_mapping($lhs in Dimensions, $rhs in Dimensions):
     requires dim_kind($lhs) is UNROLL | VECTOR || order($lhs, $rhs) is MERGED
   /// Values may be transmitted using one register for each thread.
   value THREAD_MAP:
-    requires thread_mapping($lhs, $rhs) is MAPPED
   /// Values are transmitted through registers.
   alias MAPPED = UNROLL_MAP | THREAD_MAP:
     requires "$lhs.size() == $rhs.size()"
 end
 
+require forall $lhs in StaticDims:
+  forall $rhs in StaticDims:
+    dim_mapping($lhs, $rhs) is not THREAD_MAP || thread_mapping($lhs, $rhs) is MAPPED
+
 /// Indicates how are thread dimensions mapped on the GPU.
-// FIXME: restrict to static dimensions
-define enum thread_mapping($lhs in Dimensions, $rhs in Dimensions):
+define enum thread_mapping($lhs in StaticDims, $rhs in StaticDims):
   antisymmetric:
     MAPPED_OUT -> MAPPED_IN
   /// One of the dimensions is a not thread.

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -46,6 +46,18 @@ set Dimensions subsetof BasicBlocks:
   new_objs = "$objs.dimensions"
 end
 
+/// The set of dimensions for which the sizes it can take is statically known.
+set StaticDims subsetof Dimensions:
+  item_type = "ir::Dimension"
+  id_type = "ir::dim::Id"
+  item_getter = "$fun.dim($id)"
+  id_getter = "$item.id()"
+  iterator = "$fun.static_dims()"
+  var_prefix = "dim"
+  from_superset = "$item.possible_sizes().map(|_| $item)"
+  new_objs = "$objs.static_dims"
+end
+
 set MemBlocks:
   item_type = "ir::mem::Block"
   id_type = "ir::MemId"
@@ -381,9 +393,9 @@ trigger forall $lhs in Dimensions:
 // FIXME: remove cubic choice choices
 define half counter mem_size($mem in InternalMemBlocks):
   base "$mem.base_size()"
-  forall $lhs in Dimensions:
-    forall $rhs in Dimensions:
-      mul "$lhs.size().as_int().unwrap_or(1)" when:
+  forall $lhs in StaticDims:
+    forall $rhs in StaticDims:
+      mul "unwrap!($lhs.size().as_int())" when:
         "$mem.maps_dims($lhs.id(), $rhs.id())"
         order($lhs, $rhs) is not MERGED
 end

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -253,6 +253,7 @@ define enum dim_mapping($lhs in Dimensions, $rhs in Dimensions):
     requires dim_kind($lhs) is UNROLL | VECTOR || order($lhs, $rhs) is MERGED
   /// Values may be transmitted using one register for each thread.
   value THREAD_MAP:
+    requires dim_kind($lhs) is THREAD
   /// Values are transmitted through registers.
   alias MAPPED = UNROLL_MAP | THREAD_MAP:
     requires "$lhs.size() == $rhs.size()"


### PR DESCRIPTION
This PR improves the encoding of the search space by exposing dimensions with a statically known size in a dedicated set. It allows us to restrict the scope of many constraints and of the `thread_mapping` choice. It also allows to access the size of such dimensions without providing a default value.

Later, it will allow us to expose  a `size` choice for such dimensions.

This PR greatly improves the exploration performance thanks to the reduced number of constraints to propagate: 1.8x factor on the descent time.