### PR TITLE
Benchmark the variance of measures on the device

### DIFF
--- a/kernels/Cargo.toml
+++ b/kernels/Cargo.toml
@@ -14,6 +14,9 @@ num_cpus = "1.8.0"
 rayon = "1.0.1"
 rand = "0.4.2"
 
+[dev-dependencies]
+failure = "0.1.1"
+
 [dependencies.cuda-sys]
 optional = true
 version = "0.1.0"

--- a/kernels/Cargo.toml
+++ b/kernels/Cargo.toml
@@ -14,6 +14,9 @@ num_cpus = "1.8.0"
 rayon = "1.0.1"
 rand = "0.4.2"
 
+[dev-dependencies]
+futures = "0.1.23"
+
 [dependencies.cuda-sys]
 optional = true
 version = "0.1.0"

--- a/kernels/Cargo.toml
+++ b/kernels/Cargo.toml
@@ -14,9 +14,6 @@ num_cpus = "1.8.0"
 rayon = "1.0.1"
 rand = "0.4.2"
 
-[dev-dependencies]
-failure = "0.1.1"
-
 [dependencies.cuda-sys]
 optional = true
 version = "0.1.0"

--- a/kernels/Cargo.toml
+++ b/kernels/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 env_logger = "0.5.9"
 itertools = "0.7.8"
 libc = "0.2.40"
+log = "0.4.1"
 ndarray = "0.11.2"
 num = "0.1.42"
 num_cpus = "1.8.0"
@@ -44,5 +45,11 @@ required-features = ["cuda"]
 [[bench]]
 name = "cuda-bound"
 path = "benches/cuda_bound.rs"
+harness = false
+required-features = ["cuda"]
+
+[[bench]]
+name = "cuda-variance"
+path = "benches/cuda_variance.rs"
 harness = false
 required-features = ["cuda"]

--- a/kernels/benches/cuda_variance.rs
+++ b/kernels/benches/cuda_variance.rs
@@ -1,5 +1,6 @@
 //! Benchmarks the variance of measures on the GPU.
 extern crate env_logger;
+extern crate futures;
 extern crate itertools;
 #[macro_use]
 extern crate log;
@@ -8,8 +9,10 @@ extern crate telamon_kernels;
 #[macro_use]
 extern crate telamon_utils as utils;
 
+use futures::Future;
+use futures::sync::oneshot;
 use itertools::Itertools;
-use telamon::{codegen, device, explorer, helper};
+use telamon::{device, explorer, helper};
 use telamon::device::{cuda, Context};
 use telamon::explorer::local_selection;
 use telamon_kernels::{linalg, Kernel};
@@ -22,9 +25,9 @@ const NUM_TESTS: usize = 20;
 /// The number of time each candidate should be evaluated, in cpu-bound mode.
 const NUM_SLOW_SAMPLES: usize = 20;
 /// The number of time each candidate should be evaluated, in gpu-bound mode.
-const NUM_FAST_SAMPLES: usize = 50;
-/// Maximal legal difference between evaluation times.
-const MAX_DIFF: f64 = 0.01;
+const NUM_FAST_SAMPLES: usize = 20;
+/// Maximal legal relative difference between evaluation times.
+const MAX_RELATIVE_DIFF: f64 = 0.01;
 /// The time to wait between two slow evaluations.
 const SLEEP_TIME: Duration = Duration::from_millis(500);
 /// The maximal bound for kernels to consider.
@@ -36,7 +39,7 @@ fn main() {
     let small_malmul = linalg::MatMulP::new(128, 128, 128);
     let big_malmul = linalg::MatMulP::new(256, 256, 256);
     accuracy::<linalg::MatMul<f32>>(&small_malmul, "matmul_128", &executor);
-    accuracy::<linalg::MatMul<f32>>(&big_malmul, "matmul_1024", &executor);
+    accuracy::<linalg::MatMul<f32>>(&big_malmul, "matmul_256", &executor);
 }
 
 fn accuracy<'a, K>(params: &K::Parameters,
@@ -58,37 +61,22 @@ fn accuracy<'a, K>(params: &K::Parameters,
          local_selection::descend(order, &context, candidate, CUT)
     }).take(NUM_TESTS).collect_vec();
     info!("Evaluating candidates, simulating a GPU-bound exploration");
