### PR TITLE
Ensure mapped dimensions have the same size

### DIFF
--- a/src/ir/dimension.rs
+++ b/src/ir/dimension.rs
@@ -1,6 +1,7 @@
 //! Represents iteration dimensions.
 use ir::{self, Statement};
 use std::fmt;
+use utils::*;
 
 /// Provides a unique identifier for iteration dimensions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize,
@@ -30,7 +31,7 @@ pub struct Dimension<'a> {
     iterated: Vec<ir::InstId>,
     is_thread_dim: bool,
     logical_dim: Option<LogicalDimId>,
-    mapped_dims: Vec<DimMappingId>,
+    mapped_dims: VecSet<DimMappingId>,
 }
 
 impl<'a> Dimension<'a> {
@@ -51,7 +52,7 @@ impl<'a> Dimension<'a> {
             iterated: Vec::new(),
             is_thread_dim: false,
             logical_dim: None,
-            mapped_dims: Vec::new(),
+            mapped_dims: VecSet::default(),
         })
     }
 
@@ -64,7 +65,7 @@ impl<'a> Dimension<'a> {
             iterated: Vec::new(),
             is_thread_dim: false,
             logical_dim: None,
-            mapped_dims: Vec::new(),
+            mapped_dims: VecSet::default(),
         }
     }
 
@@ -113,13 +114,13 @@ impl<'a> Dimension<'a> {
     }
 
     /// Returns the list of dimensions mapping containing this one.
-    pub fn dim_mappings(&self) -> impl Iterator<Item = DimMappingId> + '_ {
-        self.mapped_dims.iter().cloned()
+    pub fn dim_mappings(&self) -> &VecSet<DimMappingId> {
+        &self.mapped_dims
     }
 
     /// Register a dimension mapping.
     pub fn register_dim_mapping(&mut self, mapping: &DimMapping) {
-        self.mapped_dims.push(mapping.id);
+        self.mapped_dims.insert(mapping.id);
         assert!(mapping.dims.contains(&self.id()));
     }
 }
@@ -221,7 +222,7 @@ impl<'a> LogicalDim<'a> {
 }
 
 /// Uniquely identifies a pair of mapped dimensions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct DimMappingId(pub u16);
 
 impl From<DimMappingId> for usize {

--- a/src/ir/dimension.rs
+++ b/src/ir/dimension.rs
@@ -113,12 +113,12 @@ impl<'a> Dimension<'a> {
     }
 
     /// Returns the list of dimensions mapping containing this one.
-    pub fn mapped_dims(&self) -> impl Iterator<Item = MappedDimsId> + '_ {
+    pub fn dim_mappings(&self) -> impl Iterator<Item = MappedDimsId> + '_ {
         self.mapped_dims.iter().cloned()
     }
 
     /// Register a dimension mapping.
-    pub fn register_mapped_dims(&mut self, mapping: &MappedDims) {
+    pub fn register_dim_mapping(&mut self, mapping: &MappedDims) {
         self.mapped_dims.push(mapping.id);
         assert!(mapping.dims.contains(&self.id()));
     }
@@ -231,8 +231,21 @@ impl From<MappedDimsId> for usize {
 }
 
 /// Specifies that two dimensions should be mapped together.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct MappedDims {
-    pub id: MappedDimsId,
-    pub dims: [DimId; 2],
+    id: MappedDimsId,
+    dims: [DimId; 2],
+}
+
+impl MappedDims {
+    /// Creates a `MappedDims`. Panics if the provided dimensions are the same.
+    pub fn new(id: MappedDimsId, dims: [DimId; 2]) -> Self {
+        MappedDims { id, dims }
+    }
+
+    /// Returns the unique identifier of the `MappedDims`.
+    pub fn id(&self) -> MappedDimsId { self.id }
+
+    /// Returns the mapped dims.
+    pub fn dims(&self) -> [DimId; 2] { self.dims }
 }

--- a/src/ir/dimension.rs
+++ b/src/ir/dimension.rs
@@ -244,8 +244,12 @@ impl MappedDims {
     }
 
     /// Returns the unique identifier of the `MappedDims`.
