### PR TITLE
Expose SearchSpace through the C API

### DIFF
--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -15,6 +15,7 @@ use num_cpus;
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
 #[serde(deny_unknown_fields)]
+#[repr(C)]
 pub struct Config {
     /// Name of the file in wich to store the logs.
     pub log_file: String,
@@ -140,6 +141,7 @@ impl Default for Config {
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(tag="type")]
 #[serde(rename_all="snake_case")]
+#[repr(C)]
 pub enum SearchAlgorithm {
     /// Evaluate all the candidates that cannot be pruned.
     BoundOrder,
@@ -173,6 +175,7 @@ impl Default for SearchAlgorithm {
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
 #[serde(deny_unknown_fields)]
+#[repr(C)]
 pub struct BanditConfig {
     /// Indicates how to select between nodes of the search tree when none of their
     /// children have been evaluated.
@@ -222,6 +225,7 @@ impl Default for BanditConfig {
 /// evaluated.
 #[derive(Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all="snake_case")]
+#[repr(C)]
 pub enum NewNodeOrder {
     /// Consider the nodes in the order given by the search space API.
     Api,
@@ -242,6 +246,7 @@ impl Default for NewNodeOrder {
 /// evaluated.
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all="snake_case")]
+#[repr(C)]
 pub enum OldNodeOrder {
     /// Use the weights from the bandit algorithm.
     Bandit,

--- a/src/ir/dimension.rs
+++ b/src/ir/dimension.rs
@@ -6,6 +6,7 @@ use std::fmt;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[derive(Serialize, Deserialize)]
 #[repr(C)]
+/// cbindgen:field-names=[id]
 pub struct DimId(pub u32);
 
 impl Into<usize> for DimId {

--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -7,6 +7,7 @@ use utils::*;
 /// Uniquely identifies an instruction.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[repr(C)]
+/// cbindgen:field-names=[id]
 pub struct InstId(pub u32);
 
 impl Into<usize> for InstId {

--- a/src/ir/mem.rs
+++ b/src/ir/mem.rs
@@ -7,9 +7,15 @@ use utils::*;
 /// Uniquely identifies a block.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 #[repr(C)]
-pub enum MemId { Internal(u32), External(u32) }
+pub enum MemId {
+    /// cbindgen:field-names=[id]
+    Internal(u32),
+    /// cbindgen:field-names=[id]
+    External(u32),
+}
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+/// cbindgen:field-names=[id]
 pub struct InternalId(pub u32);
 
 impl Into<usize> for InternalId {

--- a/telamon-capi/Cargo.toml
+++ b/telamon-capi/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 env_logger = "0.5.9"
 libc = "0.2"
 num = "0.2.0"
+failure = "0.1.1"
 
 [dependencies.telamon]
 path = "../"

--- a/telamon-capi/src/error.rs
+++ b/telamon-capi/src/error.rs
@@ -1,0 +1,126 @@
+use std;
+use std::cell::RefCell;
+
+use libc;
+
+use telamon;
+
+/// Indicates if a telamon function exited correctly.
+#[repr(C)]
+pub enum TelamonStatus {
+    TelamonStatusOk,
+    TelamonStatusFail,
+}
+
+#[derive(Debug, Fail)]
+#[repr(C)]
+pub enum Error {
+    #[fail(display = "{}", _0)]
+    IRError(#[cause] telamon::ir::Error),
+    #[fail(display = "invalid argument: {}", _0)]
+    InvalidArgument(String),
+    #[fail(display = "unexpected NULL pointer")]
+    NullPointer,
+    #[fail(display = "unknown error")]
+    UnknownError,
+    #[fail(display = "{}", _0)]
+    StrUtf8Error(#[cause] std::str::Utf8Error),
+}
+
+impl From<telamon::ir::Error> for Error {
+    fn from(error: telamon::ir::Error) -> Error {
+        Error::IRError(error)
+    }
+}
+
+impl From<telamon::ir::TypeError> for Error {
+    fn from(error: telamon::ir::TypeError) -> Error {
+        Error::IRError(telamon::ir::Error::from(error))
+    }
+}
+
+impl From<std::str::Utf8Error> for Error {
+    fn from(error: std::str::Utf8Error) -> Error {
+        Error::StrUtf8Error(error)
+    }
+}
+
+impl From<()> for Error {
+    fn from(_error: ()) -> Error {
+        Error::UnknownError
+    }
+}
+
+/// Prints the error message in a string. Returns `null` if no error was
+/// present. The caller is responsible for freeing the string with `free`.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_strerror() -> *mut libc::c_char {
+    ERROR.with(|error| {
+        error
+            .borrow()
+            .as_ref()
+            .map(|error| {
+                let string = unwrap!(std::ffi::CString::new(error.to_string()));
+                libc::strdup(string.as_ptr())
+            })
+            .unwrap_or(std::ptr::null_mut())
+    })
+}
+
+thread_local! {
+    pub static ERROR: RefCell<Option<Error>> = RefCell::new(None);
+}
+
+/// Helper macro that unwraps a result. Exits with `$error` and sets the global
+/// `ERROR` variable when an error is encountered.
+///
+/// When no value is specified for `$error`, returns with
+/// `TELAMON_STATUS_FAIL`. When `null` is specified instead, exits with a null
+/// mutable pointer.
+#[macro_export]
+macro_rules! unwrap_or_exit {
+    ($result:expr) => {
+        unwrap_or_exit!($result, $crate::error::TelamonStatus::TelamonStatusFail)
+    };
+    ($result:expr,null) => {
+        unwrap_or_exit!($result, ::std::ptr::null_mut())
+    };
+    ($result:expr, $error:expr) => {
+        match $result {
+            Ok(data) => data,
+            Err(errno) => exit!(errno, $error),
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! exit {
+    ($errno:expr) => {
+        exit!($errno, $crate::error::TelamonStatus::TelamonStatusFail)
+    };
+    ($errno:expr,null) => {
+        exit!($errno, ::std::ptr::null_mut())
+    };
+    ($errno:expr, $error:expr) => {{
+        $crate::error::ERROR.with(|error_var| {
+            *error_var.borrow_mut() = Some($errno.into());
+        });
+
+        return $error;
+    }};
+}
+
+#[macro_export]
+macro_rules! exit_if_null {
+    ($e:expr) => {
+        exit_if_null!($e, $crate::error::TelamonStatus::TelamonStatusFail)
+    };
+    ($e:expr,null) => {
+        exit_if_null!($e, ::std::ptr::null_mut())
+    };
+    ($e:expr, $error:expr) => {{
+        if $e.is_null() {
+            exit!($crate::error::Error::NullPointer, $error)
+        }
+    }};
+}

--- a/telamon-capi/src/explorer.rs
+++ b/telamon-capi/src/explorer.rs
@@ -1,0 +1,72 @@
+use std;
+use std::ffi::CStr;
+
+use libc::c_char;
+use telamon::explorer::{self, Config};
+
+use super::error::TelamonStatus;
+use super::search_space::SearchSpace;
+use super::Context;
+
+/// Allocate a new explorer configuration object with suitable
+/// defaults.
+///
+/// The resulting config object must be freed using
+/// `telamon_config_free`.
+#[no_mangle]
+pub extern "C" fn telamon_config_new() -> *mut Config {
+    Box::into_raw(Box::new(Config::default()))
+}
+
+/// Frees an explorer configuration.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_config_free(config: *mut Config) {
+    std::mem::drop(Box::from_raw(config))
+}
+
+/// Copy a C string pointer into a Rust String object. Use this to set
+/// string-valued configuration options.
+///
+/// # Safety
+///
+/// `dst` must point to a valid Rust String object and `src` must
+/// point to a NULL-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_string_copy(
+    dst: *mut String,
+    src: *const c_char,
+) -> TelamonStatus {
+    *dst = unwrap_or_exit!(CStr::from_ptr(src).to_str()).to_string();
+    TelamonStatus::TelamonStatusOk
+}
+
+/// Run the exploration according to the configuration.
+///
+/// Does not take ownership of any of its arguments. The caller is
+/// responsible for freeing them after `telamon_explore_all` returns.
+///
+/// # Safety
+///
+///  * `config` and `context` must point to valid objects of their
+///    respective types.
+///  * `num_search_spaces` must be non-zero.
+///  * `search_space` must point to a sequence of at least
+///    `num_search_spaces` valid `SearchSpace` objects.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_explore(
+    config: *const Config,
+    context: *const Context,
+    num_search_spaces: usize,
+    search_space: *const SearchSpace,
+) -> *mut SearchSpace {
+    let search_space = std::slice::from_raw_parts(search_space, num_search_spaces)
+        .iter()
+        .cloned()
+        .map(|search_space| search_space.0)
+        .collect();
+    let best = explorer::find_best(&*config, &*(*context).0, search_space);
+    best.map(SearchSpace)
+        .map(Box::new)
+        .map(Box::into_raw)
+        .unwrap_or_else(std::ptr::null_mut)
+}

--- a/telamon-capi/src/lib.rs
+++ b/telamon-capi/src/lib.rs
@@ -10,10 +10,17 @@ extern crate telamon;
 extern crate telamon_kernels;
 #[macro_use]
 extern crate telamon_utils;
+#[macro_use]
+extern crate failure;
+
+#[macro_use]
+pub mod error;
 
 #[cfg(feature = "cuda")]
 pub mod cuda;
 pub mod ir;
+pub mod search_space;
+pub mod explorer;
 
 use libc::{c_char, c_int, c_uint, size_t, uint32_t};
 use telamon::device;
@@ -21,14 +28,15 @@ use telamon::device::x86;
 use telamon::explorer::config::Config;
 pub use telamon_kernels::{linalg, Kernel};
 
-// Pointers to `device::Context` and `device::Device` are not C-like pointers. Instead,
-// they are fat pointers containing both a regular pointer to the object and a pointer to
-// the vtable. Thus, we define wrappers to encapsulate the pointers in an opaque type and
-// we return pointers to the wrappers to C users.
+// Pointers to `device::Context` and `device::Device` are not C-like pointers.
+// Instead, they are fat pointers containing both a regular pointer to the
+// object and a pointer to the vtable. Thus, we define wrappers to encapsulate
+// the pointers in an opaque type and we return pointers to the wrappers to C
+// users.
 
-/// Description of the evaluation context. In particular, in contains the mapping between
-/// argument names and argument values.
-pub struct Context(*const device::Context);
+/// Description of the evaluation context. In particular, in contains the
+/// mapping between argument names and argument values.
+pub struct Context(pub(crate) *const device::Context);
 
 /// Description of the targeted device.
 pub struct Device(*const device::Device);

--- a/telamon-capi/src/search_space.rs
+++ b/telamon-capi/src/search_space.rs
@@ -1,0 +1,83 @@
+//! C API wrappers to work with a Telamon search space.
+
+use std;
+
+use super::error::TelamonStatus;
+use super::ir::Function;
+use telamon::search_space;
+
+/// Opaque type that abstracts away the lifetime parameter of
+/// `search_space::SearchSpace`.
+#[derive(Clone)]
+pub struct SearchSpace(pub(crate) search_space::SearchSpace<'static>);
+
+/// Creates a new search space from an IR function. The caller stays
+/// is responsible for freeing the instance and action pointers; the
+/// created search space does not keep references to them.
+///
+/// Must be freed using `telamon_search_space_free`.
+///
+/// # Safety
+///
+///  * `ir_instance` must point to a valid `Function` value.
+///  * `actions` must point to a sequence of at least `num_actions`
+///    valid `Action` values, unless `num_actions` is 0 in which case
+///    `actions` is not used.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_search_space_new(
+    ir_instance: *const Function,
+    num_actions: usize,
+    actions: *const search_space::Action,
+) -> *mut SearchSpace {
+    // std::slice::from_raw_parts require that the `actions`
+    // pointer be non-null, so we have a special case in order to
+    // allow C API users to pass in a null pointer in that case.
+    let actions = if num_actions == 0 {
+        Vec::new()
+    } else {
+        std::slice::from_raw_parts(actions, num_actions).to_vec()
+    };
+    let search_space = unwrap_or_exit!(
+        search_space::SearchSpace::new((*ir_instance).clone().into(), actions),
+        null
+    );
+    Box::into_raw(Box::new(SearchSpace(search_space)))
+}
+
+/// Apply a sequence of actions to a search space.
+///
+/// # Safety
+///
+///  * `search_space` must be a valid pointer containing a valid
+///    `SearchSpace` value.
+///  * `num_actions` must be non-zero.
+///  * `actions` must point to a sequence of at least `num_actions`
+///     valid `Action` values.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_search_space_apply(
+    search_space: *mut SearchSpace,
+    num_actions: usize,
+    actions: *const search_space::Action,
+) -> TelamonStatus {
+    unwrap_or_exit!(
+        (*search_space)
+            .0
+            .apply_decisions(std::slice::from_raw_parts(actions, num_actions).to_vec())
+    );
+    TelamonStatus::TelamonStatusOk
+}
+
+/// Frees a search space instance allocated through
+/// `telamon_search_space_new`.
+///
+/// # Safety
+///
+/// `search_space` must point to a `SearchSpace` object created by
+/// `telamon_search_space_new` which has not yet been freed.
+#[no_mangle]
+pub unsafe extern "C" fn telamon_search_space_free(
+    search_space: *mut SearchSpace,
+) -> TelamonStatus {
+    std::mem::drop(Box::from_raw(search_space));
+    TelamonStatus::TelamonStatusOk
+}

--- a/telamon-gen/src/print/template/actions.rs
+++ b/telamon-gen/src/print/template/actions.rs
@@ -1,7 +1,9 @@
 /// A decision to apply to the domain.
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Serialize, Deserialize)]
+#[repr(C)]
 pub enum Action {
     {{~#each choices}}
+        /// cbindgen:field-names=[{{~#each arguments}}{{this.[0]}}, {{/each~}}domain]
         {{to_type_name name}}(
         {{~#each arguments}}{{this.[1].def.keys.IdType}},{{/each~}}
         {{>value_type.name value_type}}),

--- a/telamon-gen/src/print/template/enum_def.rs
+++ b/telamon-gen/src/print/template/enum_def.rs
@@ -1,5 +1,6 @@
 {doc_comment}
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[repr(C)]
 pub struct {type_name} {{ bits: {bits_type} }}
 
 impl {type_name} {{

--- a/telamon-gen/src/print/template/main.rs
+++ b/telamon-gen/src/print/template/main.rs
@@ -179,6 +179,7 @@ pub trait Domain: Copy + Eq {
 
 /// Abstracts integer choices by a range.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[repr(C)]
 pub struct Range {
     pub min: u32,
     pub max: u32,
@@ -263,6 +264,7 @@ impl Domain for Range {
 
 /// Abstracts integer choices by a range, but only store `min`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[repr(C)]
 pub struct HalfRange { pub min: u32 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
This add additional wrappers to the C API for creating a SearchSpace
from an IR function, as well as `telamon_explore` allowing to run the
search from the C API. There are still some limitations, notably:

 - Action objects can be constructed, but the constants for creating
   enum values (DimKind, etc.) are not exposed yet because cbindgen
   does not parse associated constants.

 - The exploration is currently "all or nothing", i.e. there is no way
   to exerce more precise control on what happens in the exploration or
   drive the exploration from the C side.

Those will be addressed in follow-up PRs.