### PR TITLE
Pre-allocate IDs for lowering

### DIFF
--- a/src/device/argument.rs
+++ b/src/device/argument.rs
@@ -19,7 +19,7 @@ pub unsafe trait ScalarArgument: Sync + Send + Copy + PartialEq + Display + 'sta
     /// Returns a raw pointer to the object.
     fn raw_ptr(&self) -> *const libc::c_void;
     /// Returns an operand holding the argument value as a constant.
-    fn as_operand(&self) -> ir::Operand<'static>;
+    fn as_operand<L>(&self) -> ir::Operand<'static, L>;
     /// Generates a random instance of the argument type.
     fn gen_random<R: Rng>(&mut R) -> Self;
 }
@@ -31,7 +31,7 @@ unsafe impl ScalarArgument for f32 {
         self as *const f32 as *const libc::c_void
     }
 
-    fn as_operand(&self) -> ir::Operand<'static> {
+    fn as_operand<L>(&self) -> ir::Operand<'static, L> {
         ir::Operand::new_float(unwrap!(Ratio::from_float(*self)), 32)
     }
 
@@ -45,7 +45,7 @@ unsafe impl ScalarArgument for f64 {
         self as *const f64 as *const libc::c_void
     }
 
-    fn as_operand(&self) -> ir::Operand<'static> {
+    fn as_operand<L>(&self) -> ir::Operand<'static, L> {
         ir::Operand::new_float(unwrap!(Ratio::from_float(*self)), 64)
     }
 
@@ -61,7 +61,7 @@ unsafe impl ScalarArgument for i8 {
         self as *const i8 as *const libc::c_void
     }
 
-    fn as_operand(&self) -> ir::Operand<'static> {
+    fn as_operand<L>(&self) -> ir::Operand<'static, L> {
         ir::Operand::new_int(unwrap!(BigInt::from_i8(*self)), 8)
     }
 
@@ -77,7 +77,7 @@ unsafe impl ScalarArgument for i16 {
         self as *const i16 as *const libc::c_void
     }
 
-    fn as_operand(&self) -> ir::Operand<'static> {
+    fn as_operand<L>(&self) -> ir::Operand<'static, L> {
         ir::Operand::new_int(unwrap!(BigInt::from_i16(*self)), 16)
     }
 
@@ -93,7 +93,7 @@ unsafe impl ScalarArgument for i32 {
         self as *const i32 as *const libc::c_void
     }
 
-    fn as_operand(&self) -> ir::Operand<'static> {
+    fn as_operand<L>(&self) -> ir::Operand<'static, L> {
         ir::Operand::new_int(unwrap!(BigInt::from_i32(*self)), 32)
     }
 
@@ -109,7 +109,7 @@ unsafe impl ScalarArgument for i64 {
         self as *const i64 as *const libc::c_void
     }
 
-    fn as_operand(&self) -> ir::Operand<'static> {
+    fn as_operand<L>(&self) -> ir::Operand<'static, L> {
         ir::Operand::new_int(unwrap!(BigInt::from_i64(*self)), 64)
     }
 

--- a/src/helper/builder.rs
+++ b/src/helper/builder.rs
@@ -10,7 +10,7 @@ use utils::*;
 
 /// Helper to build a `Function`.
 pub struct Builder<'a> {
-    function: Function<'a>,
+    function: Function<'a, ()>,
     open_dims: HashMap<ir::DimId, ir::DimId>,
     actions: Vec<Action>,
 }
@@ -38,7 +38,7 @@ impl<'a> Builder<'a> {
     }
 
     /// Returns an operand from an `AutoOperand`.
-    fn get_op<'b: 'a>(&self, op: &AutoOperand<'b>) -> Operand<'a> {
+    fn get_op<'b: 'a>(&self, op: &AutoOperand<'b>) -> Operand<'a, ()> {
         op.get(&self.function, &self.open_dims)
     }
 
@@ -177,7 +177,7 @@ impl<'a> Builder<'a> {
     }
 
     /// Inserts an instruction in the function.
-    fn inst(&mut self, op: Operator<'a>) -> InstId {
+    fn inst(&mut self, op: Operator<'a, ()>) -> InstId {
         let open_dims = self.open_dims.iter().map(|(&x, _)| x).collect();
         unwrap!(self.function.add_inst(op, open_dims))
     }
@@ -327,7 +327,7 @@ impl<'a> Builder<'a> {
     /// Creates a dim-map operand.
     pub fn dim_map(&self, base: ir::InstId,
                    dim_map: &[(&MetaDimension, &MetaDimension)],
-                   scope: ir::DimMapScope) -> ir::Operand<'a> {
+                   scope: ir::DimMapScope<()>) -> ir::Operand<'a, ()> {
         let dim_map = dim_map.iter().flat_map(|&(lhs, rhs)| lhs.ids().zip_eq(rhs.ids()));
         let inst = self.function.inst(base);
         ir::Operand::new_inst(inst, ir::DimMap::new(dim_map), scope)

--- a/src/helper/operand.rs
+++ b/src/helper/operand.rs
@@ -5,10 +5,10 @@ use ir::Operand::*;
 use utils::*;
 
 /// Represents values that can be turned into an `Operand`.
-pub trait AutoOperand<'a> {
+pub trait AutoOperand<'a, L = ()> {
     /// Returns the corresponding `Operand`.
-    fn get<'b>(&self, fun: &Function<'b>, active_dims: &HashMap<ir::DimId, ir::DimId>)
-        -> Operand<'b> where 'a: 'b;
+    fn get<'b>(&self, fun: &Function<'b, L>, active_dims: &HashMap<ir::DimId, ir::DimId>)
+        -> Operand<'b, L> where 'a: 'b;
 }
 
 /// Helper to build `Reduce` operands.
@@ -17,9 +17,9 @@ pub struct Reduce(pub InstId);
 /// Helper to build dim maps that can be lowered to temporary memory.
 pub struct TmpArray(pub InstId);
 
-impl <'a> AutoOperand<'a> for Reduce {
-    fn get<'b>(&self, fun: &Function<'b>, active_dims: &HashMap<ir::DimId, ir::DimId>)
-            -> Operand<'b> where 'a : 'b {
+impl<'a, L> AutoOperand<'a, L> for Reduce {
+    fn get<'b>(&self, fun: &Function<'b, L>, active_dims: &HashMap<ir::DimId, ir::DimId>)
+            -> Operand<'b, L> where 'a : 'b {
         let inst = fun.inst(self.0);
         let mut mapped_dims = Vec::new();
         let mut reduce_dims = Vec::new();
@@ -36,30 +36,30 @@ impl <'a> AutoOperand<'a> for Reduce {
     }
 }
 