-    pub fn id(&self) -> MappedDimsId { self.id }
+    pub fn id(&self) -> MappedDimsId {
+        self.id
+    }
 
     /// Returns the mapped dims.
-    pub fn dims(&self) -> [DimId; 2] { self.dims }
+    pub fn dims(&self) -> [DimId; 2] {
+        self.dims
+    }
 }

--- a/src/ir/dimension.rs
+++ b/src/ir/dimension.rs
@@ -30,7 +30,7 @@ pub struct Dimension<'a> {
     iterated: Vec<ir::InstId>,
     is_thread_dim: bool,
     logical_dim: Option<LogicalDimId>,
-    mapped_dims: Vec<MappedDimsId>,
+    mapped_dims: Vec<DimMappingId>,
 }
 
 impl<'a> Dimension<'a> {
@@ -113,12 +113,12 @@ impl<'a> Dimension<'a> {
     }
 
     /// Returns the list of dimensions mapping containing this one.
-    pub fn dim_mappings(&self) -> impl Iterator<Item = MappedDimsId> + '_ {
+    pub fn dim_mappings(&self) -> impl Iterator<Item = DimMappingId> + '_ {
         self.mapped_dims.iter().cloned()
     }
 
     /// Register a dimension mapping.
-    pub fn register_dim_mapping(&mut self, mapping: &MappedDims) {
+    pub fn register_dim_mapping(&mut self, mapping: &DimMapping) {
         self.mapped_dims.push(mapping.id);
         assert!(mapping.dims.contains(&self.id()));
     }
@@ -222,29 +222,29 @@ impl<'a> LogicalDim<'a> {
 
 /// Uniquely identifies a pair of mapped dimensions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct MappedDimsId(pub u16);
+pub struct DimMappingId(pub u16);
 
-impl From<MappedDimsId> for usize {
-    fn from(id: MappedDimsId) -> usize {
+impl From<DimMappingId> for usize {
+    fn from(id: DimMappingId) -> usize {
         id.0 as usize
     }
 }
 
 /// Specifies that two dimensions should be mapped together.
 #[derive(Clone, Copy, Debug)]
-pub struct MappedDims {
-    id: MappedDimsId,
+pub struct DimMapping {
+    id: DimMappingId,
     dims: [DimId; 2],
 }
 
-impl MappedDims {
-    /// Creates a `MappedDims`. Panics if the provided dimensions are the same.
-    pub fn new(id: MappedDimsId, dims: [DimId; 2]) -> Self {
-        MappedDims { id, dims }
+impl DimMapping {
+    /// Creates a `DimMapping`. Panics if the provided dimensions are the same.
+    pub fn new(id: DimMappingId, dims: [DimId; 2]) -> Self {
+        DimMapping { id, dims }
     }
 
-    /// Returns the unique identifier of the `MappedDims`.
-    pub fn id(&self) -> MappedDimsId {
+    /// Returns the unique identifier of the `DimMapping`.
+    pub fn id(&self) -> DimMappingId {
         self.id
     }
 

--- a/src/ir/error.rs
+++ b/src/ir/error.rs
@@ -102,6 +102,8 @@ pub enum Error {
         dim
     )]
     InvalidDimInPattern { dim: ir::DimId },
+    #[fail(display = "no mapping found between dimensions {} and {}", lhs, rhs)]
+    MissingDimMapping { lhs: ir::DimId, rhs: ir::DimId },
 }
 
 impl From<TypeError> for Error {

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -587,9 +587,10 @@ impl<'a> Function<'a> {
         Ok(lowered)
     }
 
-    /// Activate dimensions mapped to existing ones. Takes as input a list of mappings, in the
-    /// format `(mapping id, [old dim, new dim])`. Returns the mapping from old dimensions to new
-    /// ones if `old_to_new` is true. The mapping from new dimensions to old ones otherwise.
+    /// Create dimensions with preallocated IDs and maps then to existing dimensions. `mapping`
+    /// provides the pairs of old and new IDs along with the mapping ID. Returns a `DimMap`
+    /// containing the mapped dimensions. The boolean controls in wich order mappings should be
+    /// returned: from the old dimension to the new or the converse.
     fn activate_mapped_dims(
         &mut self,
         mappings: &[(ir::DimMappingId, [ir::DimId; 2])],

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -349,6 +349,8 @@ impl<'a, L> Function<'a, L> {
     ) -> Option<ir::DimMappingId> {
         self.dim(lhs)
             .dim_mappings()
+            .iter()
+            .cloned()
             .find(|&id| self.dim_mapping(id).dims().contains(&rhs))
     }
 

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -68,6 +68,7 @@ pub struct Function<'a, L = ir::LoweringMap> {
     layouts_to_lower: Vec<ir::mem::InternalId>,
     induction_vars: Vec<ir::InductionVar<'a, L>>,
     logical_dims: Vec<ir::LogicalDim<'a>>,
+    mapped_dims: SparseVec<ir::MappedDimsId, ir::MappedDims>,
 }
 
 impl<'a, L> Function<'a, L> {
@@ -86,6 +87,7 @@ impl<'a, L> Function<'a, L> {
             layouts_to_lower: Vec::new(),
             induction_vars: Vec::new(),
             logical_dims: Vec::new(),
+            mapped_dims: SparseVec::new(),
         }
     }
 
@@ -327,6 +329,16 @@ impl<'a, L> Function<'a, L> {
     pub(crate) fn layouts_to_lower(&self) -> &[ir::mem::InternalId] {
         &self.layouts_to_lower
     }
+
+    /// Returns the list of dimensions mapping.
+    pub fn dim_mappings(&self) -> impl Iterator<Item = &ir::MappedDims> + '_ {
+        self.mapped_dims.iter()
+    }
+
+    /// Retrives a dimension mapping given its ID.
+    pub fn dim_mapping(&self, id: ir::MappedDimsId) -> &ir::MappedDims {
+        &self.mapped_dims[id]
+    }
 }
 
 impl<'a> Function<'a, ()> {
@@ -414,6 +426,7 @@ impl<'a> Function<'a, ()> {
             layouts_to_lower,
             induction_vars,
             logical_dims,
+            mapped_dims,
         } = self;
 
         let mut insts = SparseVec::from_vec(
@@ -448,6 +461,7 @@ impl<'a> Function<'a, ()> {
             layouts_to_lower,
             induction_vars,
             logical_dims,
+            mapped_dims,
         }
     }
 }

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -596,12 +596,13 @@ impl<'a> Function<'a> {
         let dims = mappings.iter().map(|&(mapping_id, dims)| {
             let [old_dim, new_dim] = dims;
             let dimension = Dimension::with_same_size(new_dim, &self.dims[old_dim]);
-            let mapping = self.create_mapping(mapping_id, dims);
             if dimension.possible_sizes().is_some() {
                 self.static_dims.push(new_dim);
             }
-            self.dim_mappings.set_lazy(mapping_id, mapping);
             self.dims.set_lazy(new_dim, dimension);
+            // We can only create the mapping after we activate dimensions.
+            let mapping = self.create_mapping(mapping_id, dims);
+            self.dim_mappings.set_lazy(mapping_id, mapping);
             if old_to_new {
                 (old_dim, new_dim)
             } else {

--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -1,5 +1,4 @@
 //! Describes the instructions.
-use device::Device;
 use ir::{self, BBId, DimMapScope, LoweringMap, Operand, Operator, Statement, Type};
 use std;
 use utils::*;
@@ -37,9 +36,9 @@ impl<'a, L> Instruction<'a, L> {
         operator: Operator<'a, L>,
         id: InstId,
         iter_dims: HashSet<ir::DimId>,
-        device: &Device,
+        fun: &ir::Function<L>,
     ) -> Result<Self, ir::Error> {
-        operator.check(&iter_dims, device)?;
+        operator.check(&iter_dims, fun)?;
         Ok(Instruction {
             operator,
             id,

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -12,6 +12,7 @@ mod operator;
 mod size;
 mod types;
 
+use itertools::Itertools;
 use std;
 use std::marker::PhantomData;
 
@@ -19,7 +20,7 @@ pub use self::access_pattern::{AccessPattern, Stride};
 pub use self::basic_block::{BBId, Statement};
 pub use self::dim_map::DimMap;
 pub use self::dimension::{
-    DimId, Dimension, LogicalDim, LogicalDimId, MappedDims, MappedDimsId,
+    DimId, DimMapping, DimMappingId, Dimension, LogicalDim, LogicalDimId,
 };
 pub use self::error::{Error, TypeError};
 pub use self::function::{Function, Parameter, Signature};
@@ -66,6 +67,8 @@ pub struct NewObjs {
     pub logical_dims: Vec<LogicalDimId>,
     pub tile_dimensions: Vec<(LogicalDimId, DimId)>,
     pub tiled_dimensions: Vec<(LogicalDimId, DimId)>,
+    pub dim_mappings: Vec<DimMappingId>,
+    pub mapped_dims: Vec<(DimMappingId, DimId)>,
 }
 
 impl NewObjs {
@@ -75,13 +78,10 @@ impl NewObjs {
         for &dim in inst.iteration_dims() {
             self.iteration_dims.push((inst.id(), dim));
         }
+        if inst.as_mem_inst().is_some() {
+            self.mem_insts.push(inst.id());
+        }
         self.instructions.push(inst.id());
-    }
-
-    /// Registers a new memory instruction.
-    pub fn add_mem_instruction(&mut self, inst: &Instruction) {
-        self.add_instruction(inst);
-        self.mem_insts.push(inst.id());
     }
 
     /// Registers a new dimension.
@@ -116,6 +116,14 @@ impl NewObjs {
         self.mem_blocks.push(id.into());
         self.internal_mem_blocks.push(id);
     }
+
+    /// Adds a mapping between dimensions.
+    pub fn add_dim_mapping(&mut self, mapping: &DimMapping) {
+        self.dim_mappings.push(mapping.id());
+        for &dim in mapping.dims().iter() {
+            self.mapped_dims.push((mapping.id(), dim));
+        }
+    }
 }
 
 /// A point-to-point communication lowered into a store and a load.
@@ -123,7 +131,42 @@ pub struct LoweredDimMap {
     pub mem: mem::InternalId,
     pub store: InstId,
     pub load: InstId,
-    pub dimensions: Vec<(DimId, DimId)>,
+    /// Mapping from production dimensions to store dimensions.
+    pub st_dims_mapping: Vec<(DimMappingId, [DimId; 2])>,
+    /// Mapping from consumption dimensions to load dimensions.
+    pub ld_dims_mapping: Vec<(DimMappingId, [DimId; 2])>,
+}
+
+impl LoweredDimMap {
+    /// Adds the objects created by the lowering to the list of new objects.
+    pub fn register_new_objs(&self, fun: &Function, new_objs: &mut NewObjs) {
+        new_objs.add_mem_block(self.mem);
+        new_objs.add_instruction(fun.inst(self.store));
+        new_objs.add_instruction(fun.inst(self.load));
+        let mappings = self.st_dims_mapping.iter().chain(&self.ld_dims_mapping);
+        for &(mapping, [_, new_dim]) in mappings {
+            new_objs.add_dimension(fun.dim(new_dim));
+            new_objs.add_dim_mapping(fun.dim_mapping(mapping));
+        }
+    }
+
+    /// Returns the dimensions of the memory layout to create. For each dimension, gives
+    /// a pair `(store dim, load dim)`.
+    pub fn mem_dimensions(&self) -> impl Iterator<Item = (DimId, DimId)> + '_ {
+        let st_dims = self.st_dims_mapping.iter().map(|&(_, [dim, _])| dim);
+        let ld_dims = self.ld_dims_mapping.iter().map(|&(_, [dim, _])| dim);
+        st_dims.zip_eq(ld_dims)
+    }
+
+    /// Returns the dimensions that store the value.
+    pub fn store_dims(&self) -> impl Iterator<Item = DimId> + '_ {
+        self.st_dims_mapping.iter().map(|&(_, [_, dim])| dim)
+    }
+
+    /// Returns the dimensions that load the value.
+    pub fn load_dims(&self) -> impl Iterator<Item = DimId> + '_ {
+        self.ld_dims_mapping.iter().map(|&(_, [_, dim])| dim)
+    }
 }
 
 /// A vector with holes. This provides a similar interface as a
@@ -286,6 +329,7 @@ pub struct Counter {
     pub next_mem: usize,
     pub next_inst: usize,
     pub next_dim: usize,
+    pub next_dim_mapping: u16,
 }
 
 impl Counter {
@@ -304,6 +348,12 @@ impl Counter {
     pub fn next_dim(&mut self) -> DimId {
         let next = DimId(self.next_dim as u32);
         self.next_dim += 1;
+        next
+    }
+
+    pub fn next_dim_mapping(&mut self) -> DimMappingId {
+        let next = DimMappingId(self.next_dim_mapping as u16);
+        self.next_dim_mapping += 1;
         next
     }
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -18,7 +18,9 @@ use std::marker::PhantomData;
 pub use self::access_pattern::{AccessPattern, Stride};
 pub use self::basic_block::{BBId, Statement};
 pub use self::dim_map::DimMap;
-pub use self::dimension::{DimId, Dimension, LogicalDim, LogicalDimId};
+pub use self::dimension::{
+    DimId, Dimension, LogicalDim, LogicalDimId, MappedDims, MappedDimsId,
+};
 pub use self::error::{Error, TypeError};
 pub use self::function::{Function, Parameter, Signature};
 pub use self::induction_var::{IndVarId, InductionVar};

--- a/src/ir/operand.rs
+++ b/src/ir/operand.rs
@@ -192,9 +192,17 @@ impl<'a, L> Operand<'a, L> {
 
     /// Indicates if the operand stays constant during the execution.
     pub fn is_constant(&self) -> bool {
-        match *self {
+        match self {
             Int(..) | Float(..) | Addr(..) | Param(..) => true,
             Index(..) | Inst(..) | Reduce(..) | InductionVar(..) => false,
+        }
+    }
+
+    /// Returns the list of dimensions mapped together by the operand.
+    pub fn mapped_dims(&self) -> Option<&DimMap> {
+        match self {
+            Inst(_, _, dim_map, _) | Reduce(_, _, dim_map, _) => Some(dim_map),
+            _ => None,
         }
     }
 }

--- a/src/ir/operand.rs
+++ b/src/ir/operand.rs
@@ -14,12 +14,12 @@ pub struct LoweringMap {
     /// lowering.
     st_inst: ir::InstId,
     /// Maps the lhs dimensions in `map` to their lowered dimension.
-    st_map: HashMap<ir::DimId, ir::DimId>,
+    st_map: HashMap<ir::DimId, (ir::DimId, ir::DimMappingId)>,
     /// Instruction ID to use for the `load` instruction when
     /// lowering.
     ld_inst: ir::InstId,
     /// Maps the rhs dimensions in `map` to their lowered dimension.
-    ld_map: HashMap<ir::DimId, ir::DimId>,
+    ld_map: HashMap<ir::DimId, (ir::DimId, ir::DimMappingId)>,
 }
 
 impl LoweringMap {
@@ -37,7 +37,9 @@ impl LoweringMap {
             .map(|(src, dst)| {
                 let st_dim = cnt.next_dim();
                 let ld_dim = cnt.next_dim();
-                ((src, st_dim), (dst, ld_dim))
+                let st_mapping = cnt.next_dim_mapping();
+                let ld_mapping = cnt.next_dim_mapping();
+                ((src, (st_dim, st_mapping)), (dst, (ld_dim, ld_mapping)))
             })
             .unzip();
 
@@ -56,19 +58,20 @@ impl LoweringMap {
     /// ir::Function. The appropriate instructions need to be built
     /// and stored with the corresponding IDs.
     pub(crate) fn lower(&self, map: &DimMap) -> ir::LoweredDimMap {
+        let (st_dims_mapping, ld_dims_mapping) = map
+            .iter()
+            .map(|&(src, dst)| {
+                let &(st_dim, st_mapping) = unwrap!(self.st_map.get(&src));
+                let &(ld_dim, ld_mapping) = unwrap!(self.ld_map.get(&dst));
+                ((st_mapping, [src, st_dim]), (ld_mapping, [dst, ld_dim]))
+            })
+            .unzip();
         ir::LoweredDimMap {
             mem: self.mem_id,
             store: self.st_inst,
             load: self.ld_inst,
-            dimensions: map
-                .iter()
-                .map(|(src, dst)| {
-                    (
-                        unwrap!(self.st_map.get(src)).clone(),
-                        unwrap!(self.ld_map.get(dst)).clone(),
-                    )
-                })
-                .collect(),
+            st_dims_mapping,
+            ld_dims_mapping,
         }
     }
 }

--- a/src/ir/operator.rs
+++ b/src/ir/operator.rs
@@ -102,7 +102,9 @@ impl<'a, L> Operator<'a, L> {
         iter_dims: &HashSet<ir::DimId>,
         fun: &ir::Function<L>,
     ) -> Result<(), ir::Error> {
-        self.t().map(|t| fun.device().check_type(t)).unwrap_or(Ok(()))?;
+        self.t()
+            .map(|t| fun.device().check_type(t))
+            .unwrap_or(Ok(()))?;
         for operand in self.operands() {
             fun.device().check_type(operand.t())?;
             // Ensure dimension mappings are registered.

--- a/src/ir/operator.rs
+++ b/src/ir/operator.rs
@@ -111,7 +111,7 @@ impl<'a, L> Operator<'a, L> {
             if let Some(dim_map) = operand.mapped_dims() {
                 for &(lhs, rhs) in dim_map {
                     if fun.find_mapping(lhs, rhs).is_none() {
-                        // FIXME: raise an error
+                        Err(ir::Error::MissingDimMapping { lhs, rhs })?;
                     }
                 }
             }

--- a/src/ir/operator.rs
+++ b/src/ir/operator.rs
@@ -1,6 +1,5 @@
 //! Defines operators.
 use self::Operator::*;
-use device::Device;
 use ir::{self, AccessPattern, LoweringMap, Operand, Type};
 use itertools::Itertools;
 use std;
@@ -101,11 +100,19 @@ impl<'a, L> Operator<'a, L> {
     pub fn check(
         &self,
         iter_dims: &HashSet<ir::DimId>,
-        device: &Device,
+        fun: &ir::Function<L>,
     ) -> Result<(), ir::Error> {
-        self.t().map(|t| device.check_type(t)).unwrap_or(Ok(()))?;
+        self.t().map(|t| fun.device().check_type(t)).unwrap_or(Ok(()))?;
         for operand in self.operands() {
-            device.check_type(operand.t())?;
+            fun.device().check_type(operand.t())?;
+            // Ensure dimension mappings are registered.
+            if let Some(dim_map) = operand.mapped_dims() {
+                for &(lhs, rhs) in dim_map {
+                    if fun.find_mapping(lhs, rhs).is_none() {
+                        // FIXME: raise an error
+                    }
+                }
+            }
         }
         match *self {
             BinOp(_, ref lhs, ref rhs, rounding) => {

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -493,6 +493,8 @@ require forall $lhs in LogicalDimensions:
         order($lhs_dim, $rhs_dim) is not MERGED
         || tiling_factor($lhs) == tiling_factor($rhs)
 
+/// List pairs of dimensions that must have the same size and can be use for
+/// point-to-point communication.
 set MappedDimsPairs:
   item_type = "ir::MappedDims"
   id_type = "ir::MappedDimsId"
@@ -511,7 +513,7 @@ set MappedDims($pair in MappedDimsPairs) subsetof Dimensions:
   iterator = "$pair.dims().map(|dim| $fun.dim(dim))"
   var_prefix = "mapped_dim"
   from_superset = "a" // FIXME
-  reverse forall $din in StaticDims = "a" // FIXME
+  reverse forall $din in Dimensions = "a" // FIXME
   new_objs = "$objs.mapped_dims"
 end
 

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -492,3 +492,30 @@ require forall $lhs in LogicalDimensions:
       forall $rhs_dim in TileDimensions($rhs):
         order($lhs_dim, $rhs_dim) is not MERGED
         || tiling_factor($lhs) == tiling_factor($rhs)
+
+set MappedDimsPairs:
+  item_type = "ir::MappedDims"
+  id_type = "ir::MappedDimsId"
+  item_getter = "$fun.dim_mapping($id)"
+  id_getter = "$item.id()"
+  iterator = "$fun.dim_mappings()"
+  var_prefix = "dim_pair"
+  new_objs = "$objs.dim_mappings"
+end
+
+set MappedDims($pair in MappedDimsPairs) subsetof Dimensions:
+  item_type = "ir::Dimension"
+  id_type = "ir::DimId"
+  item_getter = "$fun.dim($id)"
+  id_getter = "$item.id()"
+  iterator = "$pair.dims().map(|dim| $fun.dim(dim))"
+  var_prefix = "mapped_dim"
+  from_superset = "a" // FIXME
+  reverse forall $din in StaticDims = "a" // FIXME
+  new_objs = "$objs.mapped_dims"
+end
+
+// FIXME: dims have the same size
+// FIXME: how to handle static and non-static dims
+// Can expose them in separate sets, but cannot retrieve the logical dim for the tiling
+// factor -> Must name reverse set

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -420,6 +420,7 @@ define half counter mem_size($mem in InternalMemoryRegions):
   forall $lhs in StaticDims:
     forall $rhs in StaticDims:
       mul size($lhs) when:
+        // FIXME: remove maps_dims
         "$mem.maps_dims($lhs.id(), $rhs.id())"
         order($lhs, $rhs) is not MERGED
 end

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -495,9 +495,9 @@ require forall $lhs in LogicalDimensions:
 
 /// List pairs of dimensions that must have the same size and can be use for
 /// point-to-point communication.
-set MappedDimsPairs:
-  item_type = "ir::MappedDims"
-  id_type = "ir::MappedDimsId"
+set DimMappingPairs:
+  item_type = "ir::DimMapping"
+  id_type = "ir::DimMappingId"
   item_getter = "$fun.dim_mapping($id)"
   id_getter = "$item.id()"
   iterator = "$fun.dim_mappings()"
@@ -505,7 +505,7 @@ set MappedDimsPairs:
   new_objs = "$objs.dim_mappings"
 end
 
-set MappedDims($pair in MappedDimsPairs) subsetof Dimensions:
+set DimMapping($pair in DimMappingPairs) subsetof Dimensions:
   item_type = "ir::Dimension"
   id_type = "ir::DimId"
   item_getter = "$fun.dim($id)"
@@ -521,3 +521,4 @@ end
 // FIXME: how to handle static and non-static dims
 // Can expose them in separate sets, but cannot retrieve the logical dim for the tiling
 // factor -> Must name reverse set
+// FIXME: if we only expose static dims, make sure we only add static dims in new_objs

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -420,7 +420,6 @@ define half counter mem_size($mem in InternalMemoryRegions):
   forall $lhs in StaticDims:
     forall $rhs in StaticDims:
       mul size($lhs) when:
-        // FIXME: remove maps_dims
         "$mem.maps_dims($lhs.id(), $rhs.id())"
         order($lhs, $rhs) is not MERGED
 end

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -495,7 +495,7 @@ require forall $lhs in LogicalDimensions:
 
 /// List pairs of dimensions that must have the same size and can be use for
 /// point-to-point communication.
-set DimMappingPairs:
+set DimMappings:
   item_type = "ir::DimMapping"
   id_type = "ir::DimMappingId"
   item_getter = "$fun.dim_mapping($id)"
@@ -505,20 +505,26 @@ set DimMappingPairs:
   new_objs = "$objs.dim_mappings"
 end
 
-set DimMapping($pair in DimMappingPairs) subsetof Dimensions:
+/// Lists the static dimensions in a dimension mapping.
+set StaticMappedDims($pair in DimMappings) subsetof StaticDims:
   item_type = "ir::Dimension"
   id_type = "ir::DimId"
   item_getter = "$fun.dim($id)"
   id_getter = "$item.id()"
-  iterator = "$pair.dims().map(|dim| $fun.dim(dim))"
+  iterator = "$pair.dims().iter().map(|&dim| $fun.dim(dim))\
+    .filter(|dim| dim.possible_sizes().is_some())"
   var_prefix = "mapped_dim"
-  from_superset = "a" // FIXME
-  reverse forall $din in Dimensions = "a" // FIXME
+  from_superset = "if $item.dim_mappings().contains(&$pair.id()) { Some($item) } else { None }"
+  reverse forall $dim in StaticDims = "$dim.dim_mappings().iter().map(|&id| $fun.dim_mapping(id))"
   new_objs = "$objs.mapped_dims"
 end
 
-// FIXME: dims have the same size
-// FIXME: how to handle static and non-static dims
-// Can expose them in separate sets, but cannot retrieve the logical dim for the tiling
-// factor -> Must name reverse set
-// FIXME: if we only expose static dims, make sure we only add static dims in new_objs
+// Ensure mapped dimensions have the same size. We currently have no way to constrain the
+// size of dynamic dimensions: it would require to name the reverse set of
+// `TiledDimension($logical_dim)`. However, it is enough to constrain the size of static
+// dimensions as the tiling factor of dynamic dimensions only depend on the size of static
+// dimensions.
+require forall $mapping in DimMappings:
+  forall $lhs in StaticMappedDims($mapping):
+    forall $rhs in StaticMappedDims($mapping):
+      size($lhs) == size($rhs)

--- a/src/search_space/dim_map.rs
+++ b/src/search_space/dim_map.rs
@@ -44,7 +44,7 @@ fn lower_dim_map(
     let lowered_dim_map = fun.lower_dim_map(inst, operand)?;
     let mut actions = Vec::new();
     // Order the store and load loop nests.
-    for &(src, dst) in &lowered_dim_map.dimensions {
+    for (src, dst) in lowered_dim_map.mem_dimensions() {
         actions.push(Action::Order(
             src.into(),
             dst.into(),
@@ -67,17 +67,7 @@ fn lower_dim_map(
     ));
     let operand = fun.inst(inst).operands()[operand];
     actions.extend(operand::invariants(fun, operand, inst.into()));
-    // Update the list of new objets
-    for dim in lowered_dim_map
-        .dimensions
-        .iter()
-        .flat_map(|&(x, y)| vec![x, y])
-    {
-        new_objs.add_dimension(fun.dim(dim));
-    }
-    new_objs.add_mem_instruction(fun.inst(lowered_dim_map.store));
-    new_objs.add_mem_instruction(fun.inst(lowered_dim_map.load));
-    new_objs.add_mem_block(lowered_dim_map.mem);
+    lowered_dim_map.register_new_objs(fun, new_objs);
     debug!("lower_dim_map actions: {:?}", actions);
     Ok(actions)
 }

--- a/telamon-utils/src/vec_set.rs
+++ b/telamon-utils/src/vec_set.rs
@@ -216,6 +216,11 @@ where
             }
         }
     }
+
+    /// Indicates if the `VecSet` contains the given object.
+    pub fn contains(&self, item: &T) -> bool {
+        self.data.binary_search(item).is_ok()
+    }
 }
 
 impl<T> Default for VecSet<T> {


### PR DESCRIPTION
This PR adds a list of dimensions mapped together to the function. Pairs of dimensions in `dim_map` fields in the operands must now be mapped. A new constraint ensure mapped dimensions have the same size.

Mapped dimensions should also help us improve the data flow encoding: it exposes the structure of `dim_map`s to the constraint programing framework.