-    let fast_evals = candidates.iter().map(|_| Mutex::new(vec![])).collect_vec();
-    context.async_eval(1, device::EvalMode::TestEval, &|evaluator| {
-        for (candidate, results) in candidates.iter().zip_eq(&fast_evals) {
-            for _ in 0..NUM_FAST_SAMPLES {
-                evaluator.add_kernel(candidate.clone(), (move |_, runtime| {
-                    unwrap!(results.lock()).push(runtime);
-                }).into());
-            }
-        }
-    });
+    let fast_evals = run_evaluations(&candidates, &context, NUM_FAST_SAMPLES, None);
     info!("Evaluating candidates, simulating a CPU-bound exploration");
-    let slow_evals = candidates.iter().map(|candidate| {
-        let code = codegen::Function::build(&candidate.space);
-        (0..NUM_SLOW_SAMPLES).map(|_| {
-            std::thread::sleep(SLEEP_TIME);
-            unwrap!(context.evaluate(&code, device::EvalMode::TestEval))
-        }).collect_vec()
-    }).collect_vec();
+    let sleep = Some(SLEEP_TIME);
+    let slow_evals = run_evaluations(&candidates, &context, NUM_SLOW_SAMPLES, sleep);
     info!("Evaluation finished, analysing results");
     let results = candidates.iter().zip_eq(slow_evals.into_iter().zip_eq(fast_evals));
     let mut all_diffs = 0.;
     let mut all_cpu_gpu_diffs = 0.;
     for (_, (cpu_bound_times, gpu_bound_times)) in results {
-        let gpu_bound_times = unwrap!(gpu_bound_times.into_inner());
         let (cpu_med, cpu_diff) = analyse_runtimes(cpu_bound_times, name, "cpu");
         let (gpu_med, gpu_diff) = analyse_runtimes(gpu_bound_times, name, "gpu");
         all_diffs += cpu_diff;
         all_diffs += gpu_diff;
         let diff_factor = 2.*(cpu_med - gpu_med).abs()/(cpu_med + gpu_med);
         all_cpu_gpu_diffs += diff_factor;
-        if diff_factor > MAX_DIFF {
+        if diff_factor > MAX_RELATIVE_DIFF {
             println!("annormal difference between cpu-bound {:.2e} and gpu-bound {:.2e} \
                       evaluations ({:.2e}x) in {}", cpu_med, gpu_med, diff_factor, name)
         }
@@ -106,11 +94,39 @@ fn analyse_runtimes(mut runtimes: Vec<f64>, name: &str, bound: &str) -> (f64, f6
     runtimes.sort_by(|&x, &y| cmp_f64(x, y));
     let median = runtimes[runtimes.len()/2];
     let diff = (runtimes[runtimes.len()-1] - runtimes[0])/median;
-    if diff > MAX_DIFF {
+    if diff > MAX_RELATIVE_DIFF {
         let min = 1. - runtimes[0]/median;
         let max = runtimes[runtimes.len()-1]/median - 1.;
         println!("noisy {}-bound evaluations {:.2e}ns (-{:.2e}x, +{:.2e}x) in {}",
                   bound, median, min, max, name);
     }
     (median, diff)
+}
+
+/// Runs a series of evaluation, sleeping the given duration betwen each evaluation.
+fn run_evaluations(candidates: &[explorer::Candidate],
+                   context: &Context,
+                   num_samples: usize,
+                   sleep: Option<Duration>) -> Vec<Vec<f64>> {
+    let runtimes = candidates.iter().map(|_| Mutex::new(vec![])).collect_vec();
+    context.async_eval(1, device::EvalMode::TestEval, &|evaluator| {
+        for (candidate, results) in candidates.iter().zip_eq(&runtimes) {
+            for _ in 0..num_samples {
+                if let Some(duration) = sleep {
+                    let (sender, waiter) = oneshot::channel();
+                    evaluator.add_kernel(candidate.clone(), (move |_, runtime| {
+                        unwrap!(sender.send(()));
+                        unwrap!(results.lock()).push(runtime);
+                    }).into());
+                    unwrap!(waiter.wait());
+                    std::thread::sleep(duration);
+                } else {
+                    evaluator.add_kernel(candidate.clone(), (move |_, runtime| {
+                        unwrap!(results.lock()).push(runtime);
+                    }).into());
+                }
+            }
+        }
+    });
+    runtimes.into_iter().map(|lock| unwrap!(lock.into_inner())).collect()
 }

--- a/kernels/benches/cuda_variance.rs
+++ b/kernels/benches/cuda_variance.rs
@@ -1,5 +1,7 @@
 //! Benchmarks the variance of measures on the GPU.
 extern crate env_logger;
+#[macro_use]
+extern crate failure;
 extern crate itertools;
 #[macro_use]
 extern crate log;
@@ -18,11 +20,13 @@ use std::time::Duration;
 use utils::*;
 
 /// The number of candidates to try.
-const NUM_TESTS: usize = 10;
+const NUM_TESTS: usize = 20;
 /// The number of time each candidate should be evaluated, in cpu-bound mode.
-const NUM_SLOW_SAMPLES: usize = 10;
+const NUM_SLOW_SAMPLES: usize = 20;
 /// The number of time each candidate should be evaluated, in gpu-bound mode.
 const NUM_FAST_SAMPLES: usize = 50;
+/// Maximal legal difference between evaluation times.
+const MAX_DIFF: f64 = 0.01;
 /// The time to wait between two slow evaluations.
 const SLEEP_TIME: Duration = Duration::from_millis(500);
 /// The maximal bound for kernels to consider.
@@ -32,7 +36,7 @@ fn main() {
     env_logger::init();
     let executor = cuda::Executor::init();
     let small_malmul = linalg::MatMulP::new(128, 128, 128);
-    let big_malmul = linalg::MatMulP::new(1024, 1024, 1024);
+    let big_malmul = linalg::MatMulP::new(256, 256, 256);
     accuracy::<linalg::MatMul<f32>>(&small_malmul, "matmul_128", &executor);
     accuracy::<linalg::MatMul<f32>>(&big_malmul, "matmul_1024", &executor);
 }
@@ -57,7 +61,7 @@ fn accuracy<'a, K>(params: &K::Parameters,
     }).take(NUM_TESTS).collect_vec();
     info!("Evaluating candidates, simulating a GPU-bound exploration");
     let fast_evals = candidates.iter().map(|_| Mutex::new(vec![])).collect_vec();
-    context.async_eval(1, device::EvalMode::FindBest, &|evaluator| {
+    context.async_eval(1, device::EvalMode::TestEval, &|evaluator| {
         for (candidate, results) in candidates.iter().zip_eq(&fast_evals) {
             for _ in 0..NUM_FAST_SAMPLES {
                 evaluator.add_kernel(candidate.clone(), (move |_, runtime| {
@@ -71,22 +75,46 @@ fn accuracy<'a, K>(params: &K::Parameters,
         let code = codegen::Function::build(&candidate.space);
         (0..NUM_SLOW_SAMPLES).map(|_| {
             std::thread::sleep(SLEEP_TIME);
-            unwrap!(context.evaluate(&code, device::EvalMode::FindBest))
+            unwrap!(context.evaluate(&code, device::EvalMode::TestEval))
         }).collect_vec()
     }).collect_vec();
     info!("Evaluation finished, analysing results");
     let results = candidates.iter().zip_eq(slow_evals.into_iter().zip_eq(fast_evals));
     for (_, (cpu_bound_times, gpu_bound_times)) in results {
-        println!("-------");
-        analyse_runtimes(cpu_bound_times);
-        analyse_runtimes(unwrap!(gpu_bound_times.into_inner()));
+        let cpu = analyse_runtimes(cpu_bound_times).unwrap_or_else(|err| {
+            println!("{} in cpu-bound {}", err, name);
+            err.median
+        });
+        let gpu_bound_times = unwrap!(gpu_bound_times.into_inner());
+        let gpu = analyse_runtimes(gpu_bound_times).unwrap_or_else(|err| {
+            println!("{} in cpu-bound {}", err, name);
+            err.median
+        });
+        let diff_factor = 2.*(cpu-gpu).abs()/(cpu+gpu);
+        if diff_factor > MAX_DIFF {
+            println!("annormal difference between cpu-bound {:.2e} and gpu-bound {:.2e} \
+                      evaluations ({:.2e} factor) in {}", cpu, gpu, diff_factor, name)
+        }
     }
 }
 
-/// Analyses the regularity of execution times.
-fn analyse_runtimes(mut runtimes: Vec<f64>) {
+/// Analyses the regularity of execution times and returns the median. Fails if the
+/// relative difference between the fastest and the slowest evaluation is too big.
+fn analyse_runtimes(mut runtimes: Vec<f64>) -> Result<f64, NoisyError> {
     runtimes.sort_by(|&x, &y| cmp_f64(x, y));
-    let len = runtimes.len();
-    println!("[{}, {}, {}]", runtimes[0], runtimes[len/2], runtimes[len-1]);
-
+    let median = runtimes[runtimes.len()/2];
+    let diff = (runtimes[runtimes.len()-1] - runtimes[0])/median;
+    if diff > MAX_DIFF {
+        return Err(NoisyError {
+            median,
+            min: 1. - runtimes[0]/median,
+            max: runtimes[runtimes.len()-1]/median - 1.,
+        });
+    }
+    Ok(median)
 }
+
+/// Error raised when the fastest and slowest evaluation are too far appart.
+#[derive(Debug, Fail)]
+#[fail(display="noisy evaluations ({:.2e}ns -{:.2e}, +{:.2e}%)", median, min, max)]
+struct NoisyError { median: f64, min: f64, max: f64 }

--- a/kernels/benches/cuda_variance.rs
+++ b/kernels/benches/cuda_variance.rs
@@ -1,0 +1,92 @@
+//! Benchmarks the variance of measures on the GPU.
+extern crate env_logger;
+extern crate itertools;
+#[macro_use]
+extern crate log;
+extern crate telamon;
+extern crate telamon_kernels;
+#[macro_use]
+extern crate telamon_utils as utils;
+
+use itertools::Itertools;
+use telamon::{codegen, device, explorer, helper};
+use telamon::device::{cuda, Context};
+use telamon::explorer::local_selection;
+use telamon_kernels::{linalg, Kernel};
+use std::sync::Mutex;
+use std::time::Duration;
+use utils::*;
+
+/// The number of candidates to try.
+const NUM_TESTS: usize = 10;
+/// The number of time each candidate should be evaluated, in cpu-bound mode.
+const NUM_SLOW_SAMPLES: usize = 10;
+/// The number of time each candidate should be evaluated, in gpu-bound mode.
+const NUM_FAST_SAMPLES: usize = 50;
+/// The time to wait between two slow evaluations.
+const SLEEP_TIME: Duration = Duration::from_millis(500);
+/// The maximal bound for kernels to consider.
+const CUT: f64 = 1e8;
+
+fn main() {
+    env_logger::init();
+    let executor = cuda::Executor::init();
+    let small_malmul = linalg::MatMulP::new(128, 128, 128);
+    let big_malmul = linalg::MatMulP::new(1024, 1024, 1024);
+    accuracy::<linalg::MatMul<f32>>(&small_malmul, "matmul_128", &executor);
+    accuracy::<linalg::MatMul<f32>>(&big_malmul, "matmul_1024", &executor);
+}
+
+fn accuracy<'a, K>(params: &K::Parameters,
+                   name: &str,
+                   executor: &'a cuda::Executor) where K: Kernel<'a> {
+    let mut context = cuda::Context::new(executor);
+    info!("Generating {} candidates", NUM_TESTS);
+    let (kernel, signature) = {
+        let mut builder =helper:: SignatureBuilder::new(name, &mut context);
+        let kernel = K::build_signature(params.clone(), &mut builder);
+        (kernel, builder.get())
+    };
+    let candidates = kernel.build_body(&signature, &context);
+    let candidates = std::iter::repeat(()).flat_map(|()| {
+         let order = explorer::config::NewNodeOrder::WeightedRandom;
+         let bounds = candidates.iter().map(|c| c.bound.value()).enumerate();
+         let candidate_idx = local_selection::pick_index(order, bounds, CUT);
+         let candidate = candidates[unwrap!(candidate_idx)].clone();
+         local_selection::descend(order, &context, candidate, CUT)
+    }).take(NUM_TESTS).collect_vec();
+    info!("Evaluating candidates, simulating a GPU-bound exploration");
+    let fast_evals = candidates.iter().map(|_| Mutex::new(vec![])).collect_vec();
+    context.async_eval(1, device::EvalMode::FindBest, &|evaluator| {
+        for (candidate, results) in candidates.iter().zip_eq(&fast_evals) {
+            for _ in 0..NUM_FAST_SAMPLES {
+                evaluator.add_kernel(candidate.clone(), (move |_, runtime| {
+                    unwrap!(results.lock()).push(runtime);
+                }).into());
+            }
+        }
+    });
+    info!("Evaluating candidates, simulating a CPU-bound exploration");
+    let slow_evals = candidates.iter().map(|candidate| {
+        let code = codegen::Function::build(&candidate.space);
+        (0..NUM_SLOW_SAMPLES).map(|_| {
+            std::thread::sleep(SLEEP_TIME);
+            unwrap!(context.evaluate(&code, device::EvalMode::FindBest))
+        }).collect_vec()
+    }).collect_vec();
+    info!("Evaluation finished, analysing results");
+    let results = candidates.iter().zip_eq(slow_evals.into_iter().zip_eq(fast_evals));
+    for (_, (cpu_bound_times, gpu_bound_times)) in results {
+        println!("-------");
+        analyse_runtimes(cpu_bound_times);
+        analyse_runtimes(unwrap!(gpu_bound_times.into_inner()));
+    }
+}
+
+/// Analyses the regularity of execution times.
+fn analyse_runtimes(mut runtimes: Vec<f64>) {
+    runtimes.sort_by(|&x, &y| cmp_f64(x, y));
+    let len = runtimes.len();
+    println!("[{}, {}, {}]", runtimes[0], runtimes[len/2], runtimes[len-1]);
+
+}

--- a/src/device/context.rs
+++ b/src/device/context.rs
@@ -62,6 +62,18 @@ pub trait AsyncEvaluator<'a, 'b> {
 pub enum EvalMode {
     /// Find the best candidate, skip bad candidates and allow optimizations.
     FindBest,
+    /// Test the evaluation function, same as `FindBest` but do not skip candidates.
+    TestEval,
     /// Test the performance model, do not skip candidates and do not optimize.
     TestBound,
+}
+
+impl EvalMode {
+    /// Indicates if candidates with a bound above the cut can be skipped.
+    pub fn skip_bad_candidates(&self) -> bool {
+        match self {
+            EvalMode::FindBest => true,
+            EvalMode::TestBound | EvalMode::TestEval => false,
+        }
+    }
 }

--- a/src/device/cuda/context.rs
+++ b/src/device/cuda/context.rs
@@ -57,7 +57,7 @@ impl<'a> Context<'a> {
     fn opt_level(mode: EvalMode) -> usize {
         match mode {
             EvalMode::TestBound => 1,
-            EvalMode::FindBest => JIT_OPT_LEVEL,
+            EvalMode::FindBest | EvalMode::TestEval => JIT_OPT_LEVEL,
         }
     }
 }
@@ -123,11 +123,11 @@ impl<'a> device::Context for Context<'a> {
                 let mut best_eval = std::f64::INFINITY;
                 while let Ok((candidate, thunk, callback)) = recv.recv() {
                     let bound = candidate.bound.value();
-                    let eval = if best_eval > bound || mode == EvalMode::TestBound {
-                        thunk.execute().map(|t| t as f64 / clock_rate)
-                    } else {
-                        warn!("candidate not evaluated because of bounds");
+                    let eval = if best_eval <= bound && mode.skip_bad_candidates() {
+                        info!("candidate skipped because of bounds");
                         Ok(std::f64::INFINITY)
+                    } else {
+                        thunk.execute().map(|t| t as f64 / clock_rate)
                     };
                     let eval = eval.unwrap_or_else(|()| {
                         panic!("evaluation failed for actions {:?}, with kernel {:?}",


### PR DESCRIPTION
This PR exposes a problem with the measures on the device. It compares the execution time obtained after multiple evaluation on the GPU. It simulates both the case where the GPU is the limiting factor and the case where the CPU is the limiting factor.

It shows that when the CPU is limiting, measures are noisy and innacurate, sometime by a factor of more than 2.