### PR TITLE
Limit the Size of Inner Block Dimensions

### DIFF
--- a/src/device/cuda/gpu.rs
+++ b/src/device/cuda/gpu.rs
@@ -421,6 +421,10 @@ impl device::Device for Gpu {
         3
     }
 
+    fn max_inner_block_size(&self) -> u32 {
+        65535
+    }
+
     fn max_threads(&self) -> u32 {
         1024
     }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -25,6 +25,8 @@ pub trait Device: Sync {
     fn check_type(&self, t: ir::Type) -> Result<(), ir::TypeError>;
     /// Returns the maximal number of block dimensions.
     fn max_block_dims(&self) -> u32;
+    /// The maximal size inner block dimensions can have.
+    fn max_inner_block_size(&self) -> u32;
     /// Returns the maximal number of threads.
     fn max_threads(&self) -> u32;
     /// Returns the maximal unrolling factor.

--- a/src/device/x86/cpu.rs
+++ b/src/device/x86/cpu.rs
@@ -41,6 +41,10 @@ impl device::Device for Cpu {
         0
     }
 
+    fn max_inner_block_size(&self) -> u32 {
+        0
+    }
+
     fn max_threads(&self) -> u32 {
         (num_cpus::get()) as u32
     }

--- a/src/ir/size.rs
+++ b/src/ir/size.rs
@@ -46,6 +46,11 @@ impl<'a> Size<'a> {
             None
         }
     }
+
+    /// Returns the maximum value the size can take.
+    pub fn max(&self) -> u32 {
+        self.max_val
+    }
 }
 
 impl<'a> Default for Size<'a> {

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -139,6 +139,20 @@ define enum dim_kind($dim in Dimensions):
   alias SEQUENTIAL = LOOP | UNROLL:
 end
 
+// Ensure inner block dimensions are not too big.
+require forall $outer_dim in Dimensions:
+  forall $logical in LogicalDimensions:
+  forall $dim in TiledDimension($logical):
+    dim_kind($dim) is not BLOCK
+    || order($outer_dim, $dim) is not OUTER
+    || tiling_factor($logical) >=
+      "$logical.total_size().max()/$fun.device().max_inner_block_size()"
+require forall $outer_dim in Dimensions:
+  forall $dim in StaticDims:
+    dim_kind($dim) is not BLOCK
+    || order($outer_dim, $dim) is not OUTER
+    || size($dim) <= "$fun.device().max_inner_block_size()"
+
 /// Indicates where a memory block is located.
 define enum mem_space($mem in MemoryRegions):
   /// The block is in the device RAM.

--- a/telamon-gen/src/flat_filter.rs
+++ b/telamon-gen/src/flat_filter.rs
@@ -146,6 +146,7 @@ impl FlatFilter {
             .map(|input| input.adapt(&adaptator))
             .collect();
         let constraints = self.set_constraints.adapt(&adaptator);
-        FlatFilter::new(self.vars.clone(), inputs, rules, constraints, ir_desc)
+        let vars = self.vars.iter().map(|set| set.adapt(&adaptator)).collect();
+        FlatFilter::new(vars, inputs, rules, constraints, ir_desc)
     }
 }

--- a/tests/common/fake.rs
+++ b/tests/common/fake.rs
@@ -67,6 +67,10 @@ impl device::Device for Device {
         1024
     }
 
+    fn max_inner_block_size(&self) -> u32 {
+        65535
+    }
+
     fn shared_mem(&self) -> u32 {
         self.shared_mem_size
     }


### PR DESCRIPTION
Fixes #45.

CUDA imposes a limit on the size of BLOCK dimensions on y and z axis. This PR enforces this limit. It also fixes a bug in Telmon-gen: we forgot to rename some variables when applying a renaming.