### PR TITLE
Rely on Logical Dimensions to Constrain the Size of Merged Dimensions

### DIFF
--- a/src/ir/size.rs
+++ b/src/ir/size.rs
@@ -3,7 +3,7 @@ use num;
 use std;
 
 /// A fully specified size.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Size<'a> {
     factor: u32,
     params: Vec<&'a ir::Parameter>,

--- a/src/ir/size.rs
+++ b/src/ir/size.rs
@@ -123,14 +123,6 @@ impl<'a> PartialSize<'a> {
         self.factor /= gcd;
         self.divisor /= gcd;
     }
-
-    /// Indicates if two sizes may be equal, meaning they are equal appart from the
-    /// decisions they depend on.
-    pub fn is_compatible_with(&self, other: &ir::PartialSize) -> bool {
-        self.factor == other.factor
-            && self.divisor == other.divisor
-            && self.dividend == other.dividend
-    }
 }
 
 impl<'a, 'b> std::ops::MulAssign<&'b PartialSize<'a>> for PartialSize<'a> {

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -233,7 +233,9 @@ require forall $inst in Instructions:
 // Merge constraints.
 require forall $lhs in Dimensions:
   forall $rhs in Dimensions:
-    dim_kind($lhs) == dim_kind($rhs) || order($lhs, $rhs) is not MERGED
+    order($lhs, $rhs) is not MERGED || dim_kind($lhs) == dim_kind($rhs)
+    order($lhs, $rhs) is not MERGED
+    || "$lhs.possible_sizes().is_some() == $rhs.possible_sizes().is_some()"
 
 require forall $lhs in LogicalDimensions:
   forall $rhs in LogicalDimensions:

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -230,13 +230,18 @@ require forall $inst in Instructions:
     "$inst.iteration_dims().contains(&$dim.id())" || "!$inst.has_side_effects()"
       || is_iteration_dim($inst, $dim) is FALSE
 
+// Merge constraints.
 require forall $lhs in Dimensions:
   forall $rhs in Dimensions:
-    // Merge constraints
-    "$lhs.size().is_compatible_with($rhs.size())" || order($lhs, $rhs) is not MERGED
     dim_kind($lhs) == dim_kind($rhs) || order($lhs, $rhs) is not MERGED
 
-// Merge constraint for static dimensions.
+require forall $lhs in LogicalDimensions:
+  forall $rhs in LogicalDimensions:
+    forall $lhs_dim in TiledDimension($lhs):
+      forall $rhs_dim in TiledDimension($rhs):
+        order($lhs_dim, $rhs_dim) is not MERGED || "$lhs.total_size() == $rhs.total_size()"
+        order($lhs_dim, $rhs_dim) is not MERGED || tiling_factor($lhs) == tiling_factor($rhs)
+
 require forall $lhs in StaticDims:
   forall $rhs in StaticDims:
     size($lhs) == size($rhs) || order($lhs, $rhs) is not MERGED
@@ -483,11 +488,3 @@ end
 
 require forall $logical in LogicalDimensions:
   tiling_factor($logical) == "$logical.possible_tilings()"
-
-// Ensure merged dimensions have the same tiling factor.
-require forall $lhs in LogicalDimensions:
-  forall $rhs in LogicalDimensions:
-    forall $lhs_dim in TiledDimension($lhs):
-      forall $rhs_dim in TileDimensions($rhs):
-        order($lhs_dim, $rhs_dim) is not MERGED
-        || tiling_factor($lhs) == tiling_factor($rhs)

--- a/telamon-gen/src/ir/mod.rs
+++ b/telamon-gen/src/ir/mod.rs
@@ -260,10 +260,9 @@ impl IrDesc {
         (arg_foralls, set_constraints, adaptator)
     }
 
-    /// Generates the list of sets to iterate and to constraints to iterate on the given
-    /// environement, but from the point of view of the given choice instance. The new
-    /// foralls iterating on current arguments are returned in a separate list than the
-    /// ones issued from foralls.
+    /// Generates the foralls and the set constraints to iterate on the given environement,
+    /// from the point of view of the given choice. Returns the foralls issued from arguments
+    /// in a different list than the foralls issued from foralls in the original environement.
     pub fn adapt_env_ext(
         &self,
         mut vars: HashMap<Variable, Set>,
@@ -336,7 +335,6 @@ impl IrDesc {
                 true
             }
         });
-
         (
             arg_foralls,
             other_foralls,

--- a/telamon-gen/src/ir/mod.rs
+++ b/telamon-gen/src/ir/mod.rs
@@ -260,9 +260,9 @@ impl IrDesc {
         (arg_foralls, set_constraints, adaptator)
     }
 
-    /// Generates the foralls and the set constraints to iterate on the given environement,
+    /// Generates the foralls and the set constraints to iterate on the given environment,
     /// from the point of view of the given choice. Returns the foralls issued from arguments
-    /// in a different list than the foralls issued from foralls in the original environement.
+    /// in a different list than the foralls issued from foralls in the original environment.
     pub fn adapt_env_ext(
         &self,
         mut vars: HashMap<Variable, Set>,


### PR DESCRIPTION
Changes how we ensure merged dimensions have the same size. We used to call `is_compatible_with` method on dimension sizes, but this method won't work when we enable strip-mining: we can't test the equality on `PartialSize` as they will only be partially specified. Instead we ensure logical dimensions have the same size and that the tiling factor is the same.

We only make changes for dimensions with a dynamic size. Dimensions with a static size where already covered.

This PR also fixes a small bug in TelamonGen. Some code was inside a loop when it should not have been. The result was that it was not run when the loop had 0 iterations and generated invalid code in that case.