### PR TITLE
Revamp logical dimensions

### DIFF
--- a/kernels/src/linalg.rs
+++ b/kernels/src/linalg.rs
@@ -7,7 +7,7 @@ use rand;
 use rayon::prelude::*;
 use telamon::explorer::Candidate;
 use telamon::helper::tensor::*;
-use telamon::helper::{self, Builder, MetaDimension, SignatureBuilder};
+use telamon::helper::{self, Builder, SignatureBuilder};
 use telamon::ir::DimMapScope::Global as GlobalScope;
 use telamon::search_space::*;
 use telamon::{device, ir};
@@ -706,7 +706,7 @@ impl<'a, S: Scalar> Kernel<'a> for BatchMM<'a, S> {
                     &mut builder,
                 );
                 let b_op = {
-                    let b_dims = [&acc_batch as &MetaDimension, &acc_dim_k, &acc_dim_n];
+                    let b_dims = [&acc_batch, &acc_dim_k, &acc_dim_n];
                     let b_dims = if self.params.batch_b {
                         &b_dims
                     } else {

--- a/src/codegen/size.rs
+++ b/src/codegen/size.rs
@@ -28,7 +28,7 @@ impl<'a> Size<'a> {
     }
 
     /// Converts an `ir::Size` to `Self`.
-    pub fn from_ir(size: &ir::Size<'a>, _: &SearchSpace) -> Self {
+    pub fn from_ir(size: &ir::PartialSize<'a>, _: &SearchSpace) -> Self {
         Size::new(
             size.factor(),
             size.dividend().iter().cloned().collect(),
@@ -79,8 +79,8 @@ impl<'a, 'b> std::ops::MulAssign<&'b Size<'a>> for Size<'a> {
 
 // TODO(cleanup): remove the temporary implementation of From<ir::Size> for codgen::Size.
 // This is only needed until we have mechanism in `model::*` to handle sizes.
-impl<'a> From<ir::Size<'a>> for Size<'a> {
-    fn from(s: ir::Size<'a>) -> Size<'a> {
+impl<'a> From<ir::PartialSize<'a>> for Size<'a> {
+    fn from(s: ir::PartialSize<'a>) -> Size<'a> {
         Size::new(
             s.factor(),
             s.dividend().iter().cloned().collect(),

--- a/src/device/cuda/characterize/gen.rs
+++ b/src/device/cuda/characterize/gen.rs
@@ -166,7 +166,8 @@ pub fn init_stride_array<'a>(
 
     let pattern1 = builder.unknown_access_pattern(mem_id);
     builder.st_ex(&last_addr, &array, true, pattern1, InstFlag::MEM_CG);
-    dim.as_ref().map(|dim| builder.order(dim, &last_addr, Order::BEFORE));
+    dim.as_ref()
+        .map(|dim| builder.order(dim, &last_addr, Order::BEFORE));
     builder.get()
 }
 
@@ -291,9 +292,7 @@ pub fn parallel_load<'a>(
     let mut strides = vec![
         (
             d3,
-            ir::Size::new_const(
-                n_unroll * num_wraps * gpu.wrap_size * gpu.l1_cache_line,
-            ),
+            ir::Size::new_const(n_unroll * num_wraps * gpu.wrap_size * gpu.l1_cache_line),
         ),
         (
             d4_0,
@@ -373,7 +372,7 @@ pub fn parallel_store<'a>(
     let mut strides = vec![
         (&d3, ir::Size::new_const(n_unroll * num_wraps * wrap_stride)),
         (&d4, ir::Size::new_const(num_wraps * wrap_stride)),
-        (&d1_1, ir::Size::new_const(stride*4)),
+        (&d1_1, ir::Size::new_const(stride * 4)),
     ];
     if let Some(ref d1_0) = d1_0 {
         strides.push((d1_0, ir::Size::new_const(wrap_stride)));
@@ -502,7 +501,11 @@ pub fn load_in_loop<'a>(
     builder.close_dim(&unroll_dim_a);
     // Mad a and b
     let unroll_dims_1 = builder.open_mapped_dim(&unroll_dim_0_0);
-    let a_op = builder.dim_map(a_val, &[(&unroll_dim_a, &unroll_dims_1)], ir::DimMapScope::Thread);
+    let a_op = builder.dim_map(
+        a_val,
+        &[(&unroll_dim_a, &unroll_dims_1)],
+        ir::DimMapScope::Thread,
+    );
     let acc = builder.mad(&a_op, &2f32, &Reduce(acc_init));
     builder.close_dim(&k_dim);
 

--- a/src/device/cuda/characterize/gen.rs
+++ b/src/device/cuda/characterize/gen.rs
@@ -4,7 +4,7 @@ use device::cuda::characterize::Table;
 use device::cuda::{Context, Gpu, Kernel, PerfCounterSet};
 use device::{ArgMap, Device, ScalarArgument};
 use explorer;
-use helper::{AutoOperand, Builder, DimGroup, Reduce};
+use helper::{AutoOperand, Builder, Reduce};
 use ir::{self, Signature};
 use itertools::Itertools;
 use num::Zero;
@@ -154,19 +154,19 @@ pub fn init_stride_array<'a>(
     let (dim, addr) = if n > 1 {
         let dim = builder.open_dim_ex(size, DimKind::LOOP);
         let addr = builder.mad(&dim, &byte_stride, &array);
-        (DimGroup::new(vec![dim]), addr)
+        (Some(dim), addr)
     } else {
-        (DimGroup::default(), builder.mov(&array))
+        (None, builder.mov(&array))
     };
     let next_addr = builder.mad(&byte_stride, &1i32, &addr);
     let pattern0 = builder.unknown_access_pattern(mem_id);
     builder.st_ex(&addr, &next_addr, true, pattern0, InstFlag::MEM_CG);
-    builder.close_dim(&dim);
+    dim.as_ref().map(|dim| builder.close_dim(dim));
     let last_addr = builder.mad(&byte_stride, &(n as i32 - 1), &array);
 
     let pattern1 = builder.unknown_access_pattern(mem_id);
     builder.st_ex(&last_addr, &array, true, pattern1, InstFlag::MEM_CG);
-    builder.order(&dim, &last_addr, Order::BEFORE);
+    dim.as_ref().map(|dim| builder.order(dim, &last_addr, Order::BEFORE));
     builder.get()
 }
 
@@ -190,7 +190,7 @@ pub fn load_chain<'a>(
     let d0 = builder.open_dim_ex(loop_size, DimKind::LOOP);
     let d1 = builder.open_dim_ex(unroll_size, DimKind::UNROLL);
     if n_threads != 1 {
-        let d = builder.open_dim_ex(ir::Size::new(n_threads, vec![], 1), DimKind::THREAD);
+        let d = builder.open_dim_ex(ir::Size::new_const(n_threads), DimKind::THREAD);
         builder.order(&d, &d0, Order::OUTER);
     }
     let pattern0 = builder.unknown_access_pattern(mem_id);
@@ -285,21 +285,19 @@ pub fn parallel_load<'a>(
     for (x, y) in d1_1.iter().tuple_windows() {
         builder.order(&x, &y, Order::OUTER);
     }
-    let d3 = builder.open_dim_ex(ir::Size::new(n_chained, vec![], 1), DimKind::UNROLL);
-    let d4_0 = builder.open_dim_ex(ir::Size::new(n_unroll, vec![], 1), DimKind::UNROLL);
+    let d3 = builder.open_dim_ex(ir::Size::new_const(n_chained), DimKind::UNROLL);
+    let d4_0 = builder.open_dim_ex(ir::Size::new_const(n_unroll), DimKind::UNROLL);
     let pattern = builder.unknown_access_pattern(mem_id);
     let mut strides = vec![
         (
             d3,
-            ir::Size::new(
+            ir::Size::new_const(
                 n_unroll * num_wraps * gpu.wrap_size * gpu.l1_cache_line,
-                vec![],
-                1,
             ),
         ),
         (
             d4_0,
-            ir::Size::new(num_wraps * gpu.wrap_size * gpu.l1_cache_line, vec![], 1),
+            ir::Size::new_const(num_wraps * gpu.wrap_size * gpu.l1_cache_line),
         ),
     ];
     if stride != 0 {
@@ -308,17 +306,19 @@ pub fn parallel_load<'a>(
         } else {
             strides.push((
                 d1_1[0],
-                ir::Size::new(gpu.wrap_size * gpu.l1_cache_line, vec![], 1),
+                ir::Size::new_const(gpu.wrap_size * gpu.l1_cache_line),
             ));
             1
         };
-        strides.push((d1_1[i], ir::Size::new(stride * 4, vec![], 1)));
+        strides.push((d1_1[i], ir::Size::new_const(stride * 4)));
     };
     let addr = builder.induction_var(&array, strides);
     let val = builder.ld_ex(ir::Type::F(32), &addr, pattern, InstFlag::MEM_CG);
     let d4_1 = builder.open_mapped_dim(&d4_0)[0];
     let acc = builder.add(&val, &Reduce(init));
-    builder.close_dim(&DimGroup::new(vec![d0, d3, d4_1]));
+    builder.close_dim(&d0);
+    builder.close_dim(&d3);
+    builder.close_dim(&d4_1);
     // Write the result
     let d1_2 = builder.open_mapped_dim(&d1_1);
     for (x, y) in d1_2.iter().tuple_windows() {
@@ -358,55 +358,33 @@ pub fn parallel_store<'a>(
     let loop_size = builder.param_size(n);
     let d0 = builder.open_dim_ex(loop_size, DimKind::LOOP);
 
-    let thread_tilling = if num_wraps == 1 {
-        vec![]
+    let d1_0 = if num_wraps > 1 {
+        Some(builder.open_dim_ex(ir::Size::new_const(num_wraps), DimKind::THREAD))
     } else {
-        vec![gpu.wrap_size]
+        None
     };
-    let thread_size = builder.cst_size(num_wraps * gpu.wrap_size);
-    let d1 = builder.open_tiled_dim(thread_size, &thread_tilling);
-    for d in &d1 {
-        builder.action(Action::DimKind(d, DimKind::THREAD));
-    }
-    for (x, y) in d1.iter().tuple_windows() {
-        builder.order(&x, &y, Order::OUTER);
-    }
+    let d1_1 = builder.open_dim_ex(ir::Size::new_const(gpu.wrap_size), DimKind::THREAD);
+    builder.order(&d1_0, &d1_1, Order::OUTER);
 
-    let d3 = builder.open_dim_ex(ir::Size::new(n_chained, vec![], 1), DimKind::UNROLL);
-    let d4 = builder.open_dim_ex(ir::Size::new(n_unroll, vec![], 1), DimKind::UNROLL);
+    let d3 = builder.open_dim_ex(ir::Size::new_const(n_chained), DimKind::UNROLL);
+    let d4 = builder.open_dim_ex(ir::Size::new_const(n_unroll), DimKind::UNROLL);
     let pattern = builder.unknown_access_pattern(mem_id);
+    let wrap_stride = gpu.wrap_size * gpu.l1_cache_line;
     let mut strides = vec![
-        (
-            d3,
-            ir::Size::new(
-                n_unroll * num_wraps * gpu.wrap_size * gpu.l1_cache_line,
-                vec![],
-                1,
-            ),
-        ),
-        (
-            d4,
-            ir::Size::new(num_wraps * gpu.wrap_size * gpu.l1_cache_line, vec![], 1),
-        ),
+        (&d3, ir::Size::new_const(n_unroll * num_wraps * wrap_stride)),
+        (&d4, ir::Size::new_const(num_wraps * wrap_stride)),
+        (&d1_1, ir::Size::new_const(stride*4)),
     ];
-    if stride != 0 {
-        let i = if num_wraps == 1 {
-            0
-        } else {
-            strides.push((
-                d1[0],
-                ir::Size::new(gpu.wrap_size * gpu.l1_cache_line, vec![], 1),
-            ));
-            1
-        };
-        strides.push((d1[i], ir::Size::new(stride * 4, vec![], 1)));
-    };
+    if let Some(ref d1_0) = d1_0 {
+        strides.push((d1_0, ir::Size::new_const(wrap_stride)));
+    }
     let addr = builder.induction_var(&array, strides);
     builder.st_ex(&addr, &42f32, true, pattern, InstFlag::MEM_CG);
-    builder.close_dim(&DimGroup::new(vec![d0, d3, d4]));
 
-    builder.order(&d0, &d1, Order::OUTER);
-    builder.order(&d1, &d3, Order::OUTER);
+    builder.order(&d0, &d1_0, Order::OUTER);
+    builder.order(&d0, &d1_1, Order::OUTER);
+    builder.order(&d1_0, &d3, Order::OUTER);
+    builder.order(&d1_1, &d3, Order::OUTER);
     builder.order(&d3, &d4, Order::OUTER);
 
     builder.get()
@@ -436,7 +414,7 @@ pub fn syncthread<'a>(
     let mut kernel = builder.get();
     kernel
         .domain_mut()
-        .set_order(d1.into(), d2.into(), Order::OUTER);
+        .set_order(d1[0].into(), d2[0].into(), Order::OUTER);
     kernel
 }
 
@@ -463,12 +441,15 @@ pub fn chain_in_syncthread<'a>(
 
     let d1 = builder.open_dim_ex(loop_size, DimKind::LOOP);
     let d2 = builder.open_dim_ex(sync_unroll_size, DimKind::UNROLL);
-    let d3 = builder.open_mapped_dim(&d0)[0];
+    let d3 = builder.open_mapped_dim(&d0);
     let d4 = builder.open_dim_ex(add_unroll_size, DimKind::UNROLL);
     let acc = builder.add(&Reduce(init), &2f32);
-    builder.close_dim(&DimGroup::new(vec![d1, d2, d3, d4]));
+    builder.close_dim(&d1);
+    builder.close_dim(&d2);
+    builder.close_dim(&d3);
+    builder.close_dim(&d4);
 
-    let d5 = builder.open_mapped_dim(&d0)[0];
+    let d5 = builder.open_mapped_dim(&d0);
     let pattern = builder.unknown_access_pattern(out_id);
     builder.st_ex(&out, &acc, true, pattern, InstFlag::MEM_CG);
 
@@ -477,13 +458,13 @@ pub fn chain_in_syncthread<'a>(
     builder.order(&d2, &d4, Order::OUTER);
     builder.order(&d0, &d1, Order::BEFORE);
     builder.order(&d1, &d5, Order::BEFORE);
-    builder.action(Action::ThreadMapping(d0, d3, ThreadMapping::MAPPED));
-    builder.action(Action::ThreadMapping(d0, d5, ThreadMapping::MAPPED));
+    builder.action(Action::ThreadMapping(d0[0], d3[0], ThreadMapping::MAPPED));
+    builder.action(Action::ThreadMapping(d0[0], d5[0], ThreadMapping::MAPPED));
 
     let mut kernel = builder.get();
     kernel
         .domain_mut()
-        .set_order(d1.into(), d2.into(), Order::OUTER);
+        .set_order(d1[0].into(), d2[0].into(), Order::OUTER);
     kernel
 }
 
@@ -514,21 +495,19 @@ pub fn load_in_loop<'a>(
     let (addr, pattern) = builder.tensor_access(
         &tmp_mem,
         tmp_mem.into(),
-        &ir::Type::F(32),
+        ir::Type::F(32),
         &[&thread_dim_1_0, &unroll_dim_a],
     );
     let a_val = builder.ld_ex(ir::Type::F(32), &addr, pattern, InstFlag::MEM_CG);
     builder.close_dim(&unroll_dim_a);
     // Mad a and b
     let unroll_dims_1 = builder.open_mapped_dim(&unroll_dim_0_0);
-    let a_dim_map = ir::dim::Map::new(vec![(unroll_dim_a, unroll_dims_1[0])]);
-    let a_op =
-        ir::Operand::Inst(a_val, ir::Type::F(32), a_dim_map, ir::DimMapScope::Thread);
+    let a_op = builder.dim_map(a_val, &[(&unroll_dim_a, &unroll_dims_1)], ir::DimMapScope::Thread);
     let acc = builder.mad(&a_op, &2f32, &Reduce(acc_init));
     builder.close_dim(&k_dim);
 
     let _ = builder.open_mapped_dim(&unroll_dims_1);
-    let (addr, pattern) = builder.tensor_access(&out, out_id, &ir::Type::F(32), &[]);
+    let (addr, pattern) = builder.tensor_access(&out, out_id, ir::Type::F(32), &[]);
     let _ = builder.st_ex(&addr, &acc, true, pattern, InstFlag::MEM_CS);
 
     builder.order(&k_dim, &thread_dim_1_0, Order::INNER);

--- a/src/device/cuda/mem_model.rs
+++ b/src/device/cuda/mem_model.rs
@@ -485,17 +485,15 @@ mod tests {
         let d0 = builder.open_dim_ex(size.clone(), DimKind::THREAD);
         let d1 = builder.open_dim_ex(size.clone(), DimKind::THREAD);
         let addr = builder.mad(&d0, &(gpu.l1_cache_line as i32), &addr_base);
-        let stride = ir::Size::new(gpu.l1_cache_line, vec![], 1);
-        let pattern = ir::AccessPattern::Tensor {
-            mem_id: ir::MemId::External(0),
-            dims: std::iter::once((d0, stride)).collect(),
-        };
+        let stride = ir::Size::new_const(gpu.l1_cache_line);
+        let mem = ir::MemId::External(0);
+        let pattern = builder.tensor_access_pattern(mem, vec![(&d0, stride)]);
         let ld = builder.ld_ex(t, &addr, pattern, InstFlag::MEM_CG);
         builder.order(&d0, &d1, d0_d1_order);
 
         let mut size_map = HashMap::default();
-        size_map.insert(d0, gpu.wrap_size as u32);
-        size_map.insert(d1, gpu.wrap_size as u32);
+        size_map.insert(d0[0], gpu.wrap_size as u32);
+        size_map.insert(d1[0], gpu.wrap_size as u32);
         (builder.get(), ld, size_map)
     }
 

--- a/src/device/cuda/mem_model.rs
+++ b/src/device/cuda/mem_model.rs
@@ -87,7 +87,7 @@ fn unknown_info(is_shared_access: Trivalent, gpu: &cuda::Gpu) -> MemInfo {
 fn info(
     space: &SearchSpace,
     inst: &ir::Instruction,
-    dims: &HashMap<ir::DimId, ir::Size>,
+    dims: &HashMap<ir::DimId, ir::PartialSize>,
     is_shared_access: Trivalent,
     gpu: &cuda::Gpu,
     sizes: &HashMap<ir::DimId, u32>,
@@ -145,7 +145,7 @@ struct ThreadDimInfo {
 fn tensor_thread_dims(
     space: &SearchSpace,
     inst: &ir::Instruction,
-    tensor_dims: &HashMap<ir::DimId, ir::Size>,
+    tensor_dims: &HashMap<ir::DimId, ir::PartialSize>,
     sizes: &HashMap<ir::DimId, u32>,
     gpu: &cuda::Gpu,
     ctx: &Context,
@@ -289,7 +289,7 @@ fn wrap_access_offsets(thread_dims: &[ThreadDimInfo], gpu: &cuda::Gpu) -> Vec<u6
 /// Computes the replay factor for a shared memory access.
 fn shared_replay_factor(
     offsets: &[u64],
-    tensor_dims: &HashMap<ir::DimId, ir::Size>,
+    tensor_dims: &HashMap<ir::DimId, ir::PartialSize>,
     dim_sizes: &HashMap<ir::DimId, u32>,
     space: &SearchSpace,
     gpu: &cuda::Gpu,

--- a/src/helper/builder.rs
+++ b/src/helper/builder.rs
@@ -445,10 +445,12 @@ impl<'a> Builder<'a> {
     }
 
     /// Returns a reference to the function being built.
-    pub(super) fn function(&self) -> &ir::Function<'a, ()> { &self.function }
+    pub(super) fn function(&self) -> &ir::Function<'a, ()> {
+        &self.function
+    }
 
     /// Returns the list of open dimensions with the dimensions they are mapped to.
-    pub(super) fn open_dims(&self) -> impl Iterator<Item=(ir::DimId, ir::DimId)> + '_ {
+    pub(super) fn open_dims(&self) -> impl Iterator<Item = (ir::DimId, ir::DimId)> + '_ {
         self.open_dims.iter().map(|(&new, &old)| (new, old))
     }
 }

--- a/src/helper/builder.rs
+++ b/src/helper/builder.rs
@@ -249,10 +249,10 @@ impl<'a> Builder<'a> {
         // TODO(strip-mining): allow multiple tile size for each level.
         let tiling_factors = vec![tile_sizes.iter().product()];
         let (logical_id, real_ids) = unwrap!(self.function.add_logical_dim(
-                size.clone(),
-                tiling_factors.clone(),
-                tile_sizes,
-                ));
+            size.clone(),
+            tiling_factors.clone(),
+            tile_sizes,
+        ));
         self.open_dims.extend(real_ids.iter().map(|&id| (id, id)));
         LogicalDim {
             logical_id,
@@ -268,13 +268,16 @@ impl<'a> Builder<'a> {
     pub fn open_mapped_dim(&mut self, old_dim: &LogicalDim) -> LogicalDim {
         let (size, tiling_factors) = {
             let old_dim = self.function.logical_dim(old_dim.id());
-            (old_dim.total_size().clone(), old_dim.possible_tilings().to_vec())
+            (
+                old_dim.total_size().clone(),
+                old_dim.possible_tilings().to_vec(),
+            )
         };
         let (new_id, new_dims) = unwrap!(self.function.add_logical_dim(
-                size.clone(),
-                tiling_factors.clone(),
-                &old_dim.tile_sizes,
-                ));
+            size.clone(),
+            tiling_factors.clone(),
+            &old_dim.tile_sizes,
+        ));
         for (old, &new) in old_dim.iter().zip_eq(&new_dims) {
             self.open_dims.remove(&old);
             self.open_dims.insert(new, old);
@@ -394,11 +397,14 @@ impl<'a> Builder<'a> {
             .into_iter()
             .flat_map(|(dim, size)| {
                 let mut size: ir::PartialSize = size.into();
-                self.function.logical_dim(dim.id()).dimensions().map(move |dim| {
-                    let increment = size.clone();
-                    size *= self.function.dim(dim).size();
-                    (dim, increment)
-                })
+                self.function
+                    .logical_dim(dim.id())
+                    .dimensions()
+                    .map(move |dim| {
+                        let increment = size.clone();
+                        size *= self.function.dim(dim).size();
+                        (dim, increment)
+                    })
             })
             .collect()
     }
@@ -407,7 +413,7 @@ impl<'a> Builder<'a> {
     fn tensor_increments<'b>(
         &self,
         t: ir::Type,
-        dims: &[&'b LogicalDim]
+        dims: &[&'b LogicalDim],
     ) -> Vec<(&'b LogicalDim, ir::Size<'a>)> {
         let data_size = ir::Size::new_const(unwrap!(t.len_byte()));
         dims.into_iter()

--- a/src/helper/builder.rs
+++ b/src/helper/builder.rs
@@ -224,17 +224,15 @@ impl<'a> Builder<'a> {
     }
 
     /// Opens a new dimension.
-    pub fn open_dim(&mut self, size: ir::Size<'a>) -> ir::DimId {
-        let id = unwrap!(self.function.add_dim(size));
-        self.open_dims.insert(id, id);
-        id
+    pub fn open_dim(&mut self, size: ir::Size<'a>) -> LogicalDim {
+        self.open_tiled_dim(size, &[])
     }
 
     /// Opens a nest of new dimension with the given kinds and sizes.
-    pub fn open_dim_ex(&mut self, size: ir::Size<'a>, kind: DimKind) -> ir::DimId {
-        let id = self.open_dim(size);
-        self.actions.push(Action::DimKind(id, kind));
-        id
+    pub fn open_dim_ex(&mut self, size: ir::Size<'a>, kind: DimKind) -> LogicalDim {
+        let dim = self.open_dim(size);
+        self.actions.push(Action::DimKind(dim[0], kind));
+        dim
     }
 
     /// Open multiple dimensions to represent a tiled dimension.

--- a/src/helper/builder.rs
+++ b/src/helper/builder.rs
@@ -242,8 +242,8 @@ impl<'a> Builder<'a> {
         // TODO(strip-mining): allow multiple tile size for each level.
         let tiling_factors = vec![tile_sizes.iter().product()];
         let (logical_id, real_ids) = unwrap!(self.function.add_logical_dim(
-            size.clone(),
-            tiling_factors.clone(),
+            size,
+            tiling_factors,
             tile_sizes,
         ));
         self.open_dims.extend(real_ids.iter().map(|&id| (id, id)));

--- a/src/helper/builder.rs
+++ b/src/helper/builder.rs
@@ -38,8 +38,8 @@ impl<'a> Builder<'a> {
     }
 
     /// Returns an operand from an `AutoOperand`.
-    fn get_op<'b: 'a>(&self, op: &AutoOperand<'b>) -> Operand<'a, ()> {
-        op.get(&self.function, &self.open_dims)
+    fn get_op<'b: 'a>(&mut self, op: &AutoOperand<'b>) -> Operand<'a, ()> {
+        op.get(self)
     }
 
     /// Creates a binary operator.
@@ -195,11 +195,6 @@ impl<'a> Builder<'a> {
     pub fn cast<'b: 'a>(&mut self, val: &AutoOperand<'b>, t: Type) -> InstId {
         let val_op = self.get_op(val);
         self.inst(op::Cast(val_op, t))
-    }
-
-    /// Returns the type of an operand.
-    pub fn type_of<'b: 'a>(&self, op: &AutoOperand<'b>) -> ir::Type {
-        self.get_op(op).t()
     }
 
     /// Restricts the order between two basic blocks. Does not restricts LINK and NPACK
@@ -447,6 +442,14 @@ impl<'a> Builder<'a> {
                 .iter()
                 .find(|p| p.name == param)
         )
+    }
+
+    /// Returns a reference to the function being built.
+    pub(super) fn function(&self) -> &ir::Function<'a, ()> { &self.function }
+
+    /// Returns the list of open dimensions with the dimensions they are mapped to.
+    pub(super) fn open_dims(&self) -> impl Iterator<Item=(ir::DimId, ir::DimId)> + '_ {
+        self.open_dims.iter().map(|(&new, &old)| (new, old))
     }
 }
 

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -56,15 +56,15 @@ pub trait MetaStatement {
     fn ids(&self) -> Box<Iterator<Item = ir::BBId> + '_>;
 }
 
-impl MetaStatement for ir::BBId {
+impl<T> MetaStatement for T where T: Into<ir::BBId> + Copy {
     fn ids(&self) -> Box<Iterator<Item = ir::BBId> + '_> {
-        Box::new(std::iter::once(*self))
+        Box::new(std::iter::once((*self).into()))
     }
 }
 
-impl MetaStatement for ir::InstId {
+impl MetaStatement for Option<LogicalDim> {
     fn ids(&self) -> Box<Iterator<Item = ir::BBId> + '_> {
-        Box::new(std::iter::once((*self).into()))
+        Box::new(self.iter().flat_map(|dim| dim.ids()))
     }
 }
 

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -12,82 +12,41 @@ pub use self::signature::Builder as SignatureBuilder;
 use ir;
 use std;
 
-/// A logical dimension, possible composed of multiple nested dimensions.
-pub trait MetaDimension {
-    /// Returns the ids of the underlying dimensions.
-    fn ids(&self) -> Box<DoubleEndedIterator<Item = ir::DimId> + '_>;
-}
-
-impl MetaDimension for ir::DimId {
-    fn ids(&self) -> Box<DoubleEndedIterator<Item = ir::DimId> + '_> {
-        Box::new(std::iter::once(*self))
-    }
-}
-
-impl<T> MetaDimension for T
-where
-    T: std::borrow::Borrow<[ir::DimId]>,
-{
-    fn ids(&self) -> Box<DoubleEndedIterator<Item = ir::DimId> + '_> {
-        Box::new(self.borrow().iter().cloned())
-    }
-}
-
 /// A groups of dimensions that act as a single logical dimension.
 #[derive(Clone)]
-pub enum LogicalDim<'a> {
-    /// A single concrete dimension.
-    Simple(ir::DimId),
-    /// Multiple dimensions forming a single logical once.
-    Composite {
-        id: ir::LogicalDimId,
-        dims: Vec<ir::DimId>,
-        size: ir::Size<'a>,
-        tiling_factors: Vec<u32>,
-        // TODO(strip-minig): remove this parameter once we enable unconstrained tile sizes.
-        tile_sizes: Vec<u32>,
-    },
+pub struct LogicalDim {
+    logical_id: ir::LogicalDimId,
+    real_ids: Vec<ir::DimId>,
+    // TODO(strip-minig): remove this parameter once we enable unconstrained tile sizes.
+    tile_sizes: Vec<u32>,
 }
 
-impl<'b> LogicalDim<'b> {
-    pub fn iter(&self) -> Box<DoubleEndedIterator<Item = ir::DimId> + '_> {
+impl LogicalDim {
+    /// Iterates on the reals IDs, from the outermost to the innermost.
+    pub fn iter(&self) -> impl Iterator<Item=ir::DimId> + '_ {
         self.into_iter()
     }
-}
 
-impl From<ir::DimId> for LogicalDim<'static> {
-    fn from(id: ir::DimId) -> Self {
-        LogicalDim::Simple(id)
+    /// Returns the id of the logical dimension.
+    pub fn id(&self) -> ir::LogicalDimId {
+        self.logical_id
     }
 }
 
-impl<'b> MetaDimension for LogicalDim<'b> {
-    fn ids(&self) -> Box<DoubleEndedIterator<Item = ir::DimId> + '_> {
-        self.into_iter()
-    }
-}
-
-impl<'a> std::ops::Index<usize> for LogicalDim<'a> {
+impl std::ops::Index<usize> for LogicalDim {
     type Output = ir::DimId;
 
     fn index(&self, index: usize) -> &ir::DimId {
-        match self {
-            LogicalDim::Simple(id) if index == 0 => id,
-            LogicalDim::Simple(_) => panic!("out of bounds index {}", index),
-            LogicalDim::Composite { dims, .. } => &dims[index],
-        }
+        &self.real_ids[index]
     }
 }
 
-impl<'a> IntoIterator for &'a LogicalDim<'a> {
+impl<'a> IntoIterator for &'a LogicalDim {
     type Item = ir::DimId;
-    type IntoIter = Box<DoubleEndedIterator<Item = ir::DimId> + 'a>;
+    type IntoIter = std::iter::Cloned<std::slice::Iter<'a, ir::DimId>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        match self {
-            LogicalDim::Simple(dim) => Box::new(std::iter::once(*dim)),
-            LogicalDim::Composite { dims, .. } => Box::new(dims.iter().cloned()),
-        }
+        self.real_ids.iter().cloned()
     }
 }
 
@@ -109,11 +68,8 @@ impl MetaStatement for ir::InstId {
     }
 }
 
-impl<T> MetaStatement for T
-where
-    T: MetaDimension,
-{
+impl MetaStatement for LogicalDim {
     fn ids(&self) -> Box<Iterator<Item = ir::BBId> + '_> {
-        Box::new(MetaDimension::ids(self).map(|x| x.into()))
+        Box::new(self.iter().map(|id| id.into()))
     }
 }

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -23,7 +23,7 @@ pub struct LogicalDim {
 
 impl LogicalDim {
     /// Iterates on the reals IDs, from the outermost to the innermost.
-    pub fn iter(&self) -> impl Iterator<Item=ir::DimId> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = ir::DimId> + '_ {
         self.into_iter()
     }
 

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -56,7 +56,10 @@ pub trait MetaStatement {
     fn ids(&self) -> Box<Iterator<Item = ir::BBId> + '_>;
 }
 
-impl<T> MetaStatement for T where T: Into<ir::BBId> + Copy {
+impl<T> MetaStatement for T
+where
+    T: Into<ir::BBId> + Copy,
+{
     fn ids(&self) -> Box<Iterator<Item = ir::BBId> + '_> {
         Box::new(std::iter::once((*self).into()))
     }

--- a/src/helper/operand.rs
+++ b/src/helper/operand.rs
@@ -66,7 +66,12 @@ impl<'a, 'c> AutoOperand<'a> for &'c str {
         'a: 'b,
     {
         Param(unwrap!(
-            builder.function().signature().params.iter().find(|p| p.name == *self)
+            builder
+                .function()
+                .signature()
+                .params
+                .iter()
+                .find(|p| p.name == *self)
         ))
     }
 }

--- a/src/helper/operand.rs
+++ b/src/helper/operand.rs
@@ -1,17 +1,13 @@
 //! Provides helpers to create instruction operands.
 use device::ScalarArgument;
+use helper::{Builder, LogicalDim};
 use ir::Operand::*;
-use ir::{self, dim, mem, Function, InstId, Operand};
-use utils::*;
+use ir::{self, dim, mem, InstId, Operand};
 
 /// Represents values that can be turned into an `Operand`.
-pub trait AutoOperand<'a, L = ()> {
+pub trait AutoOperand<'a> {
     /// Returns the corresponding `Operand`.
-    fn get<'b>(
-        &self,
-        fun: &Function<'b, L>,
-        active_dims: &HashMap<ir::DimId, ir::DimId>,
-    ) -> Operand<'b, L>
+    fn get<'b>(&self, builder: &mut Builder<'b>) -> Operand<'b, ()>
     where
         'a: 'b;
 }
@@ -22,19 +18,15 @@ pub struct Reduce(pub InstId);
 /// Helper to build dim maps that can be lowered to temporary memory.
 pub struct TmpArray(pub InstId);
 
-impl<'a, L> AutoOperand<'a, L> for Reduce {
-    fn get<'b>(
-        &self,
-        fun: &Function<'b, L>,
-        active_dims: &HashMap<ir::DimId, ir::DimId>,
-    ) -> Operand<'b, L>
+impl<'a> AutoOperand<'a> for Reduce {
+    fn get<'b>(&self, builder: &mut Builder<'b>) -> Operand<'b, ()>
     where
         'a: 'b,
     {
-        let inst = fun.inst(self.0);
+        let inst = builder.function().inst(self.0);
         let mut mapped_dims = Vec::new();
         let mut reduce_dims = Vec::new();
-        for (&new_dim, &old_dim) in active_dims {
+        for (new_dim, old_dim) in builder.open_dims() {
             if inst.iteration_dims().contains(&old_dim) {
                 if old_dim != new_dim {
                     mapped_dims.push((old_dim, new_dim));
@@ -47,12 +39,8 @@ impl<'a, L> AutoOperand<'a, L> for Reduce {
     }
 }
 
-impl<'a> AutoOperand<'a, ()> for Operand<'a, ()> {
-    fn get<'b>(
-        &self,
-        _: &Function<'b, ()>,
-        _: &HashMap<ir::DimId, ir::DimId>,
-    ) -> Operand<'b, ()>
+impl<'a> AutoOperand<'a> for Operand<'a, ()> {
+    fn get<'b>(&self, _: &mut Builder<'b>) -> Operand<'b, ()>
     where
         'a: 'b,
     {
@@ -60,15 +48,11 @@ impl<'a> AutoOperand<'a, ()> for Operand<'a, ()> {
     }
 }
 
-impl<'a, T, L> AutoOperand<'a, L> for T
+impl<'a, T> AutoOperand<'a> for T
 where
     T: ScalarArgument,
 {
-    fn get<'b>(
-        &self,
-        _: &Function<'b, L>,
-        _: &HashMap<ir::DimId, ir::DimId>,
-    ) -> Operand<'b, L>
+    fn get<'b>(&self, _: &mut Builder<'b>) -> Operand<'b, ()>
     where
         'a: 'b,
     {
@@ -76,32 +60,24 @@ where
     }
 }
 
-impl<'a, 'c, L> AutoOperand<'a, L> for &'c str {
-    fn get<'b>(
-        &self,
-        fun: &Function<'b, L>,
-        _: &HashMap<ir::DimId, ir::DimId>,
-    ) -> Operand<'b, L>
+impl<'a, 'c> AutoOperand<'a> for &'c str {
+    fn get<'b>(&self, builder: &mut Builder<'b>) -> Operand<'b, ()>
     where
         'a: 'b,
     {
         Param(unwrap!(
-            fun.signature().params.iter().find(|p| p.name == *self)
+            builder.function().signature().params.iter().find(|p| p.name == *self)
         ))
     }
 }
 
-impl<'a> AutoOperand<'a, ()> for InstId {
-    fn get<'b>(
-        &self,
-        fun: &Function<'b, ()>,
-        active_dims: &HashMap<ir::DimId, ir::DimId>,
-    ) -> Operand<'b, ()>
+impl<'a> AutoOperand<'a> for InstId {
+    fn get<'b>(&self, builder: &mut Builder<'b>) -> Operand<'b, ()>
     where
         'a: 'b,
     {
-        let inst = fun.inst(*self);
-        let mapped_dims = active_dims.iter().flat_map(|(&new_dim, &old_dim)| {
+        let inst = builder.function().inst(*self);
+        let mapped_dims = builder.open_dims().flat_map(|(new_dim, old_dim)| {
             if new_dim != old_dim && inst.iteration_dims().contains(&old_dim) {
                 Some((old_dim, new_dim))
             } else {
@@ -112,17 +88,13 @@ impl<'a> AutoOperand<'a, ()> for InstId {
     }
 }
 
-impl<'a> AutoOperand<'a, ()> for TmpArray {
-    fn get<'b>(
-        &self,
-        fun: &Function<'b, ()>,
-        active_dims: &HashMap<ir::DimId, ir::DimId>,
-    ) -> Operand<'b, ()>
+impl<'a> AutoOperand<'a> for TmpArray {
+    fn get<'b>(&self, builder: &mut Builder<'b>) -> Operand<'b, ()>
     where
         'a: 'b,
     {
-        let inst = fun.inst(self.0);
-        let mapped_dims = active_dims.iter().flat_map(|(&new_dim, &old_dim)| {
+        let inst = builder.function().inst(self.0);
+        let mapped_dims = builder.open_dims().flat_map(|(new_dim, old_dim)| {
             if new_dim != old_dim && inst.iteration_dims().contains(&old_dim) {
                 Some((old_dim, new_dim))
             } else {
@@ -137,12 +109,8 @@ impl<'a> AutoOperand<'a, ()> for TmpArray {
     }
 }
 
-impl<'a, L> AutoOperand<'a, L> for mem::InternalId {
-    fn get<'b>(
-        &self,
-        _: &Function<'b, L>,
-        _: &HashMap<ir::DimId, ir::DimId>,
-    ) -> Operand<'b, L>
+impl<'a> AutoOperand<'a> for mem::InternalId {
+    fn get<'b>(&self, _: &mut Builder<'b>) -> Operand<'b, ()>
     where
         'a: 'b,
     {
@@ -150,28 +118,27 @@ impl<'a, L> AutoOperand<'a, L> for mem::InternalId {
     }
 }
 
-impl<'a, L> AutoOperand<'a, L> for ir::DimId {
-    fn get<'b>(
-        &self,
-        _: &Function<'b, L>,
-        _: &HashMap<ir::DimId, ir::DimId>,
-    ) -> Operand<'b, L>
+impl<'a> AutoOperand<'a> for LogicalDim {
+    fn get<'b>(&self, builder: &mut Builder<'b>) -> Operand<'b, ()>
     where
         'a: 'b,
     {
-        Operand::Index(*self)
+        if self.real_ids.len() == 1 {
+            Operand::Index(self[0])
+        } else {
+            let one = ir::Size::new_const(1);
+            let ind_var = builder.induction_var(&0i32, vec![(self, one)]);
+            ind_var.get(builder)
+        }
     }
 }
 
-impl<'a, L> AutoOperand<'a, L> for ir::IndVarId {
-    fn get<'b>(
-        &self,
-        fun: &Function<'b, L>,
-        _: &HashMap<ir::DimId, ir::DimId>,
-    ) -> Operand<'b, L>
+impl<'a> AutoOperand<'a> for ir::IndVarId {
+    fn get<'b>(&self, builder: &mut Builder<'b>) -> Operand<'b, ()>
     where
         'a: 'b,
     {
-        Operand::InductionVar(*self, fun.induction_var(*self).base().t())
+        let t = builder.function().induction_var(*self).base().t();
+        Operand::InductionVar(*self, t)
     }
 }

--- a/src/helper/tensor.rs
+++ b/src/helper/tensor.rs
@@ -178,21 +178,20 @@ where
     }
 
     /// Creates a `VirtualTensor` that contains the values of `self`, loaded in registers.
-    pub fn load(
-        &self,
-        tiling: &[&[u32]],
-        builder: &mut Builder,
-    ) -> VirtualTensor {
-        let dims = self.iter_dims
+    pub fn load(&self, tiling: &[&[u32]], builder: &mut Builder) -> VirtualTensor {
+        let dims = self
+            .iter_dims
             .iter()
             .zip_eq(tiling)
             .map(|((size, _), tiling)| {
                 let size = size.into_ir_size(builder);
                 builder.open_tiled_dim(size, tiling)
-            }).collect_vec();
+            })
+            .collect_vec();
         let (ptr, pattern);
         {
-            let increments = dims.iter()
+            let increments = dims
+                .iter()
                 .zip_eq(&self.iter_dims)
                 .map(|(dim, (_, stride))| (dim, stride.into_ir_size(builder)))
                 .collect_vec();
@@ -251,21 +250,13 @@ impl VirtualTensor {
         scope: ir::DimMapScope<()>,
         builder: &mut Builder<'a>,
     ) -> ir::Operand<'a, ()> {
-        let mapping = self
-            .dims
-            .iter()
-            .zip_eq(dims.iter().cloned())
-            .collect_vec();
+        let mapping = self.dims.iter().zip_eq(dims.iter().cloned()).collect_vec();
         builder.dim_map(self.inst, &mapping, scope)
     }
 
     /// Stores the `VirtualTensor` in memory. Stores contiguously without taking the
     /// layout of the target tensor into account.
-    pub fn store<S>(
-        &self,
-        tensor: &Tensor<S>,
-        builder: &mut Builder,
-    ) -> VirtualTensor
+    pub fn store<S>(&self, tensor: &Tensor<S>, builder: &mut Builder) -> VirtualTensor
     where
         S: ScalarArgument,
     {

--- a/src/helper/tensor.rs
+++ b/src/helper/tensor.rs
@@ -19,7 +19,7 @@ impl<'a> DimSize<'a> {
     /// Convert the size into the size type used by the IR.
     pub fn into_ir_size<'b>(&self, builder: &Builder<'b>) -> ir::Size<'b> {
         let params = self.params.iter().map(|p| builder.find_param(p)).collect();
-        ir::Size::new(self.factor, params, 1)
+        ir::Size::new(self.factor, params)
     }
 
     /// Converts the size into a numerical value for a given context.
@@ -188,7 +188,7 @@ where
         for (&(ref size, ref stride), tiling) in self.iter_dims.iter().zip_eq(tiling) {
             let size = size.into_ir_size(builder);
             let dim = builder.open_tiled_dim(size, tiling);
-            let mut stride = stride.into_ir_size(builder);
+            let mut stride: ir::PartialSize = stride.into_ir_size(builder).into();
             for (d, &t) in dim.ids().rev().zip(tiling.iter().rev()) {
                 induction_levels.push((d, stride.clone()));
                 stride.mul_factor(t);

--- a/src/helper/tensor.rs
+++ b/src/helper/tensor.rs
@@ -1,6 +1,6 @@
 //! Utilities to allocate and operate on tensors.
 use device::{read_array, ArgMap, ArrayArgument, Context, ScalarArgument};
-use helper::{Builder, LogicalDim, MetaDimension, SignatureBuilder};
+use helper::{Builder, LogicalDim, SignatureBuilder};
 use ir;
 use itertools::Itertools;
 use ndarray::{self, ArrayD};
@@ -178,35 +178,33 @@ where
     }
 
     /// Creates a `VirtualTensor` that contains the values of `self`, loaded in registers.
-    pub fn load<'b>(
+    pub fn load(
         &self,
         tiling: &[&[u32]],
-        builder: &mut Builder<'b>,
-    ) -> VirtualTensor<'b> {
-        let mut dims = Vec::new();
-        let mut induction_levels = Vec::new();
-        for (&(ref size, ref stride), tiling) in self.iter_dims.iter().zip_eq(tiling) {
-            let size = size.into_ir_size(builder);
-            let dim = builder.open_tiled_dim(size, tiling);
-            let mut stride: ir::PartialSize = stride.into_ir_size(builder).into();
-            for (d, &t) in dim.ids().rev().zip(tiling.iter().rev()) {
-                induction_levels.push((d, stride.clone()));
-                stride.mul_factor(t);
-            }
-            induction_levels.push((dim[0], stride));
-            dims.push(dim);
-        }
-        let pat = ir::AccessPattern::Tensor {
-            mem_id: self.mem_id,
-            dims: induction_levels.iter().cloned().collect(),
+        builder: &mut Builder,
+    ) -> VirtualTensor {
+        let dims = self.iter_dims
+            .iter()
+            .zip_eq(tiling)
+            .map(|((size, _), tiling)| {
+                let size = size.into_ir_size(builder);
+                builder.open_tiled_dim(size, tiling)
+            }).collect_vec();
+        let (ptr, pattern);
+        {
+            let increments = dims.iter()
+                .zip_eq(&self.iter_dims)
+                .map(|(dim, (_, stride))| (dim, stride.into_ir_size(builder)))
+                .collect_vec();
+            ptr = builder.induction_var(&self.name, increments.clone());
+            pattern = builder.tensor_access_pattern(self.mem_id, increments);
         };
-        let ptr = builder.induction_var(&self.name, induction_levels);
         let flag = if self.read_only {
             InstFlag::ALL
         } else {
             InstFlag::MEM_COHERENT
         };
-        let inst = builder.ld_ex(S::t(), &ptr, pat, flag);
+        let inst = builder.ld_ex(S::t(), &ptr, pattern, flag);
         for dim in &dims {
             builder.close_dim(dim);
         }
@@ -235,39 +233,39 @@ where
 }
 
 /// A tensor loaded in registers.
-pub struct VirtualTensor<'a> {
+pub struct VirtualTensor {
     inst: ir::InstId,
-    dims: Vec<LogicalDim<'a>>,
+    dims: Vec<LogicalDim>,
 }
 
-impl<'a> VirtualTensor<'a> {
+impl VirtualTensor {
     /// Creates a new `VirtualTensor`.
-    pub fn new(inst: ir::InstId, dims: Vec<LogicalDim<'a>>) -> Self {
+    pub fn new(inst: ir::InstId, dims: Vec<LogicalDim>) -> Self {
         VirtualTensor { inst, dims }
     }
 
     /// Creates an operand that yeilds the values of the tensor in the given loop nest.
-    pub fn dim_map(
+    pub fn dim_map<'a>(
         &self,
-        dims: &[&MetaDimension],
+        dims: &[&LogicalDim],
         scope: ir::DimMapScope<()>,
         builder: &mut Builder<'a>,
     ) -> ir::Operand<'a, ()> {
         let mapping = self
             .dims
             .iter()
-            .map(|x| x as &MetaDimension)
             .zip_eq(dims.iter().cloned())
             .collect_vec();
         builder.dim_map(self.inst, &mapping, scope)
     }
 
-    /// Stores the `VirtualTensor` in memory.
+    /// Stores the `VirtualTensor` in memory. Stores contiguously without taking the
+    /// layout of the target tensor into account.
     pub fn store<S>(
         &self,
         tensor: &Tensor<S>,
-        builder: &mut Builder<'a>,
-    ) -> VirtualTensor<'a>
+        builder: &mut Builder,
+    ) -> VirtualTensor
     where
         S: ScalarArgument,
     {
@@ -278,8 +276,8 @@ impl<'a> VirtualTensor<'a> {
             .map(|dim| builder.open_mapped_dim(dim))
             .collect_vec();
         let (ptr, pat) = {
-            let dims = new_dims.iter().map(|d| d as &MetaDimension).collect_vec();
-            builder.tensor_access(&tensor.name, tensor.mem_id, &S::t(), &dims)
+            let new_dims = new_dims.iter().collect_vec();
+            builder.tensor_access(&tensor.name, tensor.mem_id, S::t(), &new_dims)
         };
         let inst = builder.st(&ptr, &self.inst, pat);
         for dim in &new_dims {
@@ -297,17 +295,17 @@ impl<'a> VirtualTensor<'a> {
     }
 }
 
-impl<'a> std::ops::Index<usize> for VirtualTensor<'a> {
-    type Output = LogicalDim<'a>;
+impl std::ops::Index<usize> for VirtualTensor {
+    type Output = LogicalDim;
 
     fn index(&self, idx: usize) -> &Self::Output {
         &self.dims[idx]
     }
 }
 
-impl<'a, 'b> IntoIterator for &'a VirtualTensor<'b> {
-    type Item = &'a LogicalDim<'b>;
-    type IntoIter = std::slice::Iter<'a, LogicalDim<'b>>;
+impl<'a> IntoIterator for &'a VirtualTensor {
+    type Item = &'a LogicalDim;
+    type IntoIter = std::slice::Iter<'a, LogicalDim>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.dims.iter()

--- a/src/ir/access_pattern.rs
+++ b/src/ir/access_pattern.rs
@@ -19,7 +19,7 @@ pub enum AccessPattern<'a> {
     /// dimensions should not overlap.
     Tensor {
         mem_id: ir::MemId,
-        dims: HashMap<ir::DimId, ir::Size<'a>>,
+        dims: HashMap<ir::DimId, ir::PartialSize<'a>>,
     },
 }
 

--- a/src/ir/dimension.rs
+++ b/src/ir/dimension.rs
@@ -189,7 +189,19 @@ impl<'a> LogicalDim<'a> {
         &self.possible_tilings
     }
 
+    /// Returns all the dimensions constituing the logical dimension, from the inner-most
+    /// to the outer-most.
+    pub fn dimensions(&self) -> impl Iterator<Item = DimId> + '_ {
+        self.static_dims
+            .iter()
+            .rev()
+            .cloned()
+            .chain(self.nonstatic_dim)
+    }
+
     /// Returns the size of the logical dimension, i.e. the product of the sizes of its
     /// dimensions.
-    pub fn total_size(&self) -> &ir::Size<'a> { &self.total_size }
+    pub fn total_size(&self) -> &ir::Size<'a> {
+        &self.total_size
+    }
 }

--- a/src/ir/dimension.rs
+++ b/src/ir/dimension.rs
@@ -127,14 +127,15 @@ pub struct LogicalDimId(pub u32);
 
 /// A logic dimension composed of multiple `Dimension`s.
 #[derive(Clone, Debug)]
-pub struct LogicalDim {
+pub struct LogicalDim<'a> {
     id: LogicalDimId,
     static_dims: Vec<DimId>,
     nonstatic_dim: Option<DimId>,
     possible_tilings: Vec<u32>,
+    total_size: ir::Size<'a>,
 }
 
-impl LogicalDim {
+impl<'a> LogicalDim<'a> {
     /// Creates a new logical dimension, composed only of static dimensions.
     pub fn new_static(
         id: LogicalDimId,
@@ -146,6 +147,7 @@ impl LogicalDim {
             static_dims,
             nonstatic_dim: None,
             possible_tilings: vec![total_size],
+            total_size: ir::Size::new_const(total_size),
         }
     }
 
@@ -156,12 +158,14 @@ impl LogicalDim {
         dynamic_dim: DimId,
         static_dims: Vec<DimId>,
         possible_tilings: Vec<u32>,
+        total_size: ir::Size<'a>,
     ) -> Self {
         LogicalDim {
             id,
             static_dims,
             nonstatic_dim: Some(dynamic_dim),
             possible_tilings,
+            total_size,
         }
     }
 
@@ -184,4 +188,8 @@ impl LogicalDim {
     pub fn possible_tilings(&self) -> &[u32] {
         &self.possible_tilings
     }
+
+    /// Returns the size of the logical dimension, i.e. the product of the sizes of its
+    /// dimensions.
+    pub fn total_size(&self) -> &ir::Size<'a> { &self.total_size }
 }

--- a/src/ir/dimension.rs
+++ b/src/ir/dimension.rs
@@ -25,7 +25,7 @@ impl fmt::Display for DimId {
 #[derive(Clone, Debug)]
 pub struct Dimension<'a> {
     id: DimId,
-    size: ir::Size<'a>,
+    size: ir::PartialSize<'a>,
     possible_sizes: Vec<u32>,
     iterated: Vec<ir::InstId>,
     is_thread_dim: bool,
@@ -34,7 +34,7 @@ pub struct Dimension<'a> {
 
 impl<'a> Dimension<'a> {
     /// Creates a new dimension.
-    pub fn new(size: ir::Size, id: DimId) -> Result<Dimension, ir::Error> {
+    pub fn new(size: ir::PartialSize, id: DimId) -> Result<Dimension, ir::Error> {
         let possible_sizes = if let Some(size) = size.as_int() {
             if size == 1 {
                 return Err(ir::Error::InvalidDimSize);
@@ -66,7 +66,7 @@ impl<'a> Dimension<'a> {
     }
 
     /// Retruns the size of the dimension.
-    pub fn size(&self) -> &ir::Size<'a> {
+    pub fn size(&self) -> &ir::PartialSize<'a> {
         &self.size
     }
 

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -342,18 +342,6 @@ impl<'a> Function<'a, ()> {
         Ok(id)
     }
 
-    /// Creates a new dimension.
-    // FIXME: deprecate
-    pub fn add_dim(&mut self, size: ir::Size<'a>) -> Result<ir::DimId, ir::Error> {
-        let id = ir::DimId(self.dims.len() as u32);
-        let dim = Dimension::new(size.into(), id)?;
-        if dim.possible_sizes().is_some() {
-            self.static_dims.push(id);
-        }
-        self.dims.push(dim);
-        Ok(id)
-    }
-
     /// Allocates a new memory block.
     pub fn add_mem_block(&mut self, size: u32) -> mem::InternalId {
         self.mem_blocks.alloc_block(size, None)

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -140,7 +140,7 @@ impl<'a, L> Function<'a, L> {
     }
 
     /// Returns the list of logical dimensions.
-    pub fn logical_dims(&self) -> impl Iterator<Item = &ir::LogicalDim> {
+    pub fn logical_dims(&self) -> impl Iterator<Item = &ir::LogicalDim<'a>> {
         self.logical_dims.iter()
     }
 
@@ -175,7 +175,7 @@ impl<'a, L> Function<'a, L> {
     }
 
     /// Retrives a logical dimension given its ID.
-    pub fn logical_dim(&self, id: ir::LogicalDimId) -> &ir::LogicalDim {
+    pub fn logical_dim(&self, id: ir::LogicalDimId) -> &ir::LogicalDim<'a> {
         &self.logical_dims[id.0 as usize]
     }
 
@@ -386,7 +386,13 @@ impl<'a> Function<'a, ()> {
             dims.push(Dimension::new(tiled_size, dim_ids[0])?);
             let factors = tiling_factors;
             let static_dims = dim_ids[1..].iter().cloned().collect();
-            ir::LogicalDim::new_dynamic(logical_id, dim_ids[0], static_dims, factors, size)
+            ir::LogicalDim::new_dynamic(
+                logical_id,
+                dim_ids[0],
+                static_dims,
+                factors,
+                size,
+            )
         };
         for (&id, &size) in dim_ids[1..].iter().zip_eq(tile_sizes) {
             dims.push(Dimension::new(ir::PartialSize::new(size, vec![], 1), id)?);

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -363,7 +363,7 @@ impl<'a> Function<'a, ()> {
         // Create the objects, but don't add anythin yet so we can rollback if an error
         // occurs.
         let mut dims = Vec::new();
-        let tiling_factor = tiling_factors.iter().product();
+        let tiling_factor = tile_sizes.iter().product();
         let logical_dim = if let Some(size) = size.as_constant() {
             let tiled_size = ir::PartialSize::new(size / tiling_factor, vec![], 1);
             dims.push(Dimension::new(tiled_size, dim_ids[0])?);

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -67,7 +67,7 @@ pub struct Function<'a, L = ir::LoweringMap> {
     mem_blocks: mem::BlockMap,
     layouts_to_lower: Vec<ir::mem::InternalId>,
     induction_vars: Vec<ir::InductionVar<'a, L>>,
-    logical_dims: Vec<ir::LogicalDim>,
+    logical_dims: Vec<ir::LogicalDim<'a>>,
 }
 
 impl<'a, L> Function<'a, L> {
@@ -381,12 +381,12 @@ impl<'a> Function<'a, ()> {
             dims.push(Dimension::new(tiled_size, dim_ids[0])?);
             ir::LogicalDim::new_static(logical_id, dim_ids.clone(), size)
         } else {
-            let mut tiled_size: ir::PartialSize = size.into();
+            let mut tiled_size: ir::PartialSize = size.clone().into();
             tiled_size.mul_divisor(tiling_factor);
             dims.push(Dimension::new(tiled_size, dim_ids[0])?);
             let factors = tiling_factors;
             let static_dims = dim_ids[1..].iter().cloned().collect();
-            ir::LogicalDim::new_dynamic(logical_id, dim_ids[0], static_dims, factors)
+            ir::LogicalDim::new_dynamic(logical_id, dim_ids[0], static_dims, factors, size)
         };
         for (&id, &size) in dim_ids[1..].iter().zip_eq(tile_sizes) {
             dims.push(Dimension::new(ir::PartialSize::new(size, vec![], 1), id)?);

--- a/src/ir/induction_var.rs
+++ b/src/ir/induction_var.rs
@@ -8,7 +8,7 @@ pub struct IndVarId(pub u32);
 /// A multidimentional induction variable. No dimension should appear twice in dims.
 #[derive(Clone, Debug)]
 pub struct InductionVar<'a, L = ir::LoweringMap> {
-    dims: Vec<(ir::DimId, ir::Size<'a>)>,
+    dims: Vec<(ir::DimId, ir::PartialSize<'a>)>,
     base: ir::Operand<'a, L>,
 }
 
@@ -16,7 +16,7 @@ impl<'a, L> InductionVar<'a, L> {
     /// Creates a new induction var. Size represents the increment over each diemnsion
     /// taken independenly.
     pub fn new(
-        dims: Vec<(ir::DimId, ir::Size<'a>)>,
+        dims: Vec<(ir::DimId, ir::PartialSize<'a>)>,
         base: ir::Operand<'a, L>,
     ) -> Result<Self, ir::Error> {
         ir::TypeError::check_integer(base.t())?;
@@ -50,7 +50,7 @@ impl<'a, L> InductionVar<'a, L> {
     }
 
     /// Returns the list of induction dimensions along with the corresponding increments.
-    pub fn dims(&self) -> &[(ir::DimId, ir::Size<'a>)] {
+    pub fn dims(&self) -> &[(ir::DimId, ir::PartialSize<'a>)] {
         &self.dims
     }
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -26,7 +26,7 @@ pub use self::instruction::{InstId, Instruction};
 pub use self::mem::MemId;
 pub use self::operand::{DimMapScope, LoweringMap, Operand};
 pub use self::operator::{BinOp, Operator};
-pub use self::size::Size;
+pub use self::size::{PartialSize, Size};
 pub use self::types::Type;
 
 pub mod mem;

--- a/src/ir/size.rs
+++ b/src/ir/size.rs
@@ -41,6 +41,17 @@ impl<'a> Size<'a> {
     }
 }
 
+impl<'a, T> std::ops::MulAssign<T> for Size<'a>
+where
+    T: std::borrow::Borrow<Size<'a>>,
+{
+    fn mul_assign(&mut self, rhs: T) {
+        let rhs = rhs.borrow();
+        self.factor *= rhs.factor;
+        self.params.extend(rhs.params.iter().cloned());
+    }
+}
+
 /// A size how exact value is not yet decided.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct PartialSize<'a> {

--- a/src/model/cuda_tests.rs
+++ b/src/model/cuda_tests.rs
@@ -29,7 +29,7 @@ fn partial_bound_0() {
     builder.close_dim(&dim_x);
 
     let dim_z = builder.open_dim_ex(size, DimKind::THREAD);
-    let (addr, pattern) = builder.tensor_access(&"z", z, &ir::Type::F(32), &[&dim_z]);
+    let (addr, pattern) = builder.tensor_access(&"z", z, ir::Type::F(32), &[&dim_z]);
     let st_z = builder.st(&addr, &0f32, pattern);
 
     builder.order(&dim_x, &dim_z, Order::BEFORE);
@@ -49,8 +49,8 @@ fn partial_bound_0() {
     }.get_bottleneck(3);
 
     builder.action(Action::ThreadMapping(
-        dim_z,
-        dim_x,
+        dim_z[0],
+        dim_x[0],
         ThreadMapping::MAPPED_OUT,
     ));
     let final_pressure = {
@@ -93,7 +93,7 @@ fn partial_bound_1() {
     builder.close_dim(&dim_x);
 
     let dim_z = builder.open_dim(size);
-    let (addr, pattern) = builder.tensor_access(&"z", z, &ir::Type::F(32), &[&dim_z]);
+    let (addr, pattern) = builder.tensor_access(&"z", z, ir::Type::F(32), &[&dim_z]);
     let st_z = builder.st(&addr, &0f32, pattern);
 
     let partial_pressure = {
@@ -109,7 +109,7 @@ fn partial_bound_1() {
         )
     }.get_bottleneck(5);
 
-    builder.action(Action::DimKind(dim_z, DimKind::THREAD));
+    builder.action(Action::DimKind(dim_z[0], DimKind::THREAD));
     let final_pressure = {
         let space = builder.get();
         let local_info = LocalInfo::compute(&space, &context);
@@ -214,7 +214,7 @@ fn partial_bound_3() {
 
     let size_m = builder.cst_size(256);
     let ld_a_dim = builder.open_tiled_dim(size_m, &[4]);
-    let (addr, patt) = builder.tensor_access(&"a", a, &ir::Type::F(32), &[&ld_a_dim]);
+    let (addr, patt) = builder.tensor_access(&"a", a, ir::Type::F(32), &[&ld_a_dim]);
     builder.ld(ir::Type::F(32), &addr, patt);
     builder.close_dim(&ld_a_dim);
 
@@ -238,7 +238,7 @@ fn partial_bound_3() {
         init_dim_m[1],
         ThreadMapping::MAPPED_IN,
     ));
-    builder.action(Action::DimKind(init_dim_n, DimKind::THREAD));
+    builder.action(Action::DimKind(init_dim_n[0], DimKind::THREAD));
 
     let partial_pressure = {
         let space = builder.get_clone();
@@ -253,7 +253,7 @@ fn partial_bound_3() {
     }.get_bottleneck(4);
 
     builder.action(Action::ThreadMapping(
-        init_dim_n,
+        init_dim_n[0],
         ld_a_dim[0],
         ThreadMapping::MAPPED_IN,
     ));
@@ -355,7 +355,7 @@ fn partial_bound_5() {
     let mut builder = Builder::new(&signature, context.device());
 
     let ld_a = a.load(&[&[]], &mut builder);
-    let dim1 = builder.open_dim_ex(ir::Size::new(26, vec![], 1), DimKind::THREAD);
+    let dim1 = builder.open_dim_ex(ir::Size::new_const(26), DimKind::THREAD);
     let _ = builder.mov(&0f32);
 
     builder.order(&ld_a.inst(), &dim1, Order::AFTER);

--- a/telamon-capi/include/telamon.h
+++ b/telamon-capi/include/telamon.h
@@ -122,6 +122,11 @@ typedef struct Operator Operator;
 typedef struct Parameter Parameter;
 
 /*
+ * A size how exact value is not yet decided.
+ */
+typedef struct PartialSize PartialSize;
+
+/*
  * A partially specified implementation.
  */
 typedef struct SearchSpace SearchSpace;
@@ -151,6 +156,13 @@ typedef struct Type Type;
 typedef struct {
     uint32_t id;
 } DimId;
+
+/*
+ * Provides a unique identifier for logic dimensions.
+ */
+typedef struct {
+    uint32_t _0;
+} LogicalDimId;
 
 /*
  * Uniquely identifies an instruction.
@@ -186,6 +198,10 @@ typedef struct {
 typedef struct {
     uint8_t bits;
 } Bool;
+
+typedef struct {
+    uint16_t enabled_values;
+} NumericSet;
 
 /*
  * Specifies how iteration dimensions are implemented.
@@ -278,6 +294,7 @@ typedef struct {
 typedef enum {
     Action_IsIterationDim,
     Action_IsThreadDim,
+    Action_Size,
     Action_DimKind,
     Action_MemSpace,
     Action_InstFlag,
@@ -294,6 +311,8 @@ typedef enum {
     Action_IncrementMemSize,
     Action_MemSize,
     Action_SharedMemUsed,
+    Action_IncrementTilingFactor,
+    Action_TilingFactor,
     Action_IsIterationDimClassCounter,
     Action_IsThreadDimClassCounter,
 } Action_Tag;
@@ -308,6 +327,11 @@ typedef struct {
     DimId dim;
     Bool domain;
 } Action_IsThreadDim_Body;
+
+typedef struct {
+    DimId dim;
+    NumericSet domain;
+} Action_Size_Body;
 
 typedef struct {
     DimId dim;
@@ -394,6 +418,17 @@ typedef struct {
 } Action_SharedMemUsed_Body;
 
 typedef struct {
+    LogicalDimId logical;
+    DimId dim;
+    Bool domain;
+} Action_IncrementTilingFactor_Body;
+
+typedef struct {
+    LogicalDimId logical;
+    Range domain;
+} Action_TilingFactor_Body;
+
+typedef struct {
     InstId inst;
     DimId dim;
     Range domain;
@@ -409,6 +444,7 @@ typedef struct {
     union {
         Action_IsIterationDim_Body is_iteration_dim;
         Action_IsThreadDim_Body is_thread_dim;
+        Action_Size_Body size;
         Action_DimKind_Body dim_kind;
         Action_MemSpace_Body mem_space;
         Action_InstFlag_Body inst_flag;
@@ -425,6 +461,8 @@ typedef struct {
         Action_IncrementMemSize_Body increment_mem_size;
         Action_MemSize_Body mem_size;
         Action_SharedMemUsed_Body shared_mem_used;
+        Action_IncrementTilingFactor_Body increment_tiling_factor;
+        Action_TilingFactor_Body tiling_factor;
         Action_IsIterationDimClassCounter_Body is_iteration_dim_class_counter;
         Action_IsThreadDimClassCounter_Body is_thread_dim_class_counter;
     };
@@ -566,11 +604,23 @@ SearchSpace *telamon_explore(const Config *config,
                              const SearchSpace *search_space);
 
 /*
- * Adds a dimension of the given size to the function. Takes ownership of `size` and
- * writes the unique identifier of the dimension in `dim_id`. Returns `Ok`
- * except if an error occurs.
+ * Returns the size of a dimension.
  */
-TelamonStatus telamon_ir_function_add_dimension(Function *function, Size *size, DimId *dim_id);
+PartialSize *telamon_ir_dimension_size(const Function *function, DimId dim);
+
+/*
+ * Adds a logical dimension of the given size to the function. In practice, this creates a
+ * dimension for each tiling level plus one. Takes ownership of `size` and writes the unique
+ * identifier of the logical dimension in `logical_id`. Writes the ids of the dimensions, from the
+ * outermost to the innermost, in `dim_ids`. `dim_ids` must be at least of size `num_tiles + 1`.
+ * Returns `Ok` except if an error occurs.
+ */
+TelamonStatus telamon_ir_function_add_dimensions(Function *function,
+                                                 Size *size,
+                                                 const uint32_t *tile_sizes,
+                                                 uintptr_t num_tiles,
+                                                 LogicalDimId *logical_id,
+                                                 DimId *dim_ids);
 
 /*
  * Adds an instruction performing the given operator in the given dimensions to the
@@ -698,7 +748,7 @@ Operator *telamon_ir_operator_new_tensor_load(Function *function,
                                               MemId array_id,
                                               Operand *base_address,
                                               const DimId *strided_dims,
-                                              const Size *strides,
+                                              const PartialSize *strides,
                                               uintptr_t num_strided_dims,
                                               const Type *loaded_type);
 
@@ -712,7 +762,7 @@ Operator *telamon_ir_operator_new_tensor_store(Function *function,
                                                MemId array_id,
                                                Operand *base_address,
                                                const DimId *strided_dims,
-                                               const Size *strides,
+                                               const PartialSize *strides,
                                                uintptr_t num_strided_dims,
                                                Operand *value);
 
@@ -748,15 +798,24 @@ const Parameter *telamon_ir_signature_param(const Signature *signature, uintptr_
 void telamon_ir_size_free(Size *size);
 
 /*
+ * Converts an `ir::Size` into an `ir::PartialSize`.
+ */
+PartialSize *telamon_ir_size_into_partial(Size *size);
+
+/*
+ * Multiplies `lhs` by `rhs`.
+ */
+void telamon_ir_size_mul(PartialSize *lhs, const PartialSize *rhs);
+
+/*
  * Create a size equal to:
  * ```
- * const_factor * param_factors[0] * .. * param_factors[num_params-1] / const_divisor
+ * const_factor * param_factors[0] * .. * param_factors[num_params-1]
  * ```
  * The size must be freed calling `telamon_ir_size_free` or passed to a function that
  * takes its ownership.
  */
 Size *telamon_ir_size_new(uint32_t const_factor,
-                          uint32_t const_divisor,
                           const Parameter *const *param_factors,
                           uintptr_t num_params);
 

--- a/tests/cuda.rs
+++ b/tests/cuda.rs
@@ -127,8 +127,8 @@ fn inst_order() {
     let d1 = builder.open_dim(size_32);
     builder.mov(&0i32);
 
-    builder.action(Action::DimKind(d0, DimKind::LOOP));
-    builder.action(Action::DimKind(d1, DimKind::THREAD));
+    builder.action(Action::DimKind(d0[0], DimKind::LOOP));
+    builder.action(Action::DimKind(d1[0], DimKind::THREAD));
 
     gen_best(&context, builder.get());
 }
@@ -143,6 +143,7 @@ fn induction_var_nested() {
     let signature = {
         let mut builder = helper::SignatureBuilder::new("ind_var_test", &mut context);
         builder.scalar("k", 12i32);
+        builder.scalar("k4", 12i32/4);
         out = builder.array::<i32>("out", 1);
         builder.get()
     };
@@ -151,12 +152,12 @@ fn induction_var_nested() {
     let size_4 = builder.cst_size(4);
     let size_5 = builder.cst_size(5);
     let size_k = builder.param_size("k");
-    let size_k_tile_4 = builder.tile_size("k", 4);
+    let size_k_tile_4 = builder.param_size("k4");
     let d0 = builder.open_dim_ex(size_k_tile_4.clone(), DimKind::LOOP);
     let d1 = builder.open_dim_ex(size_4, DimKind::LOOP);
     let d2 = builder.open_dim_ex(size_5, DimKind::UNROLL);
     let ind_var = builder
-        .induction_var(&0i32, vec![(d0, size_1), (d1, size_k_tile_4), (d2, size_k)]);
+        .induction_var(&0i32, vec![(&d0, size_1), (&d1, size_k_tile_4), (&d2, size_k)]);
     let pattern = builder.unknown_access_pattern(out.0);
     let _ = builder.st(&"out", &ind_var, pattern);
 
@@ -183,7 +184,7 @@ fn induction_var_simple() {
     let size_3 = builder.cst_size(3);
     let size_4 = builder.cst_size(4);
     let d0 = builder.open_dim_ex(size_3, DimKind::LOOP);
-    let ind_var = builder.induction_var(&0i32, vec![(d0, size_4)]);
+    let ind_var = builder.induction_var(&0i32, vec![(&d0, size_4)]);
     let pattern = builder.unknown_access_pattern(out.0);
     let _ = builder.st(&"out", &ind_var, pattern);
 
@@ -219,9 +220,8 @@ fn global_vector_load() {
     // Load B from global memory
     let d0_size = builder.cst_size(D0_LEN);
     let d0 = builder.open_dim_ex(d0_size, DimKind::VECTOR);
-    let input_pattern = builder.tensor_access_pattern(input.0, &DATA_TYPE, &[&d0]);
-    let data_size = builder.cst_size(DATA_TYPE.len_byte().unwrap());
-    let addr = builder.induction_var(&"input", vec![(d0, data_size.clone())]);
+    let (addr, input_pattern) = builder.tensor_access(
+        &"input", input.0, DATA_TYPE, &[&d0]);
     let ld = builder.ld_ex(DATA_TYPE, &addr, input_pattern, InstFlag::MEM_CS);
     builder.close_dim(&d0);
     // Store B in shared memory.
@@ -250,7 +250,7 @@ fn size_cast() {
     let size_3 = builder.cst_size(3);
     let size_4 = builder.cst_size(4);
     let d0 = builder.open_dim_ex(size_3, DimKind::LOOP);
-    let ind_var = builder.induction_var(&0i64, vec![(d0, size_4)]);
+    let ind_var = builder.induction_var(&0i64, vec![(&d0, size_4)]);
     let pattern = builder.unknown_access_pattern(out.0);
     let _ = builder.st(&"out", &ind_var, pattern);
 
@@ -424,6 +424,6 @@ fn test0() {
 
     let mut space = builder.get();
     space
-        .apply_decisions(vec![Action::DimKind(d4, DimKind::UNROLL)])
+        .apply_decisions(vec![Action::DimKind(d4[0], DimKind::UNROLL)])
         .unwrap();
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -51,29 +51,29 @@ fn inst_dim_order() {
     let context = fake::Context::default();
     let signature = empty_signature(1);
     let mut builder = helper::Builder::new(&signature, context.device());
-    let dim0 = builder.open_dim(Size::new(64, vec![], 1));
+    let dim0 = builder.open_dim(Size::new_const(64));
     let inst0 = builder.mov(&0i32);
     let pattern = builder.unknown_access_pattern(ir::MemId::External(0));
     let addr = builder.cast(&0i64, ir::Type::PtrTo(ir::MemId::External(0)));
     let inst1 = builder.st(&addr, &0i32, pattern);
     builder.close_dim(&dim0);
-    let dim1 = builder.open_dim(Size::new(64, vec![], 1));
+    let dim1 = builder.open_dim(Size::new_const(64));
     let _ = builder.mov(&0i32);
     let space = builder.get();
-    assert_eq!(space.domain().get_dim_kind(dim0), !DimKind::VECTOR);
-    assert_eq!(space.domain().get_dim_kind(dim1), !DimKind::VECTOR);
-    assert_eq!(space.domain().get_is_iteration_dim(inst0, dim0), Bool::TRUE);
-    assert_eq!(space.domain().get_is_iteration_dim(inst0, dim0), Bool::TRUE);
+    assert_eq!(space.domain().get_dim_kind(dim0[0]), !DimKind::VECTOR);
+    assert_eq!(space.domain().get_dim_kind(dim1[0]), !DimKind::VECTOR);
+    assert_eq!(space.domain().get_is_iteration_dim(inst0, dim0[0]), Bool::TRUE);
+    assert_eq!(space.domain().get_is_iteration_dim(inst0, dim0[0]), Bool::TRUE);
     assert_eq!(
-        space.domain().get_order(inst0.into(), dim1.into()),
+        space.domain().get_order(inst0.into(), dim1[0].into()),
         Order::INNER | Order::ORDERED
     );
     assert_eq!(
-        space.domain().get_is_iteration_dim(inst1, dim1),
+        space.domain().get_is_iteration_dim(inst1, dim1[0]),
         Bool::FALSE
     );
     assert_eq!(
-        space.domain().get_order(inst1.into(), dim1.into()),
+        space.domain().get_order(inst1.into(), dim1[0].into()),
         Order::INNER | Order::ORDERED
     );
     gen_best(&context, space);
@@ -95,10 +95,10 @@ fn nested_thread_dims() {
     builder.mov(&0i32);
     builder.order(&d0, &d3, Order::INNER);
     let space = builder.get();
-    assert!(!space.domain().get_dim_kind(d3).intersects(DimKind::THREAD));
-    assert_eq!(space.domain().get_order(d0.into(), d3.into()), Order::INNER);
-    assert_eq!(space.domain().get_order(d1.into(), d3.into()), Order::INNER);
-    assert_eq!(space.domain().get_order(d2.into(), d3.into()), Order::INNER);
+    assert!(!space.domain().get_dim_kind(d3[0]).intersects(DimKind::THREAD));
+    assert_eq!(space.domain().get_order(d0[0].into(), d3[0].into()), Order::INNER);
+    assert_eq!(space.domain().get_order(d1[0].into(), d3[0].into()), Order::INNER);
+    assert_eq!(space.domain().get_order(d2[0].into(), d3[0].into()), Order::INNER);
     gen_best(&context, space);
 }
 
@@ -109,11 +109,11 @@ fn max_thread_on_addinst() {
     let context = fake::Context::default();
     let signature = empty_signature(0);
     let mut builder = helper::Builder::new(&signature, context.device());
-    builder.open_dim_ex(Size::new(1024, vec![], 1), DimKind::THREAD);
-    let d1 = builder.open_dim(Size::new(2, vec![], 1));
+    builder.open_dim_ex(Size::new_const(1024), DimKind::THREAD);
+    let d1 = builder.open_dim(Size::new_const(2));
     builder.mov(&0i32);
     let space = builder.get();
-    assert!(!space.domain().get_dim_kind(d1).intersects(DimKind::THREAD));
+    assert!(!space.domain().get_dim_kind(d1[0]).intersects(DimKind::THREAD));
     gen_best(&context, space);
 }
 
@@ -124,12 +124,12 @@ fn max_thread_on_setkind() {
     let context = fake::Context::default();
     let signature = empty_signature(0);
     let mut builder = helper::Builder::new(&signature, context.device());
-    let d0 = builder.open_dim(Size::new(1024, vec![], 1));
-    let d1 = builder.open_dim(Size::new(2, vec![], 1));
+    let d0 = builder.open_dim(Size::new_const(1024));
+    let d1 = builder.open_dim(Size::new_const(2));
     builder.mov(&0i32);
-    builder.action(Action::DimKind(d0, DimKind::THREAD));
+    builder.action(Action::DimKind(d0[0], DimKind::THREAD));
     let space = builder.get();
-    assert!(!space.domain().get_dim_kind(d1).intersects(DimKind::THREAD));
+    assert!(!space.domain().get_dim_kind(d1[0]).intersects(DimKind::THREAD));
     gen_best(&context, space);
 }
 
@@ -144,43 +144,43 @@ fn block_dims() {
         builder.get()
     };
     let mut builder = helper::Builder::new(&signature, context.device());
-    let d0 = builder.open_dim(Size::new(4, vec![], 1));
+    let d0 = builder.open_dim(Size::new_const(4));
     let inst = builder.mov(&0i32);
     let s1 = builder.param_size("n");
     let d1 = builder.open_dim_ex(s1, DimKind::BLOCK);
-    let d2 = builder.open_dim_ex(Size::new(2, vec![], 1), DimKind::BLOCK);
-    let d3 = builder.open_dim_ex(Size::new(3, vec![], 1), DimKind::BLOCK);
+    let d2 = builder.open_dim_ex(Size::new_const(2), DimKind::BLOCK);
+    let d3 = builder.open_dim_ex(Size::new_const(3), DimKind::BLOCK);
     let space = builder.get();
     assert_eq!(
-        space.domain().get_is_iteration_dim(inst.into(), d0),
+        space.domain().get_is_iteration_dim(inst.into(), d0[0]),
         Bool::TRUE
     );
     assert_eq!(
-        space.domain().get_is_iteration_dim(inst.into(), d1),
+        space.domain().get_is_iteration_dim(inst.into(), d1[0]),
         Bool::TRUE
     );
     assert_eq!(
-        space.domain().get_is_iteration_dim(inst.into(), d2),
+        space.domain().get_is_iteration_dim(inst.into(), d2[0]),
         Bool::TRUE
     );
     assert_eq!(
-        space.domain().get_is_iteration_dim(inst.into(), d3),
+        space.domain().get_is_iteration_dim(inst.into(), d3[0]),
         Bool::TRUE
     );
     assert_eq!(
-        space.domain().get_dim_kind(d0),
+        space.domain().get_dim_kind(d0[0]),
         DimKind::LOOP | DimKind::THREAD | DimKind::UNROLL
     );
     assert_eq!(
-        space.domain().get_order(d1.into(), d2.into()),
+        space.domain().get_order(d1[0].into(), d2[0].into()),
         Order::NESTED
     );
     assert_eq!(
-        space.domain().get_order(d1.into(), d3.into()),
+        space.domain().get_order(d1[0].into(), d3[0].into()),
         Order::NESTED
     );
     assert_eq!(
-        space.domain().get_order(d2.into(), d3.into()),
+        space.domain().get_order(d2[0].into(), d3[0].into()),
         Order::NESTED
     );
     gen_best(&context, space);
@@ -195,27 +195,26 @@ fn vector_dims() {
     let mem_block = ir::MemId::External(0);
     let mut builder = helper::Builder::new(&signature, context.device());
     let base_addr = builder.cast(&0i64, ir::Type::PtrTo(mem_block));
-    let d0 = builder.open_dim(Size::new(4, vec![], 1));
+    let d0 = builder.open_dim(Size::new_const(4));
     // Test with one vectorizable instruction
-    let pattern = builder.tensor_access_pattern(mem_block, &Type::I(8), &[&d0]);
-    let addr = builder.induction_var(&base_addr, vec![(d0, ir::Size::new(1, vec![], 1))]);
+    let (addr, pattern) = builder.tensor_access(&base_addr, mem_block, Type::I(8), &[&d0]);
     builder.ld(Type::I(8), &addr, pattern.clone());
     assert!(
         builder
             .get_clone()
             .domain()
-            .get_dim_kind(d0)
+            .get_dim_kind(d0[0])
             .intersects(DimKind::VECTOR)
     );
     // Test with two insts and a non-vectorizable inst.
     builder.ld(Type::I(8), &addr, pattern);
     builder.close_dim(&d0);
-    let d1 = builder.open_dim(Size::new(4, vec![], 1));
+    let d1 = builder.open_dim(Size::new_const(4));
     builder.mul(&0i32, &0i32);
     builder.close_dim(&d1);
     let space = builder.get();
-    assert!(!space.domain().get_dim_kind(d0).intersects(DimKind::VECTOR));
-    assert!(!space.domain().get_dim_kind(d1).intersects(DimKind::VECTOR));
+    assert!(!space.domain().get_dim_kind(d0[0]).intersects(DimKind::VECTOR));
+    assert!(!space.domain().get_dim_kind(d1[0]).intersects(DimKind::VECTOR));
     gen_best(&context, space);
 }
 
@@ -230,15 +229,15 @@ fn unroll_dims() {
         builder.get()
     };
     let mut builder = helper::Builder::new(&signature, context.device());
-    let d0 = builder.open_dim(Size::new(64, vec![], 1));
-    let d1 = builder.open_dim(Size::new(4096, vec![], 1));
+    let d0 = builder.open_dim(Size::new_const(64));
+    let d1 = builder.open_dim(Size::new_const(4096));
     let s2 = builder.param_size("n");
     let d2 = builder.open_dim(s2);
     builder.mov(&0i32);
     let space = builder.get();
-    assert!(space.domain().get_dim_kind(d0).contains(DimKind::UNROLL));
-    assert!(!space.domain().get_dim_kind(d1).contains(DimKind::UNROLL));
-    assert!(!space.domain().get_dim_kind(d2).contains(DimKind::UNROLL));
+    assert!(space.domain().get_dim_kind(d0[0]).contains(DimKind::UNROLL));
+    assert!(!space.domain().get_dim_kind(d1[0]).contains(DimKind::UNROLL));
+    assert!(!space.domain().get_dim_kind(d2[0]).contains(DimKind::UNROLL));
     gen_best(&context, space);
 }
 
@@ -250,26 +249,26 @@ fn reduce_dim_invariants() {
     let signature = empty_signature(1);
     let mut builder = helper::Builder::new(&signature, context.device());
     let init = builder.cast(&0i64, ir::Type::PtrTo(ir::MemId::External(0)));
-    let d0 = builder.open_dim(Size::new(4, vec![], 1));
+    let d0 = builder.open_dim(Size::new_const(4));
     let pattern = builder.unknown_access_pattern(ir::MemId::External(0));
     let reduce = builder.ld(Type::I(64), &helper::Reduce(init), pattern);
 
-    let d1 = builder.open_dim(Size::new(4, vec![], 1));
-    builder.action(Action::IsIterationDim(reduce.into(), d1, Bool::TRUE));
-    let d2 = builder.open_dim(Size::new(4, vec![], 1));
+    let d1 = builder.open_dim(Size::new_const(4));
+    builder.action(Action::IsIterationDim(reduce.into(), d1[0], Bool::TRUE));
+    let d2 = builder.open_dim(Size::new_const(4));
     builder.order(&d2, &init, !Order::OUTER);
     let space = builder.get();
     assert_eq!(
-        space.domain().get_dim_kind(d0),
+        space.domain().get_dim_kind(d0[0]),
         DimKind::LOOP | DimKind::UNROLL
     );
     assert_eq!(
-        space.domain().get_order(d0.into(), init.into()),
+        space.domain().get_order(d0[0].into(), init.into()),
         Order::AFTER
     );
-    assert!(Order::OUTER.contains(space.domain().get_order(d1.into(), init.into())));
+    assert!(Order::OUTER.contains(space.domain().get_order(d1[0].into(), init.into())));
     assert_eq!(
-        space.domain().get_is_iteration_dim(reduce.into(), d2),
+        space.domain().get_is_iteration_dim(reduce.into(), d2[0]),
         Bool::FALSE
     );
     gen_best(&context, space);
@@ -282,7 +281,7 @@ fn rename_thread() {
     let context = fake::Context::default();
     let signature = empty_signature(0);
     let mut builder = helper::Builder::new(&signature, context.device());
-    let d_n_1 = &builder.open_dim_ex(Size::new(8, vec![], 1), DimKind::THREAD);
+    let d_n_1 = &builder.open_dim_ex(Size::new_const(8), DimKind::THREAD);
     builder.mov(&0i32);
     builder.mov(d_n_1);
     gen_best(&context, builder.get());
@@ -295,9 +294,9 @@ fn dim_merge() {
     let context = fake::Context::default();
     let signature = empty_signature(0);
     let mut builder = helper::Builder::new(&signature, context.device());
-    let d0 = builder.open_dim_ex(Size::new(4, vec![], 1), DimKind::LOOP);
+    let d0 = builder.open_dim_ex(Size::new_const(4), DimKind::LOOP);
     builder.mov(&0i32);
-    let d1 = builder.open_dim_ex(Size::new(4, vec![], 1), DimKind::LOOP);
+    let d1 = builder.open_dim_ex(Size::new_const(4), DimKind::LOOP);
     builder.order(&d0, &d1, Order::MERGED);
     gen_best(&context, builder.get());
 }
@@ -309,9 +308,9 @@ fn loop_fusion() {
     let context = fake::Context::default();
     let signature = empty_signature(0);
     let mut builder = helper::Builder::new(&signature, context.device());
-    let d0 = builder.open_dim_ex(Size::new(4, vec![], 1), DimKind::LOOP);
+    let d0 = builder.open_dim_ex(Size::new_const(4), DimKind::LOOP);
     let inst0 = builder.mov(&0i32);
-    let d1 = builder.open_mapped_dim(&d0.into())[0];
+    let d1 = builder.open_mapped_dim(&d0);
     builder.mov(&inst0);
     builder.order(&d0, &d1, Order::MERGED);
     // Ensure no temporary memory has been generated.
@@ -327,9 +326,9 @@ fn unrolled_loop_unfused_simple() {
     let context = fake::Context::default();
     let signature = empty_signature(0);
     let mut builder = helper::Builder::new(&signature, context.device());
-    let d0 = builder.open_dim_ex(Size::new(4, vec![], 1), DimKind::UNROLL);
+    let d0 = builder.open_dim_ex(Size::new_const(4), DimKind::UNROLL);
     let inst0 = builder.mov(&0i32);
-    let d1 = builder.open_mapped_dim(&d0.into())[0];
+    let d1 = builder.open_mapped_dim(&d0);
     builder.mov(&inst0);
     builder.order(&d0, &d1, !Order::MERGED);
     // Ensure no temporary memory has been generated.
@@ -345,9 +344,9 @@ fn temporary_memory_gen_simple() {
     let context = fake::Context::default();
     let signature = empty_signature(0);
     let mut builder = helper::Builder::new(&signature, context.device());
-    let d0 = builder.open_dim_ex(Size::new(4, vec![], 1), DimKind::LOOP);
+    let d0 = builder.open_dim_ex(Size::new_const(4), DimKind::LOOP);
     let inst0 = builder.mov(&0i32);
-    let d1 = builder.open_mapped_dim(&d0.into())[0];
+    let d1 = builder.open_mapped_dim(&d0);
     builder.mov(&helper::TmpArray(inst0));
     builder.order(&d0, &d1, !Order::MERGED);
     // Ensure load and store instruction have been generated.
@@ -363,10 +362,10 @@ fn unrolled_loop_unfused_reduction() {
     let context = fake::Context::default();
     let signature = empty_signature(0);
     let mut builder = helper::Builder::new(&signature, context.device());
-    let d0 = builder.open_dim_ex(ir::Size::new(4, vec![], 1), DimKind::UNROLL);
+    let d0 = builder.open_dim_ex(ir::Size::new_const(4), DimKind::UNROLL);
     let inst0 = builder.mov(&0i32);
-    builder.open_mapped_dim(&d0.into());
-    let d1 = builder.open_dim_ex(ir::Size::new(1024, vec![], 1), DimKind::LOOP);
+    builder.open_mapped_dim(&d0);
+    let d1 = builder.open_dim_ex(ir::Size::new_const(1024), DimKind::LOOP);
     builder.mov(&helper::Reduce(inst0));
 
     builder.order(&d0, &d1, Order::BEFORE);
@@ -383,12 +382,12 @@ fn two_thread_dim_map() {
     let signature = empty_signature(0);
     let mut builder = helper::Builder::new(&signature, context.device());
     // Generate a variable in each thread.
-    let dim0_0 = builder.open_dim_ex(ir::Size::new(32, vec![], 1), DimKind::THREAD);
-    let dim0_1 = builder.open_dim_ex(ir::Size::new(32, vec![], 1), DimKind::THREAD);
+    let dim0_0 = builder.open_dim_ex(ir::Size::new_const(32), DimKind::THREAD);
+    let dim0_1 = builder.open_dim_ex(ir::Size::new_const(32), DimKind::THREAD);
     let x = builder.mov(&0i32);
     // Transpose twice the variable using temporary memory.
-    let dim1_0 = builder.open_mapped_dim(&dim0_1.into());
-    let dim1_1 = builder.open_mapped_dim(&dim0_0.into());
+    let dim1_0 = builder.open_mapped_dim(&dim0_1);
+    let dim1_1 = builder.open_mapped_dim(&dim0_0);
     builder.mov(&helper::TmpArray(x));
     // Set the nesting order.
     builder.order(&dim0_0, &dim0_1, Order::OUTER);
@@ -405,14 +404,14 @@ fn double_dim_map() {
 
     let mut builder = helper::Builder::new(&signature, context.device());
     // Load from a and b.
-    let dim0_0 = builder.open_dim_ex(ir::Size::new(32, vec![], 1), DimKind::THREAD);
-    let dim0_1 = builder.open_dim_ex(ir::Size::new(32, vec![], 1), DimKind::THREAD);
-    let dim0_2 = builder.open_dim_ex(ir::Size::new(4, vec![], 1), DimKind::UNROLL);
+    let dim0_0 = builder.open_dim_ex(ir::Size::new_const(32), DimKind::THREAD);
+    let dim0_1 = builder.open_dim_ex(ir::Size::new_const(32), DimKind::THREAD);
+    let dim0_2 = builder.open_dim_ex(ir::Size::new_const(4), DimKind::UNROLL);
     let x = builder.mov(&0i32);
     // Transpose and add a and b. Store the result in a.
-    let dim1_0 = builder.open_mapped_dim(&dim0_1.into());
-    let dim1_1 = builder.open_mapped_dim(&dim0_0.into());
-    let dim1_2 = builder.open_mapped_dim(&dim0_2.into());
+    let dim1_0 = builder.open_mapped_dim(&dim0_1);
+    let dim1_1 = builder.open_mapped_dim(&dim0_0);
+    let dim1_2 = builder.open_mapped_dim(&dim0_2);
     builder.mov(&x);
     builder.mov(&x);
     // Fix the nesting order.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -62,8 +62,14 @@ fn inst_dim_order() {
     let space = builder.get();
     assert_eq!(space.domain().get_dim_kind(dim0[0]), !DimKind::VECTOR);
     assert_eq!(space.domain().get_dim_kind(dim1[0]), !DimKind::VECTOR);
-    assert_eq!(space.domain().get_is_iteration_dim(inst0, dim0[0]), Bool::TRUE);
-    assert_eq!(space.domain().get_is_iteration_dim(inst0, dim0[0]), Bool::TRUE);
+    assert_eq!(
+        space.domain().get_is_iteration_dim(inst0, dim0[0]),
+        Bool::TRUE
+    );
+    assert_eq!(
+        space.domain().get_is_iteration_dim(inst0, dim0[0]),
+        Bool::TRUE
+    );
     assert_eq!(
         space.domain().get_order(inst0.into(), dim1[0].into()),
         Order::INNER | Order::ORDERED
@@ -95,10 +101,24 @@ fn nested_thread_dims() {
     builder.mov(&0i32);
     builder.order(&d0, &d3, Order::INNER);
     let space = builder.get();
-    assert!(!space.domain().get_dim_kind(d3[0]).intersects(DimKind::THREAD));
-    assert_eq!(space.domain().get_order(d0[0].into(), d3[0].into()), Order::INNER);
-    assert_eq!(space.domain().get_order(d1[0].into(), d3[0].into()), Order::INNER);
-    assert_eq!(space.domain().get_order(d2[0].into(), d3[0].into()), Order::INNER);
+    assert!(
+        !space
+            .domain()
+            .get_dim_kind(d3[0])
+            .intersects(DimKind::THREAD)
+    );
+    assert_eq!(
+        space.domain().get_order(d0[0].into(), d3[0].into()),
+        Order::INNER
+    );
+    assert_eq!(
+        space.domain().get_order(d1[0].into(), d3[0].into()),
+        Order::INNER
+    );
+    assert_eq!(
+        space.domain().get_order(d2[0].into(), d3[0].into()),
+        Order::INNER
+    );
     gen_best(&context, space);
 }
 
@@ -113,7 +133,12 @@ fn max_thread_on_addinst() {
     let d1 = builder.open_dim(Size::new_const(2));
     builder.mov(&0i32);
     let space = builder.get();
-    assert!(!space.domain().get_dim_kind(d1[0]).intersects(DimKind::THREAD));
+    assert!(
+        !space
+            .domain()
+            .get_dim_kind(d1[0])
+            .intersects(DimKind::THREAD)
+    );
     gen_best(&context, space);
 }
 
@@ -129,7 +154,12 @@ fn max_thread_on_setkind() {
     builder.mov(&0i32);
     builder.action(Action::DimKind(d0[0], DimKind::THREAD));
     let space = builder.get();
-    assert!(!space.domain().get_dim_kind(d1[0]).intersects(DimKind::THREAD));
+    assert!(
+        !space
+            .domain()
+            .get_dim_kind(d1[0])
+            .intersects(DimKind::THREAD)
+    );
     gen_best(&context, space);
 }
 
@@ -197,7 +227,8 @@ fn vector_dims() {
     let base_addr = builder.cast(&0i64, ir::Type::PtrTo(mem_block));
     let d0 = builder.open_dim(Size::new_const(4));
     // Test with one vectorizable instruction
-    let (addr, pattern) = builder.tensor_access(&base_addr, mem_block, Type::I(8), &[&d0]);
+    let (addr, pattern) =
+        builder.tensor_access(&base_addr, mem_block, Type::I(8), &[&d0]);
     builder.ld(Type::I(8), &addr, pattern.clone());
     assert!(
         builder
@@ -213,8 +244,18 @@ fn vector_dims() {
     builder.mul(&0i32, &0i32);
     builder.close_dim(&d1);
     let space = builder.get();
-    assert!(!space.domain().get_dim_kind(d0[0]).intersects(DimKind::VECTOR));
-    assert!(!space.domain().get_dim_kind(d1[0]).intersects(DimKind::VECTOR));
+    assert!(
+        !space
+            .domain()
+            .get_dim_kind(d0[0])
+            .intersects(DimKind::VECTOR)
+    );
+    assert!(
+        !space
+            .domain()
+            .get_dim_kind(d1[0])
+            .intersects(DimKind::VECTOR)
+    );
     gen_best(&context, space);
 }
 

--- a/tools/bench_perf_model/latency.rs
+++ b/tools/bench_perf_model/latency.rs
@@ -1,6 +1,6 @@
 //! Tests the latency model.
 use telamon::device::{ArgMap, Context};
-use telamon::helper::{Builder, DimGroup, Reduce, SignatureBuilder};
+use telamon::helper::{Builder, Reduce, SignatureBuilder};
 use telamon::ir;
 use telamon::search_space::{Action, DimKind, InstFlag, Order};
 use PerfModelTest;

--- a/tools/bench_perf_model/latency.rs
+++ b/tools/bench_perf_model/latency.rs
@@ -45,7 +45,10 @@ impl PerfModelTest for TwoEmptyLoop {
         let d0 = builder.open_dim_ex(size.clone(), DimKind::LOOP);
         let d1 = builder.open_dim_ex(size, DimKind::LOOP);
         builder.mov(&0i32);
-        TwoEmptyLoop { d0, d1 }
+        TwoEmptyLoop {
+            d0: d0[0],
+            d1: d1[0],
+        }
     }
 
     fn get_actions(&self) -> Vec<Action> {
@@ -138,7 +141,10 @@ impl PerfModelTest for UnrollReduction {
         builder.close_dim(&d1);
         let pattern = builder.unknown_access_pattern(ir::MemId::External(0));
         builder.st_ex(&"out", &inst, true, pattern, InstFlag::MEM_CS);
-        UnrollReduction { d0, d1 }
+        UnrollReduction {
+            d0: d0[0],
+            d1: d1[0],
+        }
     }
 
     fn get_actions(&self) -> Vec<Action> {
@@ -204,7 +210,9 @@ impl PerfModelTest for OrderedThreadDims {
         let d1_1 = builder.open_dim_ex(size_1.clone(), DimKind::LOOP);
         let d1_2 = builder.open_dim_ex(size_2.clone(), DimKind::UNROLL);
         let inst = builder.mul(&"x", &Reduce(init));
-        builder.close_dim(&DimGroup::new(vec![d1, d1_1, d1_2]));
+        builder.close_dim(&d1);
+        builder.close_dim(&d1_1);
+        builder.close_dim(&d1_2);
 
         let d2 = builder.open_dim_ex(size_0.clone(), DimKind::THREAD);
         let d2_1 = builder.open_dim_ex(size_1.clone(), DimKind::LOOP);
@@ -248,7 +256,8 @@ impl PerfModelTest for DimMap {
         let d2 = builder.open_dim_ex(size_1, DimKind::UNROLL);
         let op = builder.dim_map(i1, &[(&d1, &d2)], ir::DimMapScope::Thread);
         let i2 = builder.mad(&op, &op, &Reduce(init2));
-        builder.close_dim(&DimGroup::new(vec![d2, d0]));
+        builder.close_dim(&d2);
+        builder.close_dim(&d0);
         let pattern = builder.unknown_access_pattern(ir::MemId::External(0));
         builder.st_ex(&"out", &i2, true, pattern, InstFlag::MEM_CS);
         builder.order(&d1, &d2, Order::BEFORE);

--- a/tools/bench_perf_model/memory.rs
+++ b/tools/bench_perf_model/memory.rs
@@ -27,25 +27,21 @@ impl PerfModelTest for L1LinesPressure {
 
         let t = ir::Type::F(32);
         let size_n = builder.param_size("n");
-        let d1_0 =
-            builder.open_dim_ex(ir::Size::new(THREAD_Y, vec![], 1), DimKind::THREAD);
-        let d2_0 =
-            builder.open_dim_ex(ir::Size::new(THREAD_X, vec![], 1), DimKind::THREAD);
+        let d1_0 = builder.open_dim_ex(ir::Size::new_const(THREAD_Y), DimKind::THREAD);
+        let d2_0 = builder.open_dim_ex(ir::Size::new_const(THREAD_X), DimKind::THREAD);
         let init = builder.mov(&0f32);
 
         let d0 = builder.open_dim_ex(size_n.clone(), DimKind::LOOP);
-        let d1_1 = builder.open_mapped_dim(&d1_0)[0];
-        let d2_1 = builder.open_mapped_dim(&d2_0)[0];
-        let d3 = builder.open_dim_ex(ir::Size::new(UNROLL, vec![], 1), DimKind::UNROLL);
+        let d1_1 = builder.open_mapped_dim(&d1_0);
+        let d2_1 = builder.open_mapped_dim(&d2_0);
+        let d3 = builder.open_dim_ex(ir::Size::new_const(UNROLL), DimKind::UNROLL);
         let strides = vec![
-            (d3, ir::Size::new(THREAD_Y * THREAD_X * 32 * 4, vec![], 1)),
-            (d1_1, ir::Size::new(THREAD_X * 32 * 4, vec![], 1)),
-            (d2_1, ir::Size::new(STRIDE * 4, vec![], 1)),
+            (&d3, ir::Size::new_const(THREAD_Y * THREAD_X * 32 * 4)),
+            (&d1_1, ir::Size::new_const(THREAD_X * 32 * 4)),
+            (&d2_1, ir::Size::new_const(STRIDE * 4)),
         ];
-        let pattern = ir::AccessPattern::Tensor {
-            mem_id: ir::MemId::External(0),
-            dims: strides.iter().cloned().collect(),
-        };
+        let mem0 = ir::MemId::External(0);
+        let pattern = builder.tensor_access_pattern(mem0, strides.clone());
         let addr = builder.induction_var(&"array", strides);
         let val = builder.ld_ex(t, &addr, pattern, InstFlag::MEM_CG);
         let acc = builder.add(&val, &Reduce(init));
@@ -89,25 +85,21 @@ impl PerfModelTest for L2LinesPressure {
 
         let t = ir::Type::F(32);
         let size_n = builder.param_size("n");
-        let d1_0 =
-            builder.open_dim_ex(ir::Size::new(THREAD_Y, vec![], 1), DimKind::THREAD);
-        let d2_0 =
-            builder.open_dim_ex(ir::Size::new(THREAD_X, vec![], 1), DimKind::THREAD);
+        let d1_0 = builder.open_dim_ex(ir::Size::new_const(THREAD_Y), DimKind::THREAD);
+        let d2_0 = builder.open_dim_ex(ir::Size::new_const(THREAD_X), DimKind::THREAD);
         let init = builder.mov(&0f32);
 
         let d0 = builder.open_dim_ex(size_n.clone(), DimKind::LOOP);
-        let d1_1 = builder.open_mapped_dim(&d1_0)[0];
-        let d2_1 = builder.open_mapped_dim(&d2_0)[0];
-        let d3 = builder.open_dim_ex(ir::Size::new(UNROLL, vec![], 1), DimKind::UNROLL);
+        let d1_1 = builder.open_mapped_dim(&d1_0);
+        let d2_1 = builder.open_mapped_dim(&d2_0);
+        let d3 = builder.open_dim_ex(ir::Size::new_const(UNROLL), DimKind::UNROLL);
         let strides = vec![
-            (d3, ir::Size::new(THREAD_Y * THREAD_X * 8 * 4, vec![], 1)),
-            (d1_1, ir::Size::new(THREAD_X * 8 * 4, vec![], 1)),
-            (d2_1, ir::Size::new(STRIDE * 4, vec![], 1)),
+            (&d3, ir::Size::new_const(THREAD_Y * THREAD_X * 8 * 4)),
+            (&d1_1, ir::Size::new_const(THREAD_X * 8 * 4)),
+            (&d2_1, ir::Size::new_const(STRIDE * 4)),
         ];
-        let pattern = ir::AccessPattern::Tensor {
-            mem_id: ir::MemId::External(0),
-            dims: strides.iter().cloned().collect(),
-        };
+        let mem0 = ir::MemId::External(0);
+        let pattern = builder.tensor_access_pattern(mem0, strides.clone());
         let addr = builder.induction_var(&"array", strides);
         let val = builder.ld_ex(t, &addr, pattern, InstFlag::MEM_CG);
         let acc = builder.add(&val, &Reduce(init));
@@ -154,25 +146,28 @@ impl PerfModelTest for SharedLoad {
         let mem = builder.allocate_shared(8 * 32 * 32 * 4);
         let d0 = builder.open_dim_ex(size_0, DimKind::THREAD);
         let d1 = builder.open_dim_ex(size_1, DimKind::THREAD);
-        let ptr_to_mem_type = builder.type_of(&mem);
+        let (ptr_0, pattern) =
+            builder.tensor_access(&mem, mem.into(), ir::Type::F(64), &[&d1, &d0]);
+        let ptr_1 = builder.mov(&ptr_0);
+        let ptr_to_mem_type = ir::Type::PtrTo(mem.into());
         let ptr_zero = builder.cast(&"arg_zero", ptr_to_mem_type);
-        let idx = builder.mad(&d1, &32i32, &d0);
-        let ptr_0 = builder.mad(&idx, &8i32, &mem);
         let acc_0 = builder.mov(&0f32);
         let d2 = builder.open_dim_ex(size_2, DimKind::LOOP);
         let d3_size = builder.cst_size(100);
         let d3 = builder.open_dim_ex(d3_size, DimKind::UNROLL);
-        let ptr = builder.add(&Reduce(ptr_0), &ptr_zero);
-        let pattern =
-            builder.tensor_access_pattern(mem.into(), &ir::Type::F(64), &[&d1, &d0]);
+        let ptr = builder.add(&Reduce(ptr_1), &ptr_zero);
         let ld = builder.ld(ir::Type::F(32), &ptr, pattern);
         let acc = builder.add(&Reduce(acc_0), &ld);
         builder.close_dim(&d2);
         builder.close_dim(&d3);
         let out_pattern = builder.unknown_access_pattern(ir::MemId::External(0));
         builder.st_ex(&"out", &acc, true, out_pattern, InstFlag::MEM_CS);
-        builder.order(&ptr_zero, &idx, Order::BEFORE);
-        SharedLoad { d0, d1, d2, d3 }
+        SharedLoad {
+            d0: d0[0],
+            d1: d1[0],
+            d2: d2[0],
+            d3: d3[0],
+        }
     }
 
     fn get_actions(&self) -> Vec<Action> {
@@ -211,18 +206,25 @@ impl PerfModelTest for VectorSharedLoad {
         let d1 = builder.open_dim_ex(size_1, DimKind::THREAD);
         let acc_0 = builder.mov(&0f32);
         let d2 = builder.open_dim_ex(size_2, DimKind::LOOP);
-        let d3 = builder.open_dim_ex(ir::Size::new(64, vec![], 1), DimKind::UNROLL);
-        let d4 = builder.open_dim_ex(ir::Size::new(4, vec![], 1), DimKind::VECTOR);
+        let d3 = builder.open_dim_ex(ir::Size::new_const(64), DimKind::UNROLL);
+        let d4 = builder.open_dim_ex(ir::Size::new_const(4), DimKind::VECTOR);
         let (addr, pattern) =
-            builder.tensor_access(&mem, mem.into(), &ir::Type::F(32), &[&d3, &d4]);
+            builder.tensor_access(&mem, mem.into(), ir::Type::F(32), &[&d3, &d4]);
         let ld = builder.ld(ir::Type::F(32), &addr, pattern);
-        let d4_2 = builder.open_mapped_dim(&d4)[0];
+        let d4_2 = builder.open_mapped_dim(&d4);
         let acc = builder.add(&Reduce(acc_0), &ld);
-        builder.close_dim(&DimGroup::new(vec![d2, d3, d4_2]));
+        builder.close_dim(&d2);
+        builder.close_dim(&d3);
+        builder.close_dim(&d4_2);
         let out_pattern = builder.unknown_access_pattern(ir::MemId::External(0));
         builder.st_ex(&"out", &acc, true, out_pattern, InstFlag::MEM_CS);
 
-        VectorSharedLoad { d0, d1, d2, d3 }
+        VectorSharedLoad {
+            d0: d0[0],
+            d1: d1[0],
+            d2: d2[0],
+            d3: d3[0],
+        }
     }
 
     fn get_actions(&self) -> Vec<Action> {
@@ -254,21 +256,22 @@ impl PerfModelTest for SharedReplay {
         let mem = builder.allocate_shared(8 * 32 * 32 * 4);
         let d0 = builder.open_dim_ex(size_0, DimKind::THREAD);
         let d1 = builder.open_dim_ex(size_1, DimKind::THREAD);
-        let ptr_to_mem_type = builder.type_of(&mem);
+        let ptr_to_mem_type = ir::Type::PtrTo(mem.into());
         let ptr_zero = builder.cast(&"arg_zero", ptr_to_mem_type);
         let init = builder.mov(&0f32);
-        let idx = builder.mad(&d0, &32i32, &d1);
-        let addr_0 = builder.mad(&idx, &8i32, &mem);
-        let pattern =
-            builder.tensor_access_pattern(mem.into(), &ir::Type::F(64), &[&d0, &d1]);
+        let (addr_0, pattern) =
+            builder.tensor_access(&mem, mem.into(), ir::Type::F(64), &[&d0, &d1]);
+        let addr_1 = builder.mov(&addr_0);
         let d2 = builder.open_dim_ex(size_2, DimKind::LOOP);
-        let d4 = builder.open_dim_ex(ir::Size::new(32, vec![], 1), DimKind::UNROLL);
-        let d3_0 = builder.open_dim_ex(ir::Size::new(4, vec![], 1), DimKind::UNROLL);
-        let addr = builder.add(&Reduce(addr_0), &ptr_zero);
+        let d4 = builder.open_dim_ex(ir::Size::new_const(32), DimKind::UNROLL);
+        let d3_0 = builder.open_dim_ex(ir::Size::new_const(4), DimKind::UNROLL);
+        let addr = builder.add(&Reduce(addr_1), &ptr_zero);
         let val = builder.ld(ir::Type::F(32), &addr, pattern);
-        let d3_1 = builder.open_mapped_dim(&d3_0)[0];
+        let d3_1 = builder.open_mapped_dim(&d3_0);
         let acc = builder.add(&val, &Reduce(init));
-        builder.close_dim(&DimGroup::new(vec![d2, d4, d3_1]));
+        builder.close_dim(&d2);
+        builder.close_dim(&d4);
+        builder.close_dim(&d3_1);
         let out_pattern = builder.unknown_access_pattern(ir::MemId::External(0));
 
         builder.st_ex(&"out", &acc, true, out_pattern, InstFlag::MEM_CS);
@@ -302,24 +305,29 @@ impl PerfModelTest for VectorSharedReplay {
         let mem = builder.allocate_shared(mem_size);
         let d0 = builder.open_dim_ex(size_0, DimKind::THREAD);
         let d1 = builder.open_dim_ex(size_1, DimKind::THREAD);
-        let ptr_to_mem_type = builder.type_of(&mem);
+        let ptr_to_mem_type = ir::Type::PtrTo(mem.into());
         let ptr_zero = builder.cast(&"arg_zero", ptr_to_mem_type);
         let init = builder.mov(&0f32);
         let idx = builder.mad(&d0, &32i32, &d1);
         let addr_0 = builder.mad(&idx, &16i32, &mem);
         let d2 = builder.open_dim_ex(size_2, DimKind::LOOP);
-        let d4 = builder.open_dim_ex(ir::Size::new(32, vec![], 1), DimKind::UNROLL);
+        let d4 = builder.open_dim_ex(ir::Size::new_const(32), DimKind::UNROLL);
         let addr = builder.add(&Reduce(addr_0), &ptr_zero);
-        let d3_0 = builder.open_dim_ex(ir::Size::new(4, vec![], 1), DimKind::VECTOR);
+        let d3_0 = builder.open_dim_ex(ir::Size::new_const(4), DimKind::VECTOR);
         let pattern = builder.tensor_access_pattern(
             mem.into(),
-            &ir::Type::F(32),
-            &[&d0, &d1, &d3_0],
+            vec![
+                (&d0, ir::Size::new_const(4 * 4 * 32)),
+                (&d1, ir::Size::new_const(4 * 4)),
+                (&d3_0, ir::Size::new_const(4)),
+            ],
         );
         let val = builder.ld(ir::Type::F(32), &addr, pattern);
-        let d3_1 = builder.open_mapped_dim(&d3_0)[0];
+        let d3_1 = builder.open_mapped_dim(&d3_0);
         let acc = builder.add(&val, &Reduce(init));
-        builder.close_dim(&DimGroup::new(vec![d2, d4, d3_1]));
+        builder.close_dim(&d2);
+        builder.close_dim(&d4);
+        builder.close_dim(&d3_1);
         let out_pattern = builder.unknown_access_pattern(ir::MemId::External(0));
 
         builder.st_ex(&"out", &acc, true, out_pattern, InstFlag::MEM_CS);

--- a/tools/bench_perf_model/memory.rs
+++ b/tools/bench_perf_model/memory.rs
@@ -1,6 +1,6 @@
 //! Tests the memory model.
 use telamon::device::{ArgMap, Context};
-use telamon::helper::{Builder, DimGroup, Reduce, SignatureBuilder};
+use telamon::helper::{Builder, Reduce, SignatureBuilder};
 use telamon::ir;
 use telamon::search_space::{Action, DimKind, InstFlag, Order};
 use PerfModelTest;

--- a/tools/bench_perf_model/tests.rs
+++ b/tools/bench_perf_model/tests.rs
@@ -1,5 +1,5 @@
 use telamon::device::{ArgMap, Context};
-use telamon::helper::{Builder, MetaDimension, Reduce, SignatureBuilder};
+use telamon::helper::{Builder, Reduce, SignatureBuilder};
 use telamon::ir;
 use telamon::search_space::{Action, DimKind, InstFlag, Order};
 use PerfModelTest;
@@ -15,7 +15,7 @@ impl PerfModelTest for Test0 {
         const M: i32 = 1024;
         const N: i32 = 1024;
         const K: i32 = 1024;
-        builder.scalar("m", M);
+        builder.scalar("m", M / (T1 * T2));
         builder.scalar("n", N);
         builder.scalar("k", K);
         builder.array::<f32>("a", (M * K) as usize);
@@ -49,7 +49,7 @@ impl PerfModelTest for Test0 {
         let (a_addr, a_pattern) = builder.tensor_access(
             &"a",
             a,
-            &ir::Type::F(32),
+            ir::Type::F(32),
             &[&b1, &thread_dim_1, &a_ld_unroll_dim, &k0_dim, &thread_dim_0],
         );
         let a_ld = builder.ld_ex(ir::Type::F(32), &a_addr, a_pattern, InstFlag::MEM_CG);
@@ -59,7 +59,7 @@ impl PerfModelTest for Test0 {
         let (b_addr, b_pattern) = builder.tensor_access(
             &"b",
             b,
-            &ir::Type::F(32),
+            ir::Type::F(32),
             &[&k0_dim, &thread_dim_1, &b0, &thread_dim_0, &b_ld_unroll_dim],
         );
         let b_ld = builder.ld_ex(ir::Type::F(32), &b_addr, b_pattern, InstFlag::MEM_CG);
@@ -69,7 +69,7 @@ impl PerfModelTest for Test0 {
         let (a_tmp_addr, a_tmp_st_pattern) = builder.tensor_access(
             &a_tmp_mem,
             a_tmp_mem.into(),
-            &ir::Type::F(32),
+            ir::Type::F(32),
             &[&thread_dim_1, &thread_dim_0, &a_st_tmp_unroll_dim],
         );
         builder.st(&a_tmp_addr, &a_ld, a_tmp_st_pattern);
@@ -79,7 +79,7 @@ impl PerfModelTest for Test0 {
         let (b_tmp_addr, b_tmp_st_pattern) = builder.tensor_access(
             &b_tmp_mem,
             b_tmp_mem.into(),
-            &ir::Type::F(32),
+            ir::Type::F(32),
             &[&thread_dim_1, &thread_dim_0, &b_st_tmp_unroll_dim],
         );
         builder.st(&b_tmp_addr, &b_ld, b_tmp_st_pattern);
@@ -137,7 +137,7 @@ impl PerfModelTest for Test1 {
         let (addr, pattern) = builder.tensor_access(
             &a_tmp_mem,
             a_tmp_mem.into(),
-            &ir::Type::F(32),
+            ir::Type::F(32),
             &[&thread_dim_1_0, &unroll_dim_a],
         );
         let a_val = builder.ld_ex(ir::Type::F(32), &addr, pattern, InstFlag::MEM_CG);
@@ -146,14 +146,14 @@ impl PerfModelTest for Test1 {
         let unroll_dims_1 = builder.open_mapped_dim(&unroll_dim_0_0);
         let a_op = builder.dim_map(
             a_val,
-            &[(&unroll_dim_a, &unroll_dims_1[0])],
+            &[(&unroll_dim_a, &unroll_dims_1)],
             ir::DimMapScope::Thread,
         );
         let acc = builder.mad(&a_op, &2f32, &Reduce(acc_init));
         builder.close_dim(&k_dim);
 
         let _ = builder.open_mapped_dim(&unroll_dims_1);
-        let (addr, pattern) = builder.tensor_access(&"out", out, &ir::Type::F(32), &[]);
+        let (addr, pattern) = builder.tensor_access(&"out", out, ir::Type::F(32), &[]);
         let _ = builder.st_ex(&addr, &acc, true, pattern, InstFlag::MEM_CS);
 
         builder.order(&k_dim, &thread_dim_1_0, Order::INNER);
@@ -214,7 +214,7 @@ impl PerfModelTest for Test2 {
         let (addr, pattern) = builder.tensor_access(
             &a_tmp_mem,
             a_tmp_mem.into(),
-            &ir::Type::F(32),
+            ir::Type::F(32),
             &[&thread_dims_0_1, &unroll_dim_a],
         );
         let a_val = builder.ld_ex(ir::Type::F(32), &addr, pattern, InstFlag::MEM_CG);
@@ -224,7 +224,7 @@ impl PerfModelTest for Test2 {
         let (addr, pattern) = builder.tensor_access(
             &b_tmp_mem,
             b_tmp_mem.into(),
-            &ir::Type::F(32),
+            ir::Type::F(32),
             &[&thread_dims_1_1, &unroll_dim_b],
         );
         let b_val = builder.ld_ex(ir::Type::F(32), &addr, pattern, InstFlag::MEM_SHARED);
@@ -252,7 +252,7 @@ impl PerfModelTest for Test2 {
         let (addr, pattern) = builder.tensor_access(
             &"out",
             out,
-            &ir::Type::F(32),
+            ir::Type::F(32),
             &[
                 &thread_dims_0_2,
                 &unroll_dims_0_2,
@@ -269,7 +269,7 @@ impl PerfModelTest for Test2 {
         builder.order(&unroll_dim_a, &unroll_dim_b, Order::BEFORE);
         builder.order(&unroll_dim_b, &unroll_dims_0_1, Order::BEFORE);
 
-        for id in unroll_dims_1_2.ids() {
+        for id in &unroll_dims_1_2 {
             builder.action(Action::DimKind(id, DimKind::VECTOR));
         }
 

--- a/tools/bench_perf_model/tests.rs
+++ b/tools/bench_perf_model/tests.rs
@@ -6,6 +6,12 @@ use PerfModelTest;
 
 pub struct Test0;
 
+impl Test0 {
+    const TILE_1: i32 = 32;
+
+    const TILE_2: i32 = 4;
+}
+
 impl PerfModelTest for Test0 {
     fn name() -> &'static str {
         "test_0"
@@ -15,25 +21,23 @@ impl PerfModelTest for Test0 {
         const M: i32 = 1024;
         const N: i32 = 1024;
         const K: i32 = 1024;
-        builder.scalar("m", M / (T1 * T2));
-        builder.scalar("n", N);
-        builder.scalar("k", K);
+        builder.scalar("m", M / (Self::TILE_1 * Self::TILE_2));
+        builder.scalar("n", N / (Self::TILE_1 * Self::TILE_2));
+        builder.scalar("k", K / Self::TILE_1);
         builder.array::<f32>("a", (M * K) as usize);
         builder.array::<f32>("b", (K * N) as usize);
     }
 
     fn gen_function(builder: &mut Builder) -> Self {
-        let tile_1 = 32;
-        let tile_2 = 4;
-        let tile_1_size = builder.cst_size(tile_1);
-        let tile_2_size = builder.cst_size(tile_2);
-        let tmp_mem_size = 4 * tile_1 * tile_1 * tile_2;
+        let tile_1_size = builder.cst_size(Self::TILE_1 as u32);
+        let tile_2_size = builder.cst_size(Self::TILE_2 as u32);
+        let tmp_mem_size = 4 * (Self::TILE_1 * Self::TILE_2) as u32;
         let a_tmp_mem = builder.allocate_shared(tmp_mem_size);
         let b_tmp_mem = builder.allocate_shared(tmp_mem_size);
         // Configure dimension sizes
-        let m_tiled = builder.tile_size("m", tile_1 * tile_2);
-        let n_tiled = builder.tile_size("n", tile_1 * tile_2);
-        let k_tiled = builder.tile_size("k", tile_1);
+        let m_tiled = builder.param_size("m");
+        let n_tiled = builder.param_size("n");
+        let k_tiled = builder.param_size("k");
 
         let a = ir::MemId::External(0);
         let b = ir::MemId::External(1);
@@ -106,11 +110,7 @@ impl PerfModelTest for Test1 {
     }
 
     fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
-        const M: i32 = 1024;
-        const N: i32 = 1024;
         const K: i32 = 1024;
-        builder.scalar("m", M);
-        builder.scalar("n", N);
         builder.scalar("k", K);
         builder.array::<f32>("out", 4 * 32 * 32 * 4 as usize);
     }
@@ -165,6 +165,12 @@ impl PerfModelTest for Test1 {
 
 pub struct Test2;
 
+impl Test2 {
+    const TILE_1: i32 = 32;
+
+    const TILE_2: i32 = 4;
+}
+
 impl PerfModelTest for Test2 {
     fn name() -> &'static str {
         "test_2"
@@ -174,25 +180,23 @@ impl PerfModelTest for Test2 {
         const M: i32 = 1024;
         const N: i32 = 1024;
         const K: i32 = 1024;
-        builder.scalar("m", M);
-        builder.scalar("n", N);
+        builder.scalar("m", M / (Self::TILE_1 * Self::TILE_2));
+        builder.scalar("n", N / (Self::TILE_1 * Self::TILE_2));
         builder.scalar("k", K);
         builder.array::<f32>("out", 4 * 32 * 32 * 4 as usize);
     }
 
     fn gen_function(builder: &mut Builder) -> Self {
-        let tile_1 = 32;
-        let tile_2 = 4;
-        let tile_1_size = builder.cst_size(tile_1);
-        let tile_2_size = builder.cst_size(tile_2);
-        let tmp_mem_size = 4 * tile_1 * tile_2;
+        let tile_1_size = builder.cst_size(Self::TILE_1 as u32);
+        let tile_2_size = builder.cst_size(Self::TILE_2 as u32);
+        let tmp_mem_size = 4 * (Self::TILE_1 * Self::TILE_2) as u32;
         let a_tmp_mem = builder.allocate(tmp_mem_size, true);
         let b_tmp_mem = builder.allocate(tmp_mem_size, true);
         let out = ir::MemId::External(0);
 
         // Configure dimension sizes
-        let m_tiled = builder.tile_size("m", tile_1 * tile_2);
-        let n_tiled = builder.tile_size("n", tile_1 * tile_2);
+        let m_tiled = builder.param_size("m");
+        let n_tiled = builder.param_size("n");
         let b0 = builder.open_dim_ex(n_tiled, DimKind::BLOCK);
         let b1 = builder.open_dim_ex(m_tiled, DimKind::BLOCK);
         builder.order(&b0, &b1, Order::OUTER);


### PR DESCRIPTION
This PR changes how we handle dimensions. All dimensions created before the search is started are now registered in a logical dimension. Logical dimensions are groups of actual dimension that form a (possibly) tiled dimension in the original code. 

One of the side effect is that the user now exclusively deals with logical dimensions when interacting with the builder. All the magic to convert the indexes/access patterns/nestings on logical dimension to actual dimensions is hidden in the builder.

This allowed us to split the size of dimensions in two types.
- The old `ir::Size` type is simplified to remove the tiling information. It now corresponds to the size of a logical dimension.
- An `ir::PartialSize` type is added, it corresponds to the size of an actual dimension. Later, this type will be modified to depend on the decisions exposed in the domain.