### PR TITLE
Simplification of MissingEntry's check and NewObjs of Set

### DIFF
--- a/telamon-gen/src/ast/set.rs
+++ b/telamon-gen/src/ast/set.rs
@@ -20,36 +20,14 @@ impl SetDef {
             .iter()
             .map(|(k, _, _)| k.data)
             .collect::<Vec<ir::SetDefKey>>();
-
-        if !keys.contains(&&ir::SetDefKey::ItemType) {
-            Err(TypeError::MissingEntry {
-                object_name: self.name.data.to_owned(),
-                object_field: self.name.with_data(ir::SetDefKey::ItemType.to_string()),
-            })?;
-        }
-        if !keys.contains(&&ir::SetDefKey::IdType) {
-            Err(TypeError::MissingEntry {
-                object_name: self.name.data.to_owned(),
-                object_field: self.name.with_data(ir::SetDefKey::IdType.to_string()),
-            })?;
-        }
-        if !keys.contains(&&ir::SetDefKey::ItemGetter) {
-            Err(TypeError::MissingEntry {
-                object_name: self.name.data.to_owned(),
-                object_field: self.name.with_data(ir::SetDefKey::ItemGetter.to_string()),
-            })?;
-        }
-        if !keys.contains(&&ir::SetDefKey::IdGetter) {
-            Err(TypeError::MissingEntry {
-                object_name: self.name.data.to_owned(),
-                object_field: self.name.with_data(ir::SetDefKey::IdGetter.to_string()),
-            })?;
-        }
-        if !keys.contains(&&ir::SetDefKey::Iter) {
-            Err(TypeError::MissingEntry {
-                object_name: self.name.data.to_owned(),
-                object_field: self.name.with_data(ir::SetDefKey::Iter.to_string()),
-            })?;
+    
+        for ref key in ir::SetDefKey::REQUIRED.iter() {
+            if !keys.contains(&key) {
+                Err(TypeError::MissingEntry {
+                    object_name: self.name.data.to_owned(),
+                    object_field: self.name.with_data(key.to_string()),
+                })?;
+            }
         }
         if self.superset.is_some() && !keys.contains(&&ir::SetDefKey::FromSuperset) {
             Err(TypeError::MissingEntry {

--- a/telamon-gen/tests/typing/set.rs
+++ b/telamon-gen/tests/typing/set.rs
@@ -399,6 +399,43 @@ mod missing_entry {
         );
     }
 
+    /// Missing the NewObjs's key from Set.
+    #[test]
+    fn new_objs() {
+        assert_eq!(
+            parser::parse_ast(Lexer::new(
+                b"set Instruction:
+                item_type = \"ir::inst::Obj\"
+                id_type = \"ir::inst::Id\"
+                item_getter = \"ir::inst::get($fun, $id)\"
+                id_getter = \"ir::inst::Obj::id($item)\"
+                iterator = \"ir::inst::iter($fun)\"
+                var_prefix = \"inst\"
+              end"
+                    .to_vec()
+            )).unwrap()
+                .type_check()
+                .err(),
+            Some(TypeError::MissingEntry {
+                object_name: String::from("Instruction"),
+                object_field: Spanned {
+                    beg: Position {
+                        position: LexerPosition { line: 0, column: 4 },
+                        ..Default::default()
+                    },
+                    end: Position {
+                        position: LexerPosition {
+                            line: 0,
+                            column: 15
+                        },
+                        ..Default::default()
+                    },
+                    data: ir::SetDefKey::NewObjs.to_string(),
+                }
+            })
+        );
+    }
+
     /// Missing the SetDefKey's key from Set.
     #[test]
     fn from_superset() {


### PR DESCRIPTION
This PR simplify the *check_missing_entry*'s method with the replacement of a list of if by a foreach of ir::REQUIRED constant.
This PR add a checkcase for NewObjs key.

That implies a rewriting of *check_missing_entry*'s method and a completing of set from tests/typing.