-impl<'a> AutoOperand<'a> for Operand<'a> {
-    fn get<'b>(&self, _: &Function<'b>, _: &HashMap<ir::DimId, ir::DimId>)
-            -> Operand<'b> where 'a :'b {
+impl<'a> AutoOperand<'a, ()> for Operand<'a, ()> {
+    fn get<'b>(&self, _: &Function<'b, ()>, _: &HashMap<ir::DimId, ir::DimId>)
+            -> Operand<'b, ()> where 'a :'b {
         self.clone()
     }
 }
 
-impl<'a, T> AutoOperand<'a> for T where T: ScalarArgument {
-    fn get<'b>(&self, _: &Function<'b>, _: &HashMap<ir::DimId, ir::DimId>)
-            -> Operand<'b> where 'a: 'b {
+impl<'a, T, L> AutoOperand<'a, L> for T where T: ScalarArgument {
+    fn get<'b>(&self, _: &Function<'b, L>, _: &HashMap<ir::DimId, ir::DimId>)
+            -> Operand<'b, L> where 'a: 'b {
         self.as_operand()
     }
 }
 
-impl<'a, 'c> AutoOperand<'a> for &'c str {
-    fn get<'b>(&self, fun: &Function<'b>, _: &HashMap<ir::DimId, ir::DimId>)
-            -> Operand<'b> where 'a: 'b {
+impl<'a, 'c, L> AutoOperand<'a, L> for &'c str {
+    fn get<'b>(&self, fun: &Function<'b, L>, _: &HashMap<ir::DimId, ir::DimId>)
+            -> Operand<'b, L> where 'a: 'b {
         Param(unwrap!(fun.signature().params.iter().find(|p| p.name == *self)))
     }
 }
 
-impl<'a> AutoOperand<'a> for InstId {
-    fn get<'b>(&self, fun: &Function<'b>, active_dims: &HashMap<ir::DimId, ir::DimId>)
-            -> Operand<'b> where 'a: 'b {
+impl<'a> AutoOperand<'a, ()> for InstId {
+    fn get<'b>(&self, fun: &Function<'b, ()>, active_dims: &HashMap<ir::DimId, ir::DimId>)
+            -> Operand<'b, ()> where 'a: 'b {
         let inst = fun.inst(*self);
         let mapped_dims = active_dims.iter().flat_map(|(&new_dim, &old_dim)| {
             if new_dim != old_dim && inst.iteration_dims().contains(&old_dim) {
@@ -70,36 +70,36 @@ impl<'a> AutoOperand<'a> for InstId {
     }
 }
 
-impl<'a> AutoOperand<'a> for TmpArray {
-    fn get<'b>(&self, fun: &Function<'b>, active_dims: &HashMap<ir::DimId, ir::DimId>)
-            -> Operand<'b> where 'a: 'b {
+impl<'a> AutoOperand<'a, ()> for TmpArray {
+    fn get<'b>(&self, fun: &Function<'b, ()>, active_dims: &HashMap<ir::DimId, ir::DimId>)
+            -> Operand<'b, ()> where 'a: 'b {
         let inst = fun.inst(self.0);
         let mapped_dims = active_dims.iter().flat_map(|(&new_dim, &old_dim)| {
             if new_dim != old_dim && inst.iteration_dims().contains(&old_dim) {
                 Some((old_dim, new_dim))
             } else { None }
         });
-        Operand::new_inst(inst, dim::Map::new(mapped_dims), ir::DimMapScope::Global)
+        Operand::new_inst(inst, dim::Map::new(mapped_dims), ir::DimMapScope::Global(()))
     }
 }
 
-impl<'a> AutoOperand<'a> for mem::InternalId {
-    fn get<'b>(&self, _: &Function<'b>, _: &HashMap<ir::DimId, ir::DimId>)
-            -> Operand<'b> where 'a: 'b {
+impl<'a, L> AutoOperand<'a, L> for mem::InternalId {
+    fn get<'b>(&self, _: &Function<'b, L>, _: &HashMap<ir::DimId, ir::DimId>)
+            -> Operand<'b, L> where 'a: 'b {
         Operand::Addr(*self)
     }
 }
 
-impl<'a> AutoOperand<'a> for ir::DimId {
-    fn get<'b>(&self, _: &Function<'b>, _: &HashMap<ir::DimId, ir::DimId>)
-            -> Operand<'b> where 'a: 'b {
+impl<'a, L> AutoOperand<'a, L> for ir::DimId {
+    fn get<'b>(&self, _: &Function<'b, L>, _: &HashMap<ir::DimId, ir::DimId>)
+            -> Operand<'b, L> where 'a: 'b {
         Operand::Index(*self)
     }
 }
 
