### PR TITLE
Telamon C API for Cuda

### DIFF
--- a/telamon-capi/src/cuda.rs
+++ b/telamon-capi/src/cuda.rs
@@ -1,0 +1,39 @@
+//! C API wrappers for manipulating Telamon CUDA context through FFI.
+use env_logger;
+use std;
+use telamon::device::cuda;
+
+/// Opaque type that bundles a `telamon::device::cuda::Context` and its executor.
+pub struct CudaContext {
+    executor: cuda::Executor,
+    context: std::mem::ManuallyDrop<cuda::Context<'static>>,
+}
+
+/// Returns a pointer to a CUDA context. The CUDA context is not the same than
+/// `telamon::device::cuda::Context` and should only be used with the C API functions.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_cuda_create_context() -> *mut CudaContext {
+    let _ = env_logger::try_init();
+    let mut c_context = Box::new(CudaContext {
+        executor: cuda::Executor::init(),
+        context: std::mem::uninitialized(),
+    });
+    let context = std::mem::transmute(cuda::Context::new(&c_context.executor));
+    std::ptr::write(&mut c_context.context, std::mem::ManuallyDrop::new(context));
+    Box::into_raw(c_context)
+}
+
+/// Destroys a CUDA context.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_cuda_destroy_context(ctx: *mut CudaContext) {
+    let mut ctx = Box::from_raw(ctx);
+    std::mem::ManuallyDrop::drop(&mut ctx.context);
+}
+
+#[test]
+fn create_destroy_context() {
+    unsafe {
+        let ctx = telamon_cuda_create_context();
+        telamon_cuda_destroy_context(ctx);
+    }
+}

--- a/telamon-capi/src/cuda.rs
+++ b/telamon-capi/src/cuda.rs
@@ -1,39 +1,104 @@
 //! C API wrappers for manipulating Telamon CUDA context through FFI.
+use Context;
 use env_logger;
+use libc;
 use std;
-use telamon::device::cuda;
+use telamon::device::{cuda, ArgMap};
+use telamon::ir;
 
