### PR TITLE
Filters where not run when some sets where too small

### DIFF
--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -46,7 +46,7 @@ impl MMSig {
         let ld_a_m = builder.open_tiled_dim(m_size, &[16, 4]);
         let ld_a_k = builder.open_tiled_dim(k_size.clone(), &[16]);
         let (ptr, pattern) =
-            builder.tensor_access(&"a", self.a, &DATA_TYPE, &[&ld_a_m, &ld_a_k]);
+            builder.tensor_access(&"a", self.a, DATA_TYPE, &[&ld_a_m, &ld_a_k]);
         let ld_a = builder.ld_nc(DATA_TYPE.clone(), &ptr, pattern);
         builder.close_dim(&ld_a_m);
         builder.close_dim(&ld_a_k);
@@ -54,7 +54,7 @@ impl MMSig {
         let ld_b_k = builder.open_tiled_dim(k_size, &[16]);
         let ld_b_n = builder.open_tiled_dim(n_size, &[16, 4]);
         let (ptr, pattern) =
-            builder.tensor_access(&"b", self.b, &DATA_TYPE, &[&ld_b_k, &ld_b_n]);
+            builder.tensor_access(&"b", self.b, DATA_TYPE, &[&ld_b_k, &ld_b_n]);
         let ld_b = builder.ld_nc(DATA_TYPE, &ptr, pattern);
         builder.close_dim(&ld_b_k);
         builder.close_dim(&ld_b_n);
@@ -69,12 +69,12 @@ impl MMSig {
         let a_op = builder.dim_map(
             ld_a,
             &[(&ld_a_m, &acc_m), (&ld_a_k, &acc_k)],
-            ir::DimMapScope::Global,
+            ir::DimMapScope::Global(()),
         );
         let b_op = builder.dim_map(
             ld_b,
             &[(&ld_b_k, &acc_k), (&ld_b_n, &acc_n)],
-            ir::DimMapScope::Global,
+            ir::DimMapScope::Global(()),
         );
         let acc = builder.mad(&a_op, &b_op, &helper::Reduce(init));
 
@@ -82,7 +82,7 @@ impl MMSig {
         let st_m = builder.open_mapped_dim(&acc_m);
         let st_n = builder.open_mapped_dim(&acc_n);
         let (ptr, pattern) =
-            builder.tensor_access(&"c", self.c, &DATA_TYPE, &[&st_m, &st_n]);
+            builder.tensor_access(&"c", self.c, DATA_TYPE, &[&st_m, &st_n]);
         let st = builder.st(&ptr, &acc, pattern);
         // order for correctness.
         builder.order(&st, &acc_k, Order::AFTER);

--- a/examples/matmul.rs
+++ b/examples/matmul.rs
@@ -7,7 +7,7 @@
 extern crate env_logger;
 extern crate telamon;
 
-use telamon::device::{Context, cuda};
+use telamon::device::{cuda, Context};
 use telamon::{explorer, helper, ir, search_space};
 
 // Define the problem size.
@@ -93,10 +93,12 @@ fn main() {
 
     // Step 3. Apply manual decisions and retrieve the search space.
     // Don't use caches to load `A`.
-    builder.action(search_space::Action::InstFlag(ld_a.inst(), search_space::InstFlag::MEM_CS));
+    builder.action(search_space::Action::InstFlag(
+        ld_a.inst(),
+        search_space::InstFlag::MEM_CS,
+    ));
     let space = builder.get();
 
     // Step 4. Launch a search.
     explorer::find_best(&Default::default(), &context, vec![space]).unwrap();
-
 }

--- a/telamon-gen/cc_tests/src/filter_merge.exh
+++ b/telamon-gen/cc_tests/src/filter_merge.exh
@@ -1,0 +1,24 @@
+set Objects:
+  item_type = "ir::objects::Obj"
+  id_type = "ir::objects::Id"
+  item_getter = "ir::objects::get($fun, $id)"
+  id_getter = "ir::objects::Obj::id($item)"
+  iterator = "ir::objects::iter($fun)"
+  new_objs = "$objs.objects"
+end
+
+define enum foo($obj in Objects):
+  value A:
+  value B:
+  value C:
+end
+
+// Create a constraints with 2 objects and a constraint with 3 objects. Ensure the first
+// apply even if their is less than 3 objects.
+require forall $obj0 in Objects:
+  forall $obj1 in Objects:
+    foo($obj0) is A || foo($obj1) is A
+require forall $obj0 in Objects:
+  forall $obj1 in Objects:
+    forall $obj2 in Objects:
+      foo($obj0) is B || foo($obj1) is B || foo($obj2) is B

--- a/telamon-gen/cc_tests/src/main.rs
+++ b/telamon-gen/cc_tests/src/main.rs
@@ -1344,7 +1344,7 @@ mod filter_merge {
         let store = &mut DomainStore::new(&fun);
         store.set_foo(obj1, Foo::C);
         let actions = init_domain(store, &mut fun).unwrap();
-        let mut fun = &mut Arc::new(fun);
+        let fun = &mut Arc::new(fun);
         assert!(apply_decisions(actions, fun, store).is_ok());
         assert_eq!(store.get_foo(obj0), Foo::A);
     }

--- a/telamon-gen/cc_tests/src/main.rs
+++ b/telamon-gen/cc_tests/src/main.rs
@@ -1327,3 +1327,25 @@ mod integer_set {
         assert_eq!(store.get_int2(obj2), only_3);
     }
 }
+
+mod filter_merge {
+    define_ir! { struct objects; }
+    generated_file!(filter_merge);
+    use self::filter_merge::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn ensure_not_merged() {
+        let _ = ::env_logger::try_init();
+        let mut fun = ir::Function::default();
+        let obj0 = ir::objects::create(&mut fun, false);
+        let obj1 = ir::objects::create(&mut fun, false);
+
+        let store = &mut DomainStore::new(&fun);
+        store.set_foo(obj1, Foo::C);
+        let actions = init_domain(store, &mut fun).unwrap();
+        let mut fun = &mut Arc::new(fun);
+        assert!(apply_decisions(actions, fun, store).is_ok());
+        assert_eq!(store.get_foo(obj0), Foo::A);
+    }
+}

--- a/telamon-gen/src/flat_filter.rs
+++ b/telamon-gen/src/flat_filter.rs
@@ -69,6 +69,7 @@ impl FlatFilter {
 
     /// Try to merge another filter into `Self`.
     fn try_merge(&mut self, other: &FlatFilter, ir_desc: &ir::IrDesc) -> bool {
+        // FIXME: do not set the merged flag if the set of foralls is bigger
         if self.inputs.is_empty() != other.inputs.is_empty() {
             return false;
         }

--- a/telamon-gen/src/flat_filter.rs
+++ b/telamon-gen/src/flat_filter.rs
@@ -110,11 +110,16 @@ impl FlatFilter {
             // Adapt and merge the rules.
             self.rules
                 .extend(other.rules.iter().map(|r| r.adapt(&adaptator)));
-            // Early exit for static filters.
-            if self.inputs.is_empty() {
-                return true;
+            // If the number of variable is different, don't set the merged flag: otherwise, the
+            // filter might not be run if their is not enought to objects to run the filter with
+            // more variables.
+            if self.vars.len() == other.vars.len() {
+                // Early exit for static filters.
+                if self.inputs.is_empty() {
+                    return true;
+                }
+                merged = true;
             }
-            merged = true;
         }
         merged
     }

--- a/telamon-gen/src/flat_filter.rs
+++ b/telamon-gen/src/flat_filter.rs
@@ -110,9 +110,10 @@ impl FlatFilter {
             // Adapt and merge the rules.
             self.rules
                 .extend(other.rules.iter().map(|r| r.adapt(&adaptator)));
-            // If the number of variable is different, don't set the merged flag: otherwise, the
-            // filter might not be run if their is not enought to objects to run the filter with
-            // more variables.
+            // Don't set the merged flag if the variables sets are different. Otherwise, the filter
+            // will not be run when one of the different set is empty. The inclusion between the
+            // lists of sets is already tested so we only need to make sure they have the same
+            // size.
             if self.vars.len() == other.vars.len() {
                 // Early exit for static filters.
                 if self.inputs.is_empty() {


### PR DESCRIPTION
Telamon-gen generates filters to propagate the constraints. When the inputs of one filter are included in the inputs of another, they are merged together to improve propagation strength. However, if the inputs of the second depends on more sets of objects, a copy of the original filter must be kept so it is run when the second filter is not because some set is empty (or does not contain enough values). We currently do not keep the original filter.

This PR introduced a new test that exhibited this behavior and fixes it by checking the filters depend on the same sets before setting the flag that discards the first set. The inclusion between the lists of sets is already tested so we only need to make sure they have the same size.