### PR TITLE
Ensure telamon-gen output is deterministic

### DIFF
--- a/telamon-gen/Cargo.toml
+++ b/telamon-gen/Cargo.toml
@@ -25,7 +25,6 @@ lalrpop-util = "0.14"
 lazy_static = "1.0.0"
 libc = "0.2.40"
 log = "0.4.1"
-pathfinding = "0.8.0"
 regex = "0.2.10"
 rustfmt = "0.10.0"
 serde = "1.0.43"
@@ -34,6 +33,7 @@ serde = "1.0.43"
 # https://github.com/eqrion/cbindgen/pull/159
 serde_derive = "=1.0.21"
 serde_json = "1.0.16"
+indexmap = { version = "1.0", features = ["serde-1"] }
 
 [dependencies.telamon-utils]
 path = "../telamon-utils"

--- a/telamon-gen/src/ast/context.rs
+++ b/telamon-gen/src/ast/context.rs
@@ -1,5 +1,6 @@
 use ir::{self,Adaptable};
 use super::*;
+use indexmap::IndexMap;
 
 #[derive(Default)]
 pub struct TypingContext {
@@ -82,7 +83,7 @@ impl TypingContext {
         let arg = arg_def.clone().map(|arg| var_map.decl_argument(&self.ir_desc, arg));
         let superset = superset.map(|set| set.type_check(&self.ir_desc, &var_map));
         for disjoint in &disjoints { self.ir_desc.get_set_def(disjoint); }
-        let mut keymap = HashMap::default();
+        let mut keymap = IndexMap::default();
         let mut reverse = None;
         for (key, var, mut value) in keys {
             let mut env = key.env();

--- a/telamon-gen/src/ast/mod.rs
+++ b/telamon-gen/src/ast/mod.rs
@@ -19,6 +19,7 @@ use std::fmt;
 use std::collections::{BTreeSet, hash_map};
 use std::ops::Deref;
 use utils::*;
+use indexmap::IndexMap;
 
 pub use self::set::SetDef;
 pub use self::choice::integer::IntegerDef;
@@ -545,9 +546,9 @@ impl PartialEq for EnumStatement {
 #[derive(Debug, Default)]
 struct EnumStatements {
     /// The values the enum can take, with the atached documentation.
-    values: HashMap<RcStr, Option<String>>,
+    values: IndexMap<RcStr, Option<String>>,
     /// Aliases mapped to the corresponding documentation and value set.
-    aliases: HashMap<RcStr, (Option<String>, HashSet<RcStr>)>,
+    aliases: IndexMap<RcStr, (Option<String>, HashSet<RcStr>)>,
     /// Symmetry information.
     symmetry: Option<Symmetry>,
     /// Constraints on a value.

--- a/telamon-gen/src/ast/set.rs
+++ b/telamon-gen/src/ast/set.rs
@@ -60,9 +60,9 @@ impl SetDef {
 
     /// This checks that thereisn't any keys doublon.
     fn check_redefinition(&self) -> Result<(), TypeError> {
-        let mut hash: HashMap<String, _> = HashMap::default();
+        let mut hash: HashSet<String> = HashSet::default();
         for (key, ..) in self.keys.iter() {
-            if let Some(before) = hash.insert(key.to_string(), ()) {
+            if !hash.insert(key.to_string()) {
                 Err(TypeError::Redefinition(Spanned {
                     beg: Default::default(),
                     end: Default::default(),

--- a/telamon-gen/src/ir/mod.rs
+++ b/telamon-gen/src/ir/mod.rs
@@ -2,6 +2,7 @@
 use std;
 
 use itertools::Itertools;
+use indexmap::IndexMap;
 use utils::*;
 
 mod adaptator;
@@ -16,9 +17,9 @@ pub use self::adaptator::*;
 
 /// Describes the choices that constitute the IR.
 pub struct IrDesc {
-    choices: HashMap<RcStr, Choice>,
-    enums: HashMap<RcStr, Enum>,
-    set_defs: HashMap<RcStr, std::rc::Rc<SetDef>>,
+    choices: IndexMap<RcStr, Choice>,
+    enums: IndexMap<RcStr, Enum>,
+    set_defs: IndexMap<RcStr, std::rc::Rc<SetDef>>,
     triggers: Vec<Trigger>,
 }
 
@@ -197,7 +198,7 @@ impl IrDesc {
                 set_constraints.push((Variable::Arg(arg_id), expected_set.clone()));
             }
         }
-        // Add the remaining variables as foralls. We keep the foralls in the order thwy were
+        // Add the remaining variables as foralls. We keep the foralls in the order they were
         // given, so the sets are still defined after their parameters.
         let vars = vars.into_iter().sorted_by_key(|x| x.0);
         for (forall_id, (mapped_var, set)) in vars.into_iter().enumerate() {
@@ -248,9 +249,9 @@ impl IrDesc {
 impl Default for IrDesc {
     fn default() -> Self {
        let mut ir_desc =  IrDesc {
-           choices: HashMap::default(),
-           enums: HashMap::default(),
-           set_defs: HashMap::default(),
+           choices: IndexMap::default(),
+           enums: IndexMap::default(),
+           set_defs: IndexMap::default(),
            triggers: Vec::new(),
        };
        let mut bool_enum = Enum::new("Bool".into(), None, None);
@@ -281,8 +282,8 @@ impl CounterKind {
 pub struct Enum {
     name: RcStr,
     doc: Option<RcStr>,
-    values: HashMap<RcStr, Option<String>>,
-    aliases: HashMap<RcStr, (HashSet<RcStr>, Option<String>)>,
+    values: IndexMap<RcStr, Option<String>>,
+    aliases: IndexMap<RcStr, (HashSet<RcStr>, Option<String>)>,
     inverse: Option<Vec<(RcStr, RcStr)>>,
 }
 
@@ -294,8 +295,8 @@ impl Enum {
             name: name,
             doc: doc,
             inverse: inverse,
-            values: HashMap::default(),
-            aliases: HashMap::default(),
+            values: IndexMap::default(),
+            aliases: IndexMap::default(),
         }
     }
 
@@ -315,7 +316,7 @@ impl Enum {
     }
 
     /// Lists the aliases.
-    pub fn aliases(&self) -> &HashMap<RcStr, (HashSet<RcStr>, Option<String>)> {
+    pub fn aliases(&self) -> &IndexMap<RcStr, (HashSet<RcStr>, Option<String>)> {
         &self.aliases
     }
 
@@ -323,7 +324,7 @@ impl Enum {
     pub fn doc(&self) -> Option<&str> { self.doc.as_ref().map(|x| x as &str) }
 
     /// Returns the values the enum can take, and their associated comment.
-    pub fn values(&self) -> &HashMap<RcStr, Option<String>> { &self.values }
+    pub fn values(&self) -> &IndexMap<RcStr, Option<String>> { &self.values }
 
     /// Replaces aliases by the corresponding values.
     pub fn expand<IT: IntoIterator<Item=RcStr>>(&self, set: IT) -> HashSet<RcStr> {

--- a/telamon-gen/src/ir/set.rs
+++ b/telamon-gen/src/ir/set.rs
@@ -3,6 +3,7 @@ use std;
 use std::fmt;
 use std::borrow::Borrow;
 use utils::*;
+use indexmap::IndexMap;
 
 /// Generic trait for sets.
 pub trait SetRef<'a> {
@@ -182,7 +183,7 @@ pub struct SetDef {
     arg: Option<ir::Set>,
     superset: Option<Set>,
     reverse: ReverseSet,
-    keys: HashMap<SetDefKey, String>,
+    keys: IndexMap<SetDefKey, String>,
     depth: usize,
     def_order: usize,
     disjoints: Vec<String>,
@@ -194,7 +195,7 @@ impl SetDef {
                arg: Option<ir::Set>,
                superset: Option<Set>,
                reverse: Option<(Set, String)>,
-               keys: HashMap<SetDefKey, String>,
+               keys: IndexMap<SetDefKey, String>,
                disjoints: Vec<String>) -> std::rc::Rc<Self> {
         let name = RcStr::new(name);
         let reverse = if let Some((set, iter)) = reverse {
@@ -234,7 +235,7 @@ impl SetDef {
              arg: Option<ir::Set>,
              superset: Option<Set>,
              reverse: ReverseSet,
-             keys: HashMap<SetDefKey, String>,
+             keys: IndexMap<SetDefKey, String>,
              disjoints: Vec<String>) -> Self {
         let depth = superset.as_ref().map(|s| s.def.depth + 1).unwrap_or(0);
         let def_order = arg.as_ref().map(|s| s.def.def_order + 1).unwrap_or(0);
@@ -251,7 +252,7 @@ impl SetDef {
     pub fn superset(&self) -> Option<&ir::Set> { self.superset.as_ref() }
 
     /// The attributes of the set.
-    pub fn attributes(&self) -> &HashMap<SetDefKey, String> { &self.keys }
+    pub fn attributes(&self) -> &IndexMap<SetDefKey, String> { &self.keys }
 
     /// Suggest a prefix for variables in the set.
     pub fn prefix(&self) -> &str {

--- a/telamon-gen/src/lib.rs
+++ b/telamon-gen/src/lib.rs
@@ -3,7 +3,6 @@ extern crate handlebars;
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
 extern crate itertools;
-extern crate pathfinding;
 extern crate regex;
 extern crate rustfmt;
 extern crate serde;
@@ -12,6 +11,7 @@ extern crate serde_json;
 #[macro_use]
 extern crate telamon_utils as utils;
 extern crate libc;
+extern crate indexmap;
 
 extern crate lalrpop_util;
 
@@ -122,6 +122,37 @@ pub fn process<'a, T: io::Write>(
         write!(output, "{}", code).unwrap();
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::print::Variable;
+    use std::io::Cursor;
+    use std::path::Path;
+
+    /// Ensure that the output of telamon-gen is stable across calls.
+    #[test]
+    fn stable_output() {
+        let mut in_buf = Cursor::new(include_str!("../../src/search_space/choices.exh").as_bytes());
+        let ref_out = {
+            let mut ref_out = Vec::new();
+            super::process(&mut in_buf, &mut ref_out, false, &Path::new("choices.exh")).unwrap();
+            ref_out
+        };
+        // Ideally we would want to run this loop more than once, but
+        // generation is currently too slow to be worth it.
+        for _ in 0..1 {
+            Variable::reset_prefix();
+            in_buf.set_position(0);
+
+            let mut out_buf = Vec::new();
+            super::process(&mut in_buf, &mut out_buf, false, &Path::new("choices.exh")).unwrap();
+            assert_eq!(
+                ::std::str::from_utf8(&out_buf),
+                ::std::str::from_utf8(&ref_out)
+            );
+        }
+    }
 }
 
 // TODO(cleanup): avoid name conflicts in the printer

--- a/telamon-gen/src/print/mod.rs
+++ b/telamon-gen/src/print/mod.rs
@@ -377,7 +377,7 @@ where
 
     // At each iteration of this loop we maintain the invariant that
     // the priority queue contains exactly the nodes for which all
-    // predecessors are in sorted, but have not been sorted
+    // predecessors are already sorted, but have not been sorted
     // themselves. Using a priority queue ensures that we are always
     // processing nodes in the order they appear in the initial
     // `nodes` slice.
@@ -418,7 +418,7 @@ where
     }
 }
 
-/// Note that the code in the `stable_topological_sort_tests` omdule
+/// Note that the code in the `stable_topological_sort_tests` module
 /// should be in an Examples sections in the `stable_topological_sort`
 /// function, but we can't run rustdoc tests on private functions for
 /// some reason.

--- a/telamon-gen/src/print/mod.rs
+++ b/telamon-gen/src/print/mod.rs
@@ -3,9 +3,13 @@ use handlebars::{self, Handlebars, Helper, Renderable, RenderContext, RenderErro
 use ir;
 use itertools::Itertools;
 use serde_json::value::Value as JsonValue;
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
 use std::fmt::{self, Display, Formatter};
+use std::hash::Hash;
+use std::iter::FromIterator;
 //use std::io::prelude::*;
-use pathfinding::prelude::topological_sort;
+use indexmap::IndexMap;
 use utils::*;
 
 // TODO(cleanup): use handlebars instead of printer macros and static templates
@@ -201,6 +205,8 @@ mod store;
 mod value_set;
 
 use self::store::PartialIterator;
+#[cfg(test)]
+pub(crate) use self::ast::Variable;
 
 /// Generate the trigger code to add a representant to a quotient set.
 pub fn add_to_quotient(set: &ir::SetDef,
@@ -240,10 +246,265 @@ pub fn print(ir_desc: &ir::IrDesc) -> String {
     )
 }
 
+/// Find a topological order in a directed graph.
+///
+/// The topological order is guaranteed to be stable, i.e. the
+/// relative position of elements which are not (transitively) ordered
+/// is preserved.
+///
+/// # Return value
+///
+/// This function will either return `Ok` with a stable topological
+/// order or, if there are cycles in the ordering defined by
+/// `predecessors`, `Err` with a pair `(sorted, cycles)` where
+/// `cycles` contains all the nodes which are part of a cycle, and
+/// `sorted` contains a stable topological order of the remaining
+/// nodes.
+///
+/// # Arguments
+///
+/// * `nodes` - A slice that holds the nodes to sort. Must not contain
+///   duplicates.
+/// * `predecessors` - A function returning an iterable of
+///   predecessors or dependencies for each node. Will be called
+///   exactly once for each node in `nodes`. Each element of the
+///   returned iterator must be in `nodes.
+///
+/// # Panics
+///
+/// This function will panic if there are duplicates in `nodes` or if
+/// `predecessors` return a value which is not in `nodes`.
+///
+/// # Examples
+///
+/// See the `stable_topological_sort_tests` module.
+fn stable_topological_sort<'a, N, P, I>(
+    nodes: &[N],
+    predecessors: P,
+) -> Result<Vec<N>, (Vec<N>, Vec<N>)>
+where
+    N: Eq + Hash + Clone,
+    P: Fn(&N) -> I,
+    I: IntoIterator<Item = N>,
+{
+    /// Data about a node used by the topological sort algorithm.
+    #[derive(Eq)]
+    struct NodeData {
+        /// The index of the node in `nodes`
+        index: usize,
+        /// The number of predecessors. Nodes that have already been
+        /// sorted are no longer considered as predecessors.
+        num_predecessors: usize,
+        /// The indices in `nodes` of this node's successors.
+        successors: Vec<usize>,
+    }
+
+    /// `PartialEq` is implemented manually since it needs to be
+    /// compatible with `Ord` and `PartialOrd`. Note that technically
+    /// we will only ever create a single `NodeData` with a given
+    /// `index` value, so the default implementation would only be
+    /// wrong conceptually (although slower than the manual version).
+    impl PartialEq for NodeData {
+        fn eq(&self, other: &NodeData) -> bool {
+            self.index == other.index
+        }
+    }
+
+    /// Custom `Ord` implementation to only take the `index` into
+    /// account. Note that we want the `BinaryHeap` to act as a
+    /// min-heap below, so we reverse the ordering here.
+    impl Ord for NodeData {
+        fn cmp(&self, other: &NodeData) -> Ordering {
+            self.index.cmp(&other.index).reverse()
+        }
+    }
+
+    impl PartialOrd for NodeData {
+        fn partial_cmp(&self, other: &NodeData) -> Option<Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    impl NodeData {
+        fn new(index: usize) -> NodeData {
+            NodeData {
+                index,
+                num_predecessors: 0,
+                successors: Vec::new(),
+            }
+        }
+    }
+
+    // We need an index map to map back from the predecessors into their indices.
+    let mut node_data: Vec<_> = (0..nodes.len()).map(NodeData::new).map(Some).collect();
+    let index_map: HashMap<_, _> =
+        HashMap::from_iter(nodes.iter().enumerate().map(|(index, node)| (node, index)));
+    if index_map.len() != nodes.len() {
+        panic!("duplicate nodes found");
+    }
+
+    // Properly set the predecessors and successors for each node.
+    for (index, node) in nodes.iter().enumerate() {
+        let num_predecessors = predecessors(node)
+            .into_iter()
+            .map(|pred| {
+                let &pred_index =
+                    index_map.get(&pred).expect("predecessor is not in graph");
+                node_data[pred_index]
+                    .as_mut()
+                    .unwrap()
+                    .successors
+                    .push(index)
+            })
+            .count();
+
+        node_data[index].as_mut().unwrap().num_predecessors = num_predecessors
+    }
+
+    // Build the priority queue containing the nodes which have no
+    // predecessors. Note that we must loop again to create this
+    // instead of `take`ing directly from `node_data` when counting
+    // the predecessors because otherwise we would throw off the
+    // predecessor count for the succesors, and decrementing that
+    // count for the nodes we have already moved to the queue would
+    // violate the stability guarantee.
+    let mut queue = BinaryHeap::with_capacity(nodes.len());
+    for data in node_data.iter_mut() {
+        if data.as_mut().unwrap().num_predecessors == 0 {
+            queue.push(data.take().unwrap())
+        }
+    }
+
+    // At each iteration of this loop we maintain the invariant that
+    // the priority queue contains exactly the nodes for which all
+    // predecessors are in sorted, but have not been sorted
+    // themselves. Using a priority queue ensures that we are always
+    // processing nodes in the order they appear in the initial
+    // `nodes` slice.
+    //
+    // Whenever we move a node from the queue to the `sorted` array,
+    // we update all its successors (if any) by decrementing its
+    // number of predecessors. Whenever the number of predecessors
+    // reaches `0`, this node was the last predecessor not already
+    // sorted, and we add the successor to the priority queue.
+    let mut sorted = Vec::with_capacity(nodes.len());
+    while let Some(data) = queue.pop() {
+        sorted.push(nodes[data.index].clone());
+
+        for &successor_index in data.successors.iter() {
+            let mut successor_data = &mut node_data[successor_index];
+            successor_data.as_mut().unwrap().num_predecessors -= 1;
+            if successor_data.as_mut().unwrap().num_predecessors == 0 {
+                queue.push(successor_data.take().unwrap())
+            }
+        }
+    }
+
+    // If there is a cycle, we will never put it in the queue because
+    // there always will be another element of the cycle as a
+    // successor, and so `sorted` will be smaller than `nodes.We can
+    // get back all the elements which belong to a cycle by looking
+    // for the non-empty indices in `node_data`.
+    if sorted.len() != nodes.len() {
+        let mut cycles = Vec::with_capacity(nodes.len() - sorted.len());
+        for (index, data) in node_data.into_iter().enumerate() {
+            if data.is_some() {
+                cycles.push(nodes[index].clone())
+            }
+        }
+        Err((sorted, cycles))
+    } else {
+        Ok(sorted)
+    }
+}
+
+/// Note that the code in the `stable_topological_sort_tests` omdule
+/// should be in an Examples sections in the `stable_topological_sort`
+/// function, but we can't run rustdoc tests on private functions for
+/// some reason.
+///
+/// For the sake of concision and readability, the examples use
+/// letters to represent nodes and `:` to separate a node from its
+/// dependencies. For instance, `"d"` is a node called `"d"` without
+/// dependencies, `"e:d"` is a node called `"e"` with a single
+/// dependency on the node `"d"`, and `"f:e,q"` is a node called `"f"`
+/// with two dependencies on nodes `"e"` and `"q"`.
+#[cfg(test)]
+mod stable_topological_sort_tests {
+    use super::stable_topological_sort;
+
+    /// Sorting an array with no dependencies does not modify the
+    /// order.
+    #[test]
+    fn stable_no_deps() {
+        assert_eq!(
+            stable_topological_sort(&vec!["a", "b", "c", "d", "e"], |_| vec![]),
+            Ok(vec!["a", "b", "c", "d", "e"]))
+    }
+
+    /// Sorting an array which is already in topological order, even in
+    /// the presence of dependencies, does not modify the order either.
+    #[test]
+    fn stable_deps() {
+        assert_eq!(
+            stable_topological_sort(&vec!["a", "b", "c:b", "d"], |&node| {
+                match node {
+                    "c:b" => vec!["b"],
+                    _ => vec![],
+                }
+            }),
+            Ok(vec!["a", "b", "c:b", "d"]))
+    }
+
+    /// Elements which have a dependency are sorted immediately after
+    /// their last dependency.
+    #[test]
+    fn right_after_dep() {
+        assert_eq!(
+            stable_topological_sort(&vec!["a", "b:d", "c", "d", "e"], |&node| {
+                match node {
+                    "b:d" => vec!["d"],
+                    _ => vec![],
+                }
+            }),
+            Ok(vec!["a", "c", "d", "b:d", "e"]))
+    }
+
+    /// If multiple independent elements share a dependency, their
+    /// initial order is maintained.
+    #[test]
+    fn indep_after_dep() {
+        assert_eq!(
+            stable_topological_sort(&vec!["a", "b:d", "c:d", "d", "e"], |&node| {
+                match node {
+                    "b:d" => vec!["d"],
+                    "c:d" => vec!["d"],
+                    _ => vec![],
+                }
+            }),
+            Ok(vec!["a", "d", "b:d", "c:d", "e"]))
+    }
+
+    /// If multiple elements share a dependency, their own dependencies
+    /// are still satisfied.
+    #[test]
+    fn dep_after_dep() {
+        assert_eq!(
+            stable_topological_sort(&vec!["a", "b:d,c", "c:d", "d", "e"], |&node| {
+                match node {
+                    "b:d,c" => vec!["d", "c:d"],
+                    "c:d" => vec!["d"],
+                    _ => vec![],
+                }
+            }),
+            Ok(vec!["a", "d", "c:d", "b:d,c", "e"]))
+    }
+}
+
 /// Order the choices so that they are computed in the right order to avoid overflows.
 fn order_choices<'a>(ir_desc: &'a ir::IrDesc) -> impl Iterator<Item=&'a ir::Choice> +'a {
     let names = ir_desc.choices().map(|c| c.name()).collect_vec();
-    let sorted = topological_sort(&names, |choice| {
+    let sorted = stable_topological_sort(&names, |choice| {
         let def = ir_desc.get_choice(choice).choice_def();
         if let ir::ChoiceDef::Counter { ref value, .. } = *def {
             if let ir::CounterVal::Choice(ref counter) = *value {
@@ -252,7 +513,7 @@ fn order_choices<'a>(ir_desc: &'a ir::IrDesc) -> impl Iterator<Item=&'a ir::Choi
         }
         None
     });
-    unwrap!(sorted).into_iter().rev().map(move |c| ir_desc.get_choice(c))
+    unwrap!(sorted).into_iter().map(move |c| ir_desc.get_choice(c))
 }
 
 #[derive(Debug, Serialize)]
@@ -354,7 +615,7 @@ fn inverse(enum_: &ir::Enum, f: &mut Formatter) -> fmt::Result {
 fn value_def_order<'a>(enum_: &'a ir::Enum)
         -> impl Iterator<Item=(&'a RcStr, &'a Option<String>)> +'a {
     if let Some(mapping) = enum_.inverse_mapping() {
-        let mut values: HashMap<_, _> = enum_.values().iter().collect();
+        let mut values: IndexMap<_, _> = enum_.values().iter().collect();
         Box::new(mapping.iter().flat_map(|&(ref x, ref y)| vec![x, y])
             .map(|x| (x, values.remove(x).unwrap())).collect_vec().into_iter()
             .chain(values)) as Box<Iterator<Item=_>>


### PR DESCRIPTION
We want telamon-gen output to be deterministic on a given .exh file
because we want to be able to assume field and enum order when
serializing to compact binary formats. Currently telamon-gen is
deterministic (thanks to using the non-random HashMaps from
telamon-utils) up to the printer, where we use a topological sort from
the `pathfinding` crate to ensure counters are serialized after their
dependencies. Unfortunately, the topological sort in the `pathfinding`
crate is non-deterministic due to its use of regular Rust HashMaps.

This patch replaces the topological sort from the `pathfinding` crate
with our own topological sort implementation,
`stable_topological_sort`, which we guarantee is not only
non-deterministic but is also stable: the order between elements which
don't have (transitive) dependencies to each other is preserved.

In addition, it replaces the use of some HashMaps with IndexMaps from
the `indexmap` crate, which are hash tables ensuring that iteration
order is identical to insertion order until any value is removed. This
allows to help propagate the stability guarantee to the order in which
choices are defined in the `.exh` file, giving some control on the
generated code to the user.