-impl<'a> AutoOperand<'a> for ir::IndVarId {
-    fn get<'b>(&self, fun: &Function<'b>, _: &HashMap<ir::DimId, ir::DimId>)
-            -> Operand<'b> where 'a: 'b {
+impl<'a, L> AutoOperand<'a, L> for ir::IndVarId {
+    fn get<'b>(&self, fun: &Function<'b, L>, _: &HashMap<ir::DimId, ir::DimId>)
+            -> Operand<'b, L> where 'a: 'b {
         Operand::InductionVar(*self, fun.induction_var(*self).base().t())
     }
 }

--- a/src/helper/tensor.rs
+++ b/src/helper/tensor.rs
@@ -187,8 +187,8 @@ impl VirtualTensor {
     /// Creates an operand that yeilds the values of the tensor in the given loop nest.
     pub fn dim_map<'a>(&self,
                        dims: &[&MetaDimension],
-                       scope: ir::DimMapScope,
-                       builder: &mut Builder<'a>) -> ir::Operand<'a>
+                       scope: ir::DimMapScope<()>,
+                       builder: &mut Builder<'a>) -> ir::Operand<'a, ()>
     {
         let mapping = self.dims.iter().map(|x| x as &MetaDimension)
             .zip_eq(dims.iter().cloned()).collect_vec();

--- a/src/ir/basic_block.rs
+++ b/src/ir/basic_block.rs
@@ -15,11 +15,11 @@ impl From<ir::DimId> for BBId {
 }
 
 /// Represents a basic block in an Exhaust function.
-pub trait BasicBlock<'a>: std::fmt::Debug {
+pub trait BasicBlock<'a, L = ir ::LoweringMap>: std::fmt::Debug {
     /// Returns the unique identifier of the `BasicBlock`.
     fn bb_id(&self) -> BBId;
     /// Returns 'self' if it is an instruction.
-    fn as_inst(&self) -> Option<&ir::Instruction<'a>> { None }
+    fn as_inst(&self) -> Option<&ir::Instruction<'a, L>> { None }
     /// Returns 'self' if it is a dimension
     fn as_dim(&self) -> Option<&ir::Dimension<'a>> { None }
 }

--- a/src/ir/dim_map.rs
+++ b/src/ir/dim_map.rs
@@ -5,11 +5,12 @@ use utils::*;
 
 /// Represents a mapping between dimenions.
 #[derive(Clone, Debug)]
-// TODO(cleanup): once merge is handled exclusively from the domain, we can use a `Vec`
-// instead.
+// TODO(cleanup): once merge is handled exclusively from the domain, we can use
+// a `Vec` instead.
 pub struct DimMap {
     map: LinkedList<(ir::DimId, ir::DimId)>,
 }
+
 
 // TODO(cleanup): Send should be derived for LinkedList.
 unsafe impl Send for DimMap {}
@@ -18,42 +19,61 @@ unsafe impl Sync for DimMap {}
 impl DimMap {
     /// Create a new `DimMap`.
     pub fn new<IT>(dims: IT) -> Self
-            where IT: IntoIterator<Item=(ir::DimId, ir::DimId)> {
-        DimMap { map: dims.into_iter().collect() }
+    where
+        IT: IntoIterator<Item = (ir::DimId, ir::DimId)>,
+    {
+        DimMap {
+            map: dims.into_iter().collect(),
+        }
     }
 
     /// Returns an empty `DimMap`.
-    pub fn empty() -> DimMap { DimMap { map: LinkedList::new() } }
+    pub fn empty() -> Self {
+        DimMap {
+            map: LinkedList::new(),
+        }
+    }
 
-    /// Renames a basic block into an other. Indicates if some mapping were removed.
+    /// Renames a basic block into an other. Indicates if some mapping were
+    /// removed.
     pub fn merge_dims(&mut self, lhs: ir::DimId, rhs: ir::DimId) -> bool {
-        self.filter(|&mut pair| pair == (lhs, rhs) || pair == (rhs, lhs)).count() > 0
+        self.filter(|&mut pair| pair == (lhs, rhs) || pair == (rhs, lhs))
+            .count() > 0
     }
 
     /// Iterates over the DimMap.
-    pub fn iter(&self) -> linked_list::Iter<(ir::DimId, ir::DimId)> { self.map.iter() }
+    pub fn iter(&self) -> linked_list::Iter<(ir::DimId, ir::DimId)> {
+        self.map.iter()
+    }
 
     /// Filters the DimMap.
     pub fn filter<F>(&mut self, f: F) -> FilterList<(ir::DimId, ir::DimId), F>
-            where F: FnMut(&mut (ir::DimId, ir::DimId)) -> bool {
+    where
+        F: FnMut(&mut (ir::DimId, ir::DimId)) -> bool,
+    {
         filter_list(&mut self.map, f)
     }
 
     /// Returns true if the `DimMap` is empty.
-    pub fn is_empty(&self) -> bool { self.map.is_empty() }
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
 }
 
 impl IntoIterator for DimMap {
     type Item = (ir::DimId, ir::DimId);
     type IntoIter = linked_list::IntoIter<(ir::DimId, ir::DimId)>;
 
-    fn into_iter(self) -> Self::IntoIter { self.map.into_iter() }
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.into_iter()
+    }
 }
-
 
 impl<'a> IntoIterator for &'a DimMap {
     type Item = &'a (ir::DimId, ir::DimId);
     type IntoIter = linked_list::Iter<'a, (ir::DimId, ir::DimId)>;
 
-    fn into_iter(self) -> Self::IntoIter { self.map.iter() }
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.iter()
+    }
 }

--- a/src/ir/dimension.rs
+++ b/src/ir/dimension.rs
@@ -8,6 +8,12 @@ use std::fmt;
 #[repr(C)]
 pub struct DimId(pub u32);
 
+impl Into<usize> for DimId {
+    fn into(self) -> usize {
+        self.0 as usize
+    }
+}
+
 impl fmt::Display for DimId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.0.fmt(f) }
 }
