### PR TITLE
Add a Structure to Represent Values

### DIFF
--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -53,7 +53,7 @@ impl<'a> Function<'a> {
         );
         let device_code_args = device_code_args.into_iter().collect();
         debug!("compiling cfg {:?}", cfg);
-        let values = space.ir_instance().values().map(|v| v.clone()).collect_vec();
+        let values = space.ir_instance().values().cloned().collect_vec();
         Function {
             cfg,
             thread_dims,

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -16,6 +16,7 @@ pub struct Function<'a> {
     induction_vars: Vec<InductionVar<'a>>,
     mem_blocks: Vec<InternalMemoryRegion<'a>>,
     init_induction_levels: Vec<InductionLevel<'a>>,
+    values: Vec<ir::Value>,
     // TODO(cleanup): remove dependency on the search space
     space: &'a SearchSpace<'a>,
 }
@@ -52,6 +53,7 @@ impl<'a> Function<'a> {
         );
         let device_code_args = device_code_args.into_iter().collect();
         debug!("compiling cfg {:?}", cfg);
+        let values = space.ir_instance().values().map(|v| v.clone()).collect_vec();
         Function {
             cfg,
             thread_dims,
@@ -60,6 +62,7 @@ impl<'a> Function<'a> {
             device_code_args,
             space,
             mem_blocks,
+            values,
             init_induction_levels,
         }
     }

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -424,6 +424,7 @@ impl<'a> Function<'a, ()> {
             layouts_to_lower,
             induction_vars,
             logical_dims,
+            values
         } = self;
 
         let mut insts = SparseVec::from_vec(
@@ -458,6 +459,7 @@ impl<'a> Function<'a, ()> {
             layouts_to_lower,
             induction_vars,
             logical_dims,
+            values,
         }
     }
 }

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -1,7 +1,7 @@
 //! Provides a representation of functions.
 use device::Device;
 use ir::mem::Block;
-use ir::{self, BBId, Dimension, InstId, Instruction, Operator, Statement, Value, ValueId};
+use ir::{self, BBId, Dimension, InstId, Instruction, Operator, Statement, Value, ValueId, ValueDef};
 use ir::{dim, mem, AccessPattern, Operand, SparseVec, Type};
 use itertools::Itertools;
 use std;
@@ -68,7 +68,7 @@ pub struct Function<'a, L = ir::LoweringMap> {
     layouts_to_lower: Vec<ir::mem::InternalId>,
     induction_vars: Vec<ir::InductionVar<'a, L>>,
     logical_dims: Vec<ir::LogicalDim<'a>>,
-    values: SparseVec<ir::ValueId, ir::Value>,
+    values: SparseVec<ValueId, Value>,
 }
 
 impl<'a, L> Function<'a, L> {
@@ -125,8 +125,8 @@ impl<'a, L> Function<'a, L> {
     }
 
     /// Returns a Value without adding it to self.values
-    fn create_value(id: ir::ValueId, t: Type, def: ir::ValueDef) -> Result<ir::Value, ir::Error> {
-        Ok(ir::Value::new(id, t, def))
+    fn create_value(id: ValueId, t: Type, def: ValueDef) -> Result<Value, ir::Error> {
+        Ok(Value::new(id, t, def))
     }
 
     /// Adds an induction variable.
@@ -171,7 +171,7 @@ impl<'a, L> Function<'a, L> {
     }
 
     /// Returns a mutable reference to an instruction given its id.
-    fn inst_mut(&mut self, id: InstId) -> &mut Instruction<'a, L> {
+    pub fn inst_mut(&mut self, id: InstId) -> &mut Instruction<'a, L> {
         &mut self.insts[id]
     }
 

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -131,7 +131,6 @@ impl<'a, L> Function<'a, L> {
                 let inst = &self.insts[id];
                 unwrap!(inst.t())
             }
-            _ => unreachable!(),
         };
         Ok(Value::new(id, t, def))
     }

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -1,7 +1,7 @@
 //! Provides a representation of functions.
 use device::Device;
 use ir::mem::Block;
-use ir::{self, BBId, Dimension, InstId, Instruction, Operator, Statement};
+use ir::{self, BBId, Dimension, InstId, Instruction, Operator, Statement, Value, ValueId};
 use ir::{dim, mem, AccessPattern, Operand, SparseVec, Type};
 use itertools::Itertools;
 use std;
@@ -156,7 +156,6 @@ impl<'a, L> Function<'a, L> {
         self.static_dims.iter().map(move |&id| self.dim(id))
     }
 