-/// Opaque type that bundles a `telamon::device::cuda::Context` and its executor.
-pub struct CudaContext {
+/// Opaque type that contains the mapping of kernel parameters to actual values.
+pub struct CudaEnvironment {
     executor: cuda::Executor,
     context: std::mem::ManuallyDrop<cuda::Context<'static>>,
+    context_ref: Context,
 }
 
-/// Returns a pointer to a CUDA context. The CUDA context is not the same than
-/// `telamon::device::cuda::Context` and should only be used with the C API functions.
+/// Returns a pointer to a CUDA environement. The caller is responsible for deallocating
+/// the pointer by calling `telamon_cuda_destroy_environment`.
 #[no_mangle]
-pub unsafe extern "C" fn telamon_cuda_create_context() -> *mut CudaContext {
+pub unsafe extern "C" fn telamon_cuda_create_environment() -> *mut CudaEnvironment {
     let _ = env_logger::try_init();
-    let mut c_context = Box::new(CudaContext {
+    let mut env = Box::new(CudaEnvironment {
         executor: cuda::Executor::init(),
         context: std::mem::uninitialized(),
+        context_ref: std::mem::uninitialized(),
     });
-    let context = std::mem::transmute(cuda::Context::new(&c_context.executor));
-    std::ptr::write(&mut c_context.context, std::mem::ManuallyDrop::new(context));
-    Box::into_raw(c_context)
+    let context = std::mem::transmute(cuda::Context::new(&env.executor));
+    std::ptr::write(&mut env.context, std::mem::ManuallyDrop::new(context));
+    std::ptr::write(&mut env.context_ref, Context(&*env.context));
+    Box::into_raw(env)
 }
 
 /// Destroys a CUDA context.
 #[no_mangle]
-pub unsafe extern "C" fn telamon_cuda_destroy_context(ctx: *mut CudaContext) {
-    let mut ctx = Box::from_raw(ctx);
-    std::mem::ManuallyDrop::drop(&mut ctx.context);
+pub unsafe extern "C" fn telamon_cuda_destroy_context(env: *mut CudaEnvironment) {
+    let mut env = Box::from_raw(env);
+    std::mem::ManuallyDrop::drop(&mut env.context);
 }
 
-#[test]
-fn create_destroy_context() {
-    unsafe {
-        let ctx = telamon_cuda_create_context();
-        telamon_cuda_destroy_context(ctx);
-    }
+/// Returns a pointer to a view of environment generic to all target devices.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_cuda_get_context(env: *const CudaEnvironment)
+    -> *const Context
+{
+        &(*env).context_ref
+}
+
+/// Allocates and binds an array to the given parameter. `size` is given in bytes.
+///
+/// The allocated array is managed by the context and doesn't need to be explicitely
+/// destroyed.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_cuda_bind_array(env: *mut CudaEnvironment,
+                                                 param: *const ir::Parameter,
+                                                 size: libc::size_t) {
+    (*env).context.bind_array::<i8>(&*param, size);
+}
+
+/// Binds an `int8_t` to a parameter.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_cuda_bind_int8(env: *mut CudaEnvironment,
+                                                param: *const ir::Parameter,
+                                                value: libc::int8_t) {
+    (*env).context.bind_scalar::<i8>(&*param, value);
+}
+
+/// Binds an `int16_t` to a parameter.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_cuda_bind_int16(env: *mut CudaEnvironment,
+                                                param: *const ir::Parameter,
+                                                value: libc::int16_t) {
+    (*env).context.bind_scalar::<i16>(&*param, value);
+}
+
+/// Binds an `int32_t` to a parameter.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_cuda_bind_int32(env: *mut CudaEnvironment,
+                                                param: *const ir::Parameter,
+                                                value: libc::int32_t) {
+    (*env).context.bind_scalar::<i32>(&*param, value);
+}
+
+/// Binds an `int64_t` to a parameter.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_cuda_bind_int64(env: *mut CudaEnvironment,
+                                                param: *const ir::Parameter,
+                                                value: libc::int64_t) {
+    (*env).context.bind_scalar::<i64>(&*param, value);
+}
+
+/// Binds a `float` to a parameter.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_cuda_bind_float(env: *mut CudaEnvironment,
+                                                param: *const ir::Parameter,
+                                                value: libc::c_float) {
+    (*env).context.bind_scalar::<f32>(&*param, value);
+}
+
+/// Binds a `double` to a parameter.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_cuda_bind_double(env: *mut CudaEnvironment,
+                                                param: *const ir::Parameter,
+                                                value: libc::c_double) {
+    (*env).context.bind_scalar::<f64>(&*param, value);
 }

--- a/telamon-capi/src/lib.rs
+++ b/telamon-capi/src/lib.rs
@@ -9,10 +9,11 @@ extern crate libc;
 extern crate telamon;
 extern crate telamon_kernels;
 
+#[cfg(feature = "cuda")]
+pub mod cuda;
+
 use libc::{c_char, c_int, c_uint, size_t, uint32_t};
 use telamon::device;
-#[cfg(feature = "cuda")]
-use telamon::device::cuda;
 use telamon::device::x86;
 use telamon::explorer::config::Config;
 pub use telamon_kernels::{linalg, Kernel};
@@ -128,8 +129,9 @@ pub unsafe extern "C" fn kernel_optimize(
         Device::Cuda => {
             #[cfg(feature = "cuda")]
             {
-                let executor = cuda::Executor::init();
-                (*params).optimize_kernel(&config, &mut cuda::Context::new(&executor));
+                let executor = device::cuda::Executor::init();
+                let mut context = device::cuda::Context::new(&executor);
+                (*params).optimize_kernel(&config, &mut context);
             }
             #[cfg(not(feature = "cuda"))]
             return false;

--- a/telamon-capi/src/lib.rs
+++ b/telamon-capi/src/lib.rs
@@ -18,6 +18,9 @@ use telamon::device::x86;
 use telamon::explorer::config::Config;
 pub use telamon_kernels::{linalg, Kernel};
 
+/// Generic type that stores the exection environment of kernels on any device.
+pub struct Context(*const device::Context);
+
 /// Initializes the logger.
 #[no_mangle]
 pub extern "C" fn env_logger_try_init() {


### PR DESCRIPTION
This PR extends telamon-capi to create and manipulate Cuda devices and contexts. It also creates two wrapped types `Context` and `Device` to hold pointers to trait objects of the same types in Rust.

As a side effect, the former `Device` enum has been renamed into `DeviceId`. I guess we must update the python API to reflect this change, but I have no idea where.