@@ -36,6 +42,17 @@ impl<'a> Dimension<'a> {
             iterated: Vec::new(),
             is_thread_dim: false,
         })
+    }
+
+    /// Creates a new dimension with the same size as an existing one.
+    pub fn with_same_size(id: DimId, other: &Self) -> Self {
+        Dimension {
+            size: other.size().clone(),
+            possible_sizes: other.possible_sizes.clone(),
+            id: id,
+            iterated: Vec::new(),
+            is_thread_dim: false,
+        }
     }
 
     /// Retruns the size of the dimension.

--- a/src/ir/induction_var.rs
+++ b/src/ir/induction_var.rs
@@ -7,15 +7,15 @@ pub struct IndVarId(pub u32);
 
 /// A multidimentional induction variable. No dimension should appear twice in dims.
 #[derive(Clone, Debug)]
-pub struct InductionVar<'a> {
+pub struct InductionVar<'a, L = ir::LoweringMap> {
     dims: Vec<(ir::DimId, ir::Size<'a>)>,
-    base: ir::Operand<'a>,
+    base: ir::Operand<'a, L>,
 }
 
-impl<'a> InductionVar<'a> {
+impl<'a, L> InductionVar<'a, L> {
     /// Creates a new induction var. Size represents the increment over each diemnsion
     /// taken independenly.
-    pub fn new(dims: Vec<(ir::DimId, ir::Size<'a>)>, base: ir::Operand<'a>)
+    pub fn new(dims: Vec<(ir::DimId, ir::Size<'a>)>, base: ir::Operand<'a, L>)
         -> Result<Self, ir::Error>
     {
         ir::TypeError::check_integer(base.t())?;
@@ -30,7 +30,7 @@ impl<'a> InductionVar<'a> {
         match base {
             ir::Operand::Reduce(..) =>
                 panic!("induction variables cannot perform reductions"),
-            ir::Operand::Inst(.., ir::DimMapScope::Global) =>
+            ir::Operand::Inst(.., ir::DimMapScope::Global(..)) =>
                 // TODO(search_space): allow dim map lowering for induction variables
                 unimplemented!("dim map lowering for induction vars is not implemented yet"),
             _ => (),
@@ -44,8 +44,14 @@ impl<'a> InductionVar<'a> {
     }
 
     /// Returns the base operand of the induction variable.
-    pub fn base(&self) -> &ir::Operand<'a> { &self.base }
+    pub fn base(&self) -> &ir::Operand<'a, L> { &self.base }
 
     /// Returns the list of induction dimensions along with the corresponding increments.
     pub fn dims(&self) -> &[(ir::DimId, ir::Size<'a>)] { &self.dims }
+}
+
+impl<'a> InductionVar<'a, ()> {
+    pub fn freeze(self, cnt: &mut ir::Counter) -> InductionVar<'a> {
+        InductionVar { dims: self.dims, base: self.base.freeze(cnt) }
+    }
 }

--- a/src/ir/mem.rs
+++ b/src/ir/mem.rs
@@ -12,6 +12,12 @@ pub enum MemId { Internal(u32), External(u32) }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub struct InternalId(pub u32);
 
+impl Into<usize> for InternalId {
+    fn into(self) -> usize {
+        self.0 as usize
+    }
+}
+
 impl From<InternalId> for MemId {
     fn from(id: InternalId) -> Self { MemId::Internal(id.0) }
 }
@@ -90,7 +96,7 @@ impl Block for ExternalBlock {
 /// Holds the blocks of memory to allocate on the device.
 #[derive(Clone)]
 pub struct BlockMap {
-    internal_blocks: Vec<InternalBlock>,
+    internal_blocks: ir::SparseVec<InternalId, InternalBlock>,
     external_blocks: Vec<ExternalBlock>,
     layouts: HashSet<InternalId>,
 }
@@ -102,10 +108,14 @@ impl BlockMap {
             ExternalBlock { id: MemId::External(id), uses: vec![] }
         }).collect();
         BlockMap {
-            internal_blocks: vec![],
+            internal_blocks: ir::SparseVec::new(),
             external_blocks,
             layouts: HashSet::default(),
         }
+    }
+
+    pub fn num_internal_blocks(&self) -> usize {
+        self.internal_blocks.len()
     }
 
     /// Allocates a new `Block` with the given type and sizes. Must call not merged on
@@ -114,26 +124,41 @@ impl BlockMap {
         -> InternalId
     {
         let id = InternalId(self.internal_blocks.len() as u32);
+        let block = self.create_block(id, base_size, maybe_mapped);
+        self.internal_blocks.push(block);
+        id
+    }
+
+    fn create_block(
+        &mut self,
+        id: InternalId,
+        base_size: u32,
+        maybe_mapped: Option<ir::DimMap>,
+    ) -> InternalBlock {
         if let Some(ref dim_map) = maybe_mapped {
             assert!(!dim_map.is_empty());
             self.layouts.insert(id);
         }
-        let block = InternalBlock {
+        InternalBlock {
             id,
             base_size: base_size,
             uses: vec![],
             mapped_dims: vec![],
             maybe_mapped: maybe_mapped.unwrap_or_else(ir::DimMap::empty),
-        };
-        self.internal_blocks.push(block);
-        id
+        }
+    }
+
+    pub fn expand_internal_blocks_to(&mut self, capacity: usize) {
+        self.internal_blocks.expand_to(capacity);
     }
 
     /// Inserts a new temporary memory. Must be inserted before not_merged is called
     /// on dimensions.
-    pub fn new_tmp<IT>(&mut self, t: Type, dims: IT) -> InternalId
+    pub fn set_lazy_tmp<IT>(&mut self, id: InternalId, t: Type, dims: IT)
             where IT: Iterator<Item=(ir::DimId, ir::DimId)> {
-        self.alloc_block(unwrap!(t.len_byte()), Some(ir::DimMap::new(dims)))
+        let block = self.create_block(
+            id, unwrap!(t.len_byte()), Some(ir::DimMap::new(dims)));
+        self.internal_blocks.set_lazy(id, block);
     }
 
     /// Registers a use of a memory block by an instruction.
@@ -144,7 +169,7 @@ impl BlockMap {
     /// Returns a block given its Id.
     pub fn block(&self, id: MemId) -> &Block {
         match id {
-            MemId::Internal(num) => &self.internal_blocks[num as usize],
+            MemId::Internal(num) => &self.internal_blocks[InternalId(num)],
             MemId::External(num) => &self.external_blocks[num as usize],
         }
     }
@@ -152,14 +177,14 @@ impl BlockMap {
     /// Returns a block given its Id.
     pub fn block_mut(&mut self, id: MemId) -> &mut Block {
         match id {
-            MemId::Internal(num) => &mut self.internal_blocks[num as usize],
+            MemId::Internal(num) => &mut self.internal_blocks[InternalId(num)],
             MemId::External(num) => &mut self.external_blocks[num as usize],
         }
     }
 
     /// Returns the internal block given its ID.
     pub fn internal_block(&self, id: InternalId) -> &InternalBlock {
-        &self.internal_blocks[id.0 as usize]
+        &self.internal_blocks[id]
     }
 
     /// Retuns the list of internal blocks.
@@ -176,7 +201,7 @@ impl BlockMap {
     /// Rename a basic block. Returns the lyaouts to lower.
     pub fn merge_dims(&mut self, lhs: ir::DimId, rhs: ir::DimId) -> Vec<InternalId> {
         let mut to_lower = Vec::new();
-        for block in &mut self.internal_blocks {
+        for block in self.internal_blocks.iter_mut() {
             if block.maybe_mapped.merge_dims(lhs, rhs) && block.is_ready() {
                 to_lower.push(block.id());
             }
@@ -192,7 +217,7 @@ impl BlockMap {
         let mut to_lower = Vec::new();
         for &id in &self.layouts {
             let mut changed = false; // Ensure we only lower once.
-            let block = &mut self.internal_blocks[id.0 as usize];
+            let block = &mut self.internal_blocks[id];
             for pair in block.maybe_mapped.filter(|&mut (lhs2, rhs2)| {
                 (lhs2 == lhs && rhs2 == rhs) || (lhs2 == rhs && rhs2 == lhs)
             }) {
@@ -207,7 +232,7 @@ impl BlockMap {
     /// Lowers a fully defined layout. Returns the mapping of dimensions.
     pub fn lower_layout(&mut self, id: InternalId) -> Vec<(ir::DimId, ir::DimId)> {
         assert!(self.layouts.remove(&id));
-        let block = &self.internal_blocks[id.0 as usize];
+        let block = &self.internal_blocks[id];
         assert!(block.is_ready());
         block.mapped_dims.clone()
     }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -12,6 +12,8 @@ mod operator;
 mod size;
 mod types;
 
+use std::marker::PhantomData;
+
 pub use self::access_pattern::{Stride, AccessPattern};
 pub use self::basic_block::{BasicBlock, BBId};
 pub use self::dim_map::DimMap;
@@ -21,7 +23,7 @@ pub use self::function::{Function, Signature, Parameter};
 pub use self::instruction::{InstId, Instruction};
 pub use self::induction_var::{IndVarId, InductionVar};
 pub use self::mem::MemId;
-pub use self::operand::{Operand, DimMapScope};
+pub use self::operand::{Operand, DimMapScope, LoweringMap};
 pub use self::operator::{BinOp, Operator};
 pub use self::size::Size;
 pub use self::types::Type;
@@ -108,6 +110,168 @@ pub struct LoweredDimMap {
     pub store: InstId,
     pub load: InstId,
     pub dimensions: Vec<(DimId, DimId)>
+}
+
+/// A vector with holes. This provides a similar interface as a
+/// standard `Vec` does, but also provides a `set_lazy` method which
+/// can be used to assign new values past the end of the vector and
+/// will allocate holes in between if needed. Hole spaces must first
+/// be reserved through `expand_to`.
+///
+/// An index type `I` is also used in order to provide strong typing
+/// guarantees since `SparseVec` is meant to hold `DimId -> Dimension`
+/// and `InstId -> Instruction` mappings.
+#[derive(Clone, Debug)]
+pub(crate) struct SparseVec<I, T> {
+    vec: Vec<Option<T>>,
+    capacity: usize,
+    _marker: PhantomData<I>,
+}
+
+impl<T, I> SparseVec<I, T>
+where I: Into<usize>
+{
+    /// Creates a new sparse vector.
+    pub fn new() -> Self {
+        SparseVec {
+            vec: Vec::new(),
+            capacity: 0,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn from_vec(vec: Vec<Option<T>>) -> Self {
+        let capacity = vec.len();
+        SparseVec {
+            vec,
+            capacity,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns the length of the sparse vector. This includes holes.
+    pub fn len(&self) -> usize {
+        self.capacity
+    }
+
+    /// Append an element to the back of the collection.
+    pub fn push(&mut self, value: T) {
+        if self.vec.len() < self.capacity {
+            let extra = (self.vec.len()..=self.capacity).map(|_| None);
+            self.vec.extend(extra);
+        }
+        assert!(self.vec.len() == self.capacity);
+
+        self.capacity += 1;
+        self.vec.push(Some(value))
+    }
+
+    /// Increase the possible size of the vector by adding holes at
+    /// the end.
+    pub fn expand_to(&mut self, capacity: usize) {
+        assert!(capacity >= self.capacity);
+        self.capacity = capacity;
+    }
+
+    /// Initializes a hole. The index can be past the length of the
+    /// vector.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the element at index `index` is not a hole.
+    pub fn set_lazy(&mut self, index: I, value: T) {
+        let index = index.into();
+        if index >= self.capacity {
+            panic!("Cannot fill a hole that was not declared.");
+        }
+
+        if index >= self.vec.len() {
+            let extra = (self.vec.len()..=index).map(|_| None);
+            self.vec.extend(extra);
+        }
+
+        let old = ::std::mem::replace(&mut self.vec[index], Some(value));
+        if old.is_some() {
+            panic!("can only set a lazy entry once")
+        }
+    }
+
+    /// Returns an iterator over the filled elements of the
+    /// slice. Holes are skipped.
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = &'a T> + Clone {
+        self.vec.iter().filter_map(Option::as_ref)
+    }
+
+    /// Returns a mutable iterator over the filled elements of the
+    /// slice. Holes are skipped.
+    pub fn iter_mut<'a>(&'a mut self) -> impl Iterator<Item = &'a mut T> {
+        self.vec.iter_mut().filter_map(Option::as_mut)
+    }
+}
+
+impl<I, T> IntoIterator for SparseVec<I, T> {
+    type Item = Option<T>;
+    type IntoIter = <Vec<Option<T>> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.vec.into_iter()
+    }
+}
+
+/// Implements the indexing operation (`vec[index]`). The `index` must
+/// be of type `I` as declared in the `SparseVec` type. Panics when
+/// accessing an index which is out of bounds *or* contains a hole.
+impl<T, I> ::std::ops::Index<I> for SparseVec<I, T>
+where I: Into<usize>
+{
+    type Output = T;
+
+    fn index(&self, index: I) -> &T {
+        unwrap!(self.vec[index.into()].as_ref())
+    }
+}
+
+/// Implements the mutable indexing operation (`vec[index]`). The
+/// `index` must be of type `I` as declared in the `SparseVec`
+/// type. Panics when accessing an index which is out of bounds *or*
+/// contains a hole.
+impl<T, I> ::std::ops::IndexMut<I> for SparseVec<I, T>
+where I: Into<usize>
+{
+    fn index_mut(&mut self, index: I) -> &mut T {
+        unwrap!(self.vec[index.into()].as_mut())
+    }
+}
+
+/// A wrapper used to count extra dimensions that will be needed in
+/// the future and allocates IDs for them. This is used when freezing
+/// in order to pre-allocate IDs for the various objects (internal
+/// memory block, instructions, dimensions, etc.) required for future
+/// lowering.
+pub struct Counter {
+    pub next_mem: usize,
+    pub next_inst: usize,
+    pub next_dim: usize,
+}
+
+impl Counter {
+    pub fn next_mem(&mut self) -> mem::InternalId {
+        let next = mem::InternalId(self.next_mem as u32);
+        self.next_mem += 1;
+        next
+    }
+
+    pub fn next_inst(&mut self) -> InstId {
+        let next = InstId(self.next_inst as u32);
+        self.next_inst += 1;
+        next
+    }
+
+    pub fn next_dim(&mut self) -> DimId {
+        let next = DimId(self.next_dim as u32);
+        self.next_dim += 1;
+        next
+    }
 }
 
 // TODO(perf): group static computations

--- a/src/ir/operand.rs
+++ b/src/ir/operand.rs
@@ -4,28 +4,93 @@ use num::bigint::BigInt;
 use num::rational::Ratio;
 use num::traits::{Signed, Zero};
 use self::Operand::*;
+use utils::HashMap;
 
-/// Indicates how dimensions can be mapped.
+#[derive(Clone, Debug)]
+pub struct LoweringMap {
+        /// Memory ID to use for the temporary array
+        mem_id: ir::mem::InternalId,
+        /// Instruction ID to use for the `store` instruction when
+        /// lowering.
+        st_inst: ir::InstId,
+        /// Maps the lhs dimensions in `map` to their lowered dimension.
+        st_map: HashMap<ir::DimId, ir::DimId>,
+        /// Instruction ID to use for the `load` instruction when
+        /// lowering.
+        ld_inst: ir::InstId,
+        /// Maps the rhs dimensions in `map` to their lowered dimension.
+        ld_map: HashMap<ir::DimId, ir::DimId>,
+}
+
+impl LoweringMap {
+    /// Creates a new lowering map from an existing dimension map and
+    /// a counter. This allocates new IDs for the new
+    /// dimensions/instructions/memory locations that will be used
+    /// when lowering the DimMap.
+    pub fn for_dim_map(dim_map: &DimMap, cnt: &mut ir::Counter) -> LoweringMap {
+        let mem_id = cnt.next_mem();
+        let st_inst = cnt.next_inst();
+        let ld_inst = cnt.next_inst();
+        let (st_map, ld_map) = dim_map.iter().cloned().map(|(src, dst)| {
+            let st_dim = cnt.next_dim();
+            let ld_dim = cnt.next_dim();
+            ((src, st_dim), (dst, ld_dim))
+        }).unzip();
+        
+        LoweringMap {
+            mem_id,
+            st_inst,
+            st_map,
+            ld_inst,
+            ld_map,
+        }
+    }
+
+    /// Returns lowering information about the dim_map. The returned
+    /// `LoweredDimMap` object should not be used immediately: it
+    /// refers to fresh IDs that are not activated in the
+    /// ir::Function. The appropriate instructions need to be built
+    /// and stored with the corresponding IDs.
+    pub(crate) fn lower(&self, map: &DimMap) -> ir::LoweredDimMap {
+        ir::LoweredDimMap {
+            mem: self.mem_id,
+            store: self.st_inst,
+            load: self.ld_inst,
+            dimensions: map.iter().map(|(src, dst)| {
+                (unwrap!(self.st_map.get(src)).clone(),
+                 unwrap!(self.ld_map.get(dst)).clone())
+            }).collect(),
+        }
+    }
+}
+
+/// Indicates how dimensions can be mapped. The `L` type indicates how
+/// to lower mapped dimensions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DimMapScope {
+pub enum DimMapScope<L> {
     /// The dimensions are mapped within registers, without producing syncthreads.
     Local,
     /// The dimensions are mapped within registers.
     Thread,
-    /// The dimensions are mapped, possibly using temporary memory.
-    Global,
+    /// The dimensions are mapped, possibly using temporary
+    /// memory. The parameter `L` is used to indicate how the mapping
+    /// should be lowered. It is `()` when building the function
+    /// (lowering is not possible at that time), and a `LoweringMap`
+    /// instance when exploring which indicates what IDs to use for
+    /// the new objects.
+    Global(L),
 }
 
 /// Represents an instruction operand.
 #[derive(Clone, Debug)]
-pub enum Operand<'a> {
+pub enum Operand<'a, L = LoweringMap> {
     /// An integer constant, on a given number of bits.
     Int(BigInt, u16),
     /// A float constant, on a given number of bits.
     Float(Ratio<BigInt>, u16),
     /// A value produced by an instruction. The boolean indicates if the `DimMap` can be
     /// lowered.
-    Inst(InstId, Type, DimMap, DimMapScope),
+    Inst(InstId, Type, DimMap, DimMapScope<L>),
     /// The current index in a loop.
     Index(ir::DimId),
     /// A parameter of the function.
@@ -38,7 +103,7 @@ pub enum Operand<'a> {
     InductionVar(ir::IndVarId, Type),
 }
 
-impl<'a> Operand<'a> {
+impl<'a, L> Operand<'a, L> {
     /// Returns the type of the `Operand`.
     pub fn t(&self) -> Type {
         match *self {
@@ -52,29 +117,32 @@ impl<'a> Operand<'a> {
     }
 
     /// Create an operand from an instruction.
-    pub fn new_inst(inst: &Instruction, dim_map: DimMap, mut scope: DimMapScope)
-            -> Operand<'a> {
-        // A temporary arry can only be generated if the type size is known.
-        if scope == DimMapScope::Global && unwrap!(inst.t()).len_byte().is_none() {
-            scope = DimMapScope::Thread
+    pub fn new_inst(inst: &Instruction<L>, dim_map: DimMap, mut scope: DimMapScope<L>)
+            -> Self {
+        // A temporary array can only be generated if the type size is known.
+        if let DimMapScope::Global(_) = scope {
+            if unwrap!(inst.t()).len_byte().is_none() {
+                scope = DimMapScope::Thread;
+            }
         }
+
         Inst(inst.id(), unwrap!(inst.t()), dim_map, scope)
     }
 
     /// Creates a reduce operand from an instruction and a set of dimensions to reduce on.
-    pub fn new_reduce(init: &Instruction, dim_map: DimMap, dims: Vec<ir::DimId>)
-            -> Operand<'a> {
+    pub fn new_reduce(init: &Instruction<L>, dim_map: DimMap, dims: Vec<ir::DimId>)
+            -> Self {
         Reduce(init.id(), unwrap!(init.t()), dim_map, dims)
     }
 
     /// Creates a new Int operand and checks its number of bits.
-    pub fn new_int(val: BigInt, len: u16) -> Operand<'a> {
+    pub fn new_int(val: BigInt, len: u16) -> Self {
         assert!(num_bits(&val) <= len);
         Int(val, len)
     }
 
     /// Creates a new Float operand.
-    pub fn new_float(val: Ratio<BigInt>, len: u16) -> Operand<'a> {
+    pub fn new_float(val: Ratio<BigInt>, len: u16) -> Self {
         Float(val, len)
     }
 
@@ -110,6 +178,29 @@ impl<'a> Operand<'a> {
         match *self {
             Int(..) | Float(..) | Addr(..) | Param(..) => true,
             Index(..) | Inst(..) | Reduce(..) | InductionVar(..) => false,
+        }
+    }
+}
+
+impl<'a> Operand<'a, ()> {
+    pub fn freeze(self, cnt: &mut ir::Counter) -> Operand<'a> {
+        match self {
+            Int(val, len) => Int(val, len),
+            Float(val, len) => Float(val, len),
+            Inst(id, t, dim_map, DimMapScope::Global(())) => {
+                let lowering_map = LoweringMap::for_dim_map(
+                    &dim_map, cnt);
+                Inst(id, t, dim_map, DimMapScope::Global(lowering_map))
+            },
+            Inst(id, t, dim_map, DimMapScope::Local) =>
+                Inst(id, t, dim_map, DimMapScope::Local),
+            Inst(id, t, dim_map, DimMapScope::Thread) =>
+                Inst(id, t, dim_map, DimMapScope::Thread),
+            Index(id) => Index(id),
+            Param(param) => Param(param),
+            Addr(id) => Addr(id),
+            Reduce(id, t, dim_map, dims) => Reduce(id, t, dim_map, dims),
+            InductionVar(id, t) => InductionVar(id, t),
         }
     }
 }

--- a/src/search_space/mod.rs
+++ b/src/search_space/mod.rs
@@ -20,8 +20,11 @@ pub struct SearchSpace<'a> {
 
 impl<'a> SearchSpace<'a> {
     /// Creates a new `SearchSpace` for the given `ir_instance`.
-    pub fn new(mut ir_instance: ir::Function<'a>,
+    pub fn new(ir_instance: ir::Function<'a, ()>,
                mut actions: Vec<Action>) -> Result<Self, ()> {
+        // Pre-allocate IDs for future lowerings.
+        let mut ir_instance = ir_instance.freeze();
+
         let mut domain = DomainStore::new(&ir_instance);
         // Enforce invariants.
         for inst in ir_instance.insts() {

--- a/src/search_space/operand.rs
+++ b/src/search_space/operand.rs
@@ -7,7 +7,7 @@ use search_space::choices::{Action, DimKind, DimMapping, Order};
 pub fn invariants(fun: &ir::Function, op: &ir::Operand, user: ir::BBId) -> Vec<Action> {
     match *op {
         Int(..) | Float(..) | Param(..) | Addr(..) => vec![],
-        Inst(src, _, ref dim_map, scope) => {
+        Inst(src, _, ref dim_map, ref scope) => {
             // Order dimensions in the dim map.
             let order = Order::BEFORE | Order::MERGED;
             let mut actions = Vec::new();
@@ -16,7 +16,7 @@ pub fn invariants(fun: &ir::Function, op: &ir::Operand, user: ir::BBId) -> Vec<A
                 let mapping = match scope {
                     DimMapScope::Local => DimMapping::UNROLL_MAP,
                     DimMapScope::Thread => DimMapping::MAPPED,
-                    DimMapScope::Global => DimMapping::ALL,
+                    DimMapScope::Global(..) => DimMapping::ALL,
                 };
                 actions.push(Action::DimMapping(lhs, rhs, mapping));
                 // FIXME: allow tmp mem with dynamic size when the scope is global.

--- a/telamon-capi/src/ir.rs
+++ b/telamon-capi/src/ir.rs
@@ -119,7 +119,7 @@ pub unsafe extern "C" fn telamon_ir_type_free(t: *mut ir::Type) {
 
 /// Opaque type that abstracts away the lifetime parameter of `ir::Function` so that
 /// cbindgen generates the bindings.
-pub struct Function(ir::Function<'static>);
+pub struct Function(ir::Function<'static, ()>);
 
 /// Creates a function to optimize. The function must be freed with
 /// `telamon_ir_function_free`. `signature` and `device` must outlive the function.
@@ -200,7 +200,7 @@ pub unsafe extern "C" fn telamon_ir_size_free(size: *mut Size) {
 
 /// Opaque type that abstracts away the lifetime parameter of `ir::Operand` so that
 /// cbindgen can generate bindings.
-pub struct Operand(ir::Operand<'static>);
+pub struct Operand(ir::Operand<'static, ()>);
 
 /// Create a constant integer operand. The provided type must be an integer type.
 /// Returns `null` if an error is encountered.
@@ -267,7 +267,7 @@ pub unsafe extern "C" fn telamon_ir_operand_new_inst(
     let dim_map_scope = if allow_tmp_mem == 0 {
         ir::DimMapScope::Thread
     } else {
-        ir::DimMapScope::Global
+        ir::DimMapScope::Global(())
     };
     let operand = ir::Operand::new_inst(inst, dim_map, dim_map_scope);
     Box::into_raw(Box::new(Operand(operand)))
@@ -313,7 +313,7 @@ unsafe fn dim_map_from_arrays(
 
 /// Opaque type that abstracts away the lifetime parameter of `ir::Operator` so that
 /// cbindgen can generate bindings.
-pub struct Operator(ir::Operator<'static>);
+pub struct Operator(ir::Operator<'static, ()>);
 
 /// Creates a `mov` operator. Takes ownership of `operand`.
 #[no_mangle]
@@ -437,7 +437,7 @@ unsafe fn tensor_access(
     strided_dims: *const ir::DimId,
     strides: *const Size,
     num_strided_dims: usize
-) -> Result<(ir::Operand<'static>, ir::AccessPattern<'static>), ir::Error> {
+) -> Result<(ir::Operand<'static, ()>, ir::AccessPattern<'static>), ir::Error> {
     let base_address = Box::from_raw(base_address).0;
     let strided_dims = std::slice::from_raw_parts(strided_dims, num_strided_dims);
     let strides = std::slice::from_raw_parts(strides, num_strided_dims);


### PR DESCRIPTION
Currently telamon is dynamically creating new instruction and dimension
IDs when performing a lowering, which means that:

 - Depending on previous choices, the same ID can be used for different
   choices semantically.
 - The total number of possible choices is not known until all the
   lowerings have been performed (or not).

Both of those properties make it awkward to build statistical models on
top of the information present in the domain. This PR addresses those
issues by pre-allocating IDs for the instruction and dimensions that
will need to be created when a dimension map is lowered.

That information is stored on the `DimMap` instance associated with a
lowerable operand (currently only `Inst`) when the scope is global, and
is annotated on the creation of the DomainStore. This means that an
`ir::Function` can exist in an "invalid" non-annotated state prior to be
stored in a `SearchSpace`. However, that is not an issue, because the
function is not supposed to be used outside of the search space, and
additional instructions (except for lowering) are not supposed to be
added once the function is in the search space.