-    /// Returns the list of values.
     pub fn values(&self) -> impl Iterator<Item = &ir::Value> {
         self.values.iter()
     }

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -125,7 +125,7 @@ impl<'a, L> Function<'a, L> {
     }
 
     /// Returns a Value without adding it to self.values
-    fn create_value(id: ValueId, t: Type, def: ValueDef) -> Result<Value, ir::Error> {
+    fn create_value(id: ValueId, t: ir::Type, def: ValueDef) -> Result<Value, ir::Error> {
         Ok(Value::new(id, t, def))
     }
 
@@ -192,6 +192,19 @@ impl<'a, L> Function<'a, L> {
 
     /// Returns a `Value` given its id.
     pub fn value(&self, id: ir::ValueId) -> &ir::Value { &self.values[id] }
+
+    /// Adds a value to the function.
+    pub fn add_value(
+        &mut self,
+        t: ir::Type,
+        def: ir::ValueDef,
+    ) -> Result<ir::ValueId, ir::Error> {
+        let id = ir::ValueId(self.insts.len() as u16);
+        let val = Self::create_value(id, t, def)?;
+        val.def().register(val.id(), self);
+        self.values.push(val);
+        Ok(id)
+    }
 
     /// Returns the list of memory blocks. The block with id `i` is in i-th position.
     pub fn mem_blocks<'b>(&'b self) -> impl Iterator<Item = &'b mem::Block> {
@@ -353,18 +366,6 @@ impl<'a> Function<'a, ()> {
         let id = ir::InstId(self.insts.len() as u32);
         let inst = self.create_inst(id, op, iter_dims)?;
         self.insts.push(inst);
-        Ok(id)
-    }
-
-    /// Adds a value to the function.
-    pub fn add_value(
-        &mut self,
-        t: ir::Type,
-        def: ir::ValueDef,
-    ) -> Result<ir::ValueId, ir::Error> {
-        let id = ir::ValueId(self.insts.len() as u16);
-        let val = Self::create_value(id, t, def)?;
-        self.values.push(val);
         Ok(id)
     }
 

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -199,6 +199,14 @@ impl<'a, L> Function<'a, L> {
         t: ir::Type,
         def: ir::ValueDef,
     ) -> Result<ir::ValueId, ir::Error> {
+        // Check that type is coherent with definition of the value
+        match def {
+            ValueDef::Inst(id) => {
+                let inst = &self.insts[id];
+                ir::TypeError::check_equals(unwrap!(inst.t()), t)?;
+            }
+            _ => unreachable!(),
+        }
         let id = ir::ValueId(self.insts.len() as u16);
         let val = Self::create_value(id, t, def)?;
         val.def().register(val.id(), self);

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -125,7 +125,14 @@ impl<'a, L> Function<'a, L> {
     }
 
     /// Returns a Value without adding it to self.values
-    fn create_value(id: ValueId, t: ir::Type, def: ValueDef) -> Result<Value, ir::Error> {
+    fn create_value(&self, id: ValueId, def: ValueDef) -> Result<Value, ir::Error> {
+        let t = match def {
+            ValueDef::Inst(id) => {
+                let inst = &self.insts[id];
+                unwrap!(inst.t())
+            }
+            _ => unreachable!(),
+        };
         Ok(Value::new(id, t, def))
     }
 
@@ -196,19 +203,10 @@ impl<'a, L> Function<'a, L> {
     /// Adds a value to the function.
     pub fn add_value(
         &mut self,
-        t: ir::Type,
         def: ir::ValueDef,
     ) -> Result<ir::ValueId, ir::Error> {
-        // Check that type is coherent with definition of the value
-        match def {
-            ValueDef::Inst(id) => {
-                let inst = &self.insts[id];
-                ir::TypeError::check_equals(unwrap!(inst.t()), t)?;
-            }
-            _ => unreachable!(),
-        }
         let id = ir::ValueId(self.insts.len() as u16);
-        let val = Self::create_value(id, t, def)?;
+        let val = self.create_value(id, def)?;
         val.def().register(val.id(), self);
         self.values.push(val);
         Ok(id)

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -68,6 +68,7 @@ pub struct Function<'a, L = ir::LoweringMap> {
     layouts_to_lower: Vec<ir::mem::InternalId>,
     induction_vars: Vec<ir::InductionVar<'a, L>>,
     logical_dims: Vec<ir::LogicalDim<'a>>,
+    values: Vec<ir::Value>,
 }
 
 impl<'a, L> Function<'a, L> {
@@ -86,6 +87,7 @@ impl<'a, L> Function<'a, L> {
             layouts_to_lower: Vec::new(),
             induction_vars: Vec::new(),
             logical_dims: Vec::new(),
+            values: Vec::new(),
         }
     }
 
@@ -149,6 +151,11 @@ impl<'a, L> Function<'a, L> {
         self.static_dims.iter().map(move |&id| self.dim(id))
     }
 
+    /// Returns the list of values.
+    pub fn values(&self) -> std::slice::Iter<ir::Value> {
+        self.values.iter()
+    }
+
     /// Returns the list of thread dimensions.
     pub fn thread_dims(&self) -> impl Iterator<Item = &Dimension<'a>> {
         self.thread_dims.iter().map(move |&d| self.dim(d))
@@ -178,6 +185,9 @@ impl<'a, L> Function<'a, L> {
     pub fn logical_dim(&self, id: ir::LogicalDimId) -> &ir::LogicalDim<'a> {
         &self.logical_dims[id.0 as usize]
     }
+
+    /// Returns a `Value` given its id.
+    pub fn value(&self, id: ir::ValueId) -> &ir::Value { &self.values[id.0 as usize] }
 
     /// Returns the list of memory blocks. The block with id `i` is in i-th position.
     pub fn mem_blocks<'b>(&'b self) -> impl Iterator<Item = &'b mem::Block> {

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -124,6 +124,11 @@ impl<'a, L> Function<'a, L> {
         Ok(inst)
     }
 
+    /// Returns a Value without adding it to self.values
+    fn create_value(id: ir::ValueId, t: Type, def: ir::ValueDef) -> Result<ir::Value, ir::Error> {
+        Ok(ir::Value::new(id, t, def))
+    }
+
     /// Adds an induction variable.
     pub fn add_ind_var(&mut self, ind_var: ir::InductionVar<'a, L>) -> ir::IndVarId {
         let id = ir::IndVarId(self.induction_vars.len() as u32);
@@ -351,6 +356,19 @@ impl<'a> Function<'a, ()> {
         self.insts.push(inst);
         Ok(id)
     }
+
+    /// Adds a value to the function.
+    pub fn add_value(
+        &mut self,
+        t: ir::Type,
+        def: ir::ValueDef,
+    ) -> Result<ir::ValueId, ir::Error> {
+        let id = ir::ValueId(self.insts.len() as u16);
+        let val = Self::create_value(id, t, def)?;
+        self.values.push(val);
+        Ok(id)
+    }
+
 
     /// Allocates a new memory block.
     pub fn add_mem_block(&mut self, size: u32) -> mem::InternalId {

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -68,7 +68,7 @@ pub struct Function<'a, L = ir::LoweringMap> {
     layouts_to_lower: Vec<ir::mem::InternalId>,
     induction_vars: Vec<ir::InductionVar<'a, L>>,
     logical_dims: Vec<ir::LogicalDim<'a>>,
-    values: Vec<ir::Value>,
+    values: SparseVec<ir::ValueId, ir::Value>,
 }
 
 impl<'a, L> Function<'a, L> {
@@ -87,7 +87,7 @@ impl<'a, L> Function<'a, L> {
             layouts_to_lower: Vec::new(),
             induction_vars: Vec::new(),
             logical_dims: Vec::new(),
-            values: Vec::new(),
+            values: SparseVec::new(),
         }
     }
 
@@ -157,7 +157,7 @@ impl<'a, L> Function<'a, L> {
     }
 
     /// Returns the list of values.
-    pub fn values(&self) -> std::slice::Iter<ir::Value> {
+    pub fn values(&self) -> impl Iterator<Item = &ir::Value> {
         self.values.iter()
     }
 
@@ -192,7 +192,7 @@ impl<'a, L> Function<'a, L> {
     }
 
     /// Returns a `Value` given its id.
-    pub fn value(&self, id: ir::ValueId) -> &ir::Value { &self.values[id.0 as usize] }
+    pub fn value(&self, id: ir::ValueId) -> &ir::Value { &self.values[id] }
 
     /// Returns the list of memory blocks. The block with id `i` is in i-th position.
     pub fn mem_blocks<'b>(&'b self) -> impl Iterator<Item = &'b mem::Block> {

--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -2,6 +2,7 @@
 use device::Device;
 use ir::{self, BBId, DimMapScope, LoweringMap, Operand, Operator, Statement, Type};
 use std;
+use std::hash::{Hash, Hasher};
 use utils::*;
 
 /// Uniquely identifies an instruction.
@@ -29,6 +30,7 @@ pub struct Instruction<'a, L = LoweringMap> {
     operator: Operator<'a, L>,
     id: InstId,
     iter_dims: HashSet<ir::DimId>,
+    value: Option<ir::ValueId>,
 }
 
 impl<'a, L> Instruction<'a, L> {
@@ -141,6 +143,15 @@ impl<'a, L> Instruction<'a, L> {
     /// iteration dimension.
     pub fn add_iteration_dimension(&mut self, dim: ir::DimId) -> bool {
         self.iter_dims.insert(dim)
+    }
+
+    /// Returns the `Value` holding the result of this instruction.
+    pub fn result_value(&self) -> Option<ir::ValueId> { self.value }
+
+    /// Sets the `Value` holdings the result of this instruction.
+    pub fn set_result_value(&mut self, value: ir::ValueId) {
+        // An instruction value cannot be set twice.
+        assert_eq!(std::mem::replace(&mut self.value, Some(value)), None);
     }
 }
 

--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -46,6 +46,7 @@ impl<'a, L> Instruction<'a, L> {
             operator,
             id,
             iter_dims,
+            value: None
         })
     }
 
@@ -161,6 +162,7 @@ impl<'a> Instruction<'a, ()> {
             operator: self.operator.freeze(cnt),
             id: self.id,
             iter_dims: self.iter_dims,
+            value: self.value,
         }
     }
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -11,6 +11,7 @@ mod operand;
 mod operator;
 mod size;
 mod types;
+mod value;
 
 use std;
 use std::marker::PhantomData;
@@ -28,6 +29,7 @@ pub use self::operand::{DimMapScope, LoweringMap, Operand};
 pub use self::operator::{BinOp, Operator};
 pub use self::size::{PartialSize, Size};
 pub use self::types::Type;
+pub use self::value::{Value, ValueId, ValueDef};
 
 pub mod mem;
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -66,6 +66,7 @@ pub struct NewObjs {
     pub logical_dims: Vec<LogicalDimId>,
     pub tile_dimensions: Vec<(LogicalDimId, DimId)>,
     pub tiled_dimensions: Vec<(LogicalDimId, DimId)>,
+    pub values: Vec<ValueId>,
 }
 
 impl NewObjs {
@@ -115,6 +116,10 @@ impl NewObjs {
     pub fn add_mem_block(&mut self, id: mem::InternalId) {
         self.mem_blocks.push(id.into());
         self.internal_mem_blocks.push(id);
+    }
+
+    pub fn add_value(&mut self, val: &Value) {
+        self.values.push(val.id());
     }
 }
 

--- a/src/ir/value.rs
+++ b/src/ir/value.rs
@@ -5,6 +5,12 @@ use ir;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ValueId(pub u16);
 
+impl Into<usize> for ValueId {
+    fn into(self) -> usize {
+        self.0 as usize
+    }
+}
+
 /// A value produced by the code.
 #[derive(Clone, Debug)]
 pub struct Value {

--- a/src/ir/value.rs
+++ b/src/ir/value.rs
@@ -51,7 +51,6 @@ impl ValueDef {
         // TODO change this code when we add new variant for ValueDef
         let inst_id = match self {
             ValueDef::Inst(id) => id,
-            _ => panic!(),
         };
         function.inst_mut(*inst_id).set_result_value(self_id);
     }

--- a/src/ir/value.rs
+++ b/src/ir/value.rs
@@ -2,7 +2,7 @@
 use ir;
 
 /// Uniquely identifies values.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct ValueId(pub u16);
 
 impl Into<usize> for ValueId {

--- a/src/ir/value.rs
+++ b/src/ir/value.rs
@@ -47,7 +47,7 @@ pub enum ValueDef {
 }
 
 impl ValueDef {
-    fn register(&self, self_id: ir::ValueId, function: &mut ir::Function) {
+    pub fn register<L>(&self, self_id: ir::ValueId, function: &mut ir::Function<'_, L>) {
         // TODO change this code when we add new variant for ValueDef
         let inst_id = match self {
             ValueDef::Inst(id) => id,

--- a/src/ir/value.rs
+++ b/src/ir/value.rs
@@ -46,8 +46,16 @@ pub enum ValueDef {
     // - ExternalMem
 }
 
-// FIXME: value creation
-// - allocate an id
+impl ValueDef {
+    fn register(&self, self_id: ir::ValueId, function: &mut ir::Function) {
+        // TODO change this code when we add new variant for ValueDef
+        let inst_id = match self {
+            ValueDef::Inst(id) => id,
+            _ => panic!(),
+        };
+        function.inst_mut(*inst_id).set_result_value(self_id);
+    }
+}
 // - register in the instruction
 // - retrieve the type
 // FIXME: def point

--- a/src/ir/value.rs
+++ b/src/ir/value.rs
@@ -14,6 +14,10 @@ pub struct Value {
 }
 
 impl Value {
+    pub fn new(id: ValueId, t: ir::Type, def: ValueDef) -> Self {
+        Value { id, t, def }
+    }
+
     /// Return the unique identifiers of the `Value`.
     pub fn id(&self) -> ValueId { self.id }
 

--- a/src/ir/value.rs
+++ b/src/ir/value.rs
@@ -1,0 +1,49 @@
+//! Encodes the data-flow information.
+use ir;
+
+/// Uniquely identifies values.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct ValueId(pub u16);
+
+/// A value produced by the code.
+#[derive(Clone, Debug)]
+pub struct Value {
+    id: ValueId,
+    t: ir::Type,
+    def: ValueDef,
+}
+
+impl Value {
+    /// Return the unique identifiers of the `Value`.
+    pub fn id(&self) -> ValueId { self.id }
+
+    /// Specifies how the value is defined.
+    pub fn def(&self) -> &ValueDef { &self.def }
+
+    /// Indicates the type of the value.
+    pub fn t(&self) -> &ir::Type { &self.t }
+}
+
+/// Specifies how is a `Value` defined.
+#[derive(Clone, Debug)]
+pub enum ValueDef {
+    /// Takes the value produced by an instruction.
+    Inst(ir::InstId),
+    // TODO(value):
+    // - Last
+    // - Dim Map
+    // - Fby
+    // - ExternalMem
+}
+
+// FIXME: value creation
+// - allocate an id
+// - register in the instruction
+// - retrieve the type
+// FIXME: def point
+// FIXME: use points
+// FIXME: def dims
+//  - use is in def dims ?
+//  - use is before def
+// FIXME: value in operand position
+

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -190,16 +190,6 @@ define enum inst_flag($inst in MemInsts):
 end
 
 /// Defines how two basic blocks are ordered.
-define enum value_order($lhs in Values, $rhs in Values):
-  antisymmetric:
-    BEFORE -> AFTER
-  /// $lhs is executed before $rhs.
-  value BEFORE:
-  /// $lhs is executed after $rhs.
-  value AFTER:
-end
-
-/// Defines how two basic blocks are ordered.
 define enum order($lhs in Statements, $rhs in Statements):
   antisymmetric:
     BEFORE -> AFTER

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -58,6 +58,16 @@ set StaticDims subsetof Dimensions:
   new_objs = "$objs.static_dims"
 end
 
+set Values:
+  item_type = "ir::Value"
+  id_type = "ir::ValueId"
+  item_getter = "$fun.value($id)"
+  id_getter = "$item.id()"
+  iterator = "$fun.values()"
+  var_prefix = "value"
+  new_objs = "$objs.values"
+end
+
 set MemoryRegions:
   item_type = "ir::mem::Block"
   id_type = "ir::MemId"
@@ -177,6 +187,16 @@ define enum inst_flag($inst in MemInsts):
   alias MEM_COHERENT = MEM_SHARED | MEM_CG | MEM_CS:
   /// Ensure coherency within a block between memory accesses.
   alias MEM_BLOCK_COHERENT = MEM_COHERENT | MEM_CA:
+end
+
+/// Defines how two basic blocks are ordered.
+define enum value_order($lhs in Values, $rhs in Values):
+  antisymmetric:
+    BEFORE -> AFTER
+  /// $lhs is executed before $rhs.
+  value BEFORE:
+  /// $lhs is executed after $rhs.
+  value AFTER:
 end
 
 /// Defines how two basic blocks are ordered.


### PR DESCRIPTION
Telamon's IR currently represents values as instruction inputs with ir::Operand.
Unfortunately, this does not allows us to manipulate decisions about operands and to
reason about the data flow in the program. This PR introduces a new type ir::Value
that represents a value stored in a variable. It lays the foundations for #41.