### PR TITLE
Add an interface to handle partially specified sizes in the performance model

### DIFF
--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -12,7 +12,7 @@ pub use self::context::{ArgMap, AsyncCallback, AsyncEvaluator, Context, EvalMode
 
 use codegen::Function;
 use ir;
-use model::{HwPressure, Nesting};
+use model::{self, HwPressure, Nesting};
 use search_space::{DimKind, SearchSpace};
 use std::io::Write;
 use utils::*;
@@ -75,8 +75,9 @@ pub trait Device: Sync {
     /// be `1`.
     fn add_block_overhead(
         &self,
-        predicated_dims_size: u64,
-        max_threads_per_blocks: u64,
+        max_active_threads: model::size::FactorRange,
+        max_threads: model::size::FactorRange,
+        predication_factor: model::size::Range,
         pressure: &mut HwPressure,
     );
 

--- a/src/device/x86/cpu.rs
+++ b/src/device/x86/cpu.rs
@@ -75,9 +75,10 @@ impl device::Device for Cpu {
 
     fn add_block_overhead(
         &self,
-        _predicated_dims_size: u64,
-        _max_threads_per_blocks: u64,
-        _pressure: &mut HwPressure,
+        _: model::size::FactorRange,
+        _: model::size::FactorRange,
+        _: model::size::Range,
+        _: &mut HwPressure,
     ) {
     }
 

--- a/src/ir/size.rs
+++ b/src/ir/size.rs
@@ -143,6 +143,12 @@ impl<'a> PartialSize<'a> {
     }
 }
 
+impl<'a> Default for PartialSize<'a> {
+    fn default() -> Self {
+        PartialSize { factor: 1, dividend: vec![], divisor: 1 }
+    }
+}
+
 impl<'a, 'b> std::ops::MulAssign<&'b PartialSize<'a>> for PartialSize<'a> {
     fn mul_assign(&mut self, rhs: &'b PartialSize<'a>) {
         self.factor *= rhs.factor;
@@ -151,6 +157,24 @@ impl<'a, 'b> std::ops::MulAssign<&'b PartialSize<'a>> for PartialSize<'a> {
         self.simplify();
     }
 }
+
+
+impl<'a, 'b> std::iter::Product<&'b PartialSize<'a>> for PartialSize<'a>
+where
+    'a: 'b,
+{
+    fn product<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'b PartialSize<'a>>,
+    {
+        let mut total = PartialSize::default();
+        for size in iter {
+            total *= size;
+        }
+        total
+    }
+}
+
 
 impl<'a> From<Size<'a>> for PartialSize<'a> {
     fn from(size: Size<'a>) -> PartialSize<'a> {

--- a/src/ir/size.rs
+++ b/src/ir/size.rs
@@ -145,7 +145,11 @@ impl<'a> PartialSize<'a> {
 
 impl<'a> Default for PartialSize<'a> {
     fn default() -> Self {
-        PartialSize { factor: 1, dividend: vec![], divisor: 1 }
+        PartialSize {
+            factor: 1,
+            dividend: vec![],
+            divisor: 1,
+        }
     }
 }
 
@@ -157,7 +161,6 @@ impl<'a, 'b> std::ops::MulAssign<&'b PartialSize<'a>> for PartialSize<'a> {
         self.simplify();
     }
 }
-
 
 impl<'a, 'b> std::iter::Product<&'b PartialSize<'a>> for PartialSize<'a>
 where
@@ -174,7 +177,6 @@ where
         total
     }
 }
-
 
 impl<'a> From<Size<'a>> for PartialSize<'a> {
     fn from(size: Size<'a>) -> PartialSize<'a> {

--- a/src/ir/size.rs
+++ b/src/ir/size.rs
@@ -162,6 +162,15 @@ impl<'a, 'b> std::ops::MulAssign<&'b PartialSize<'a>> for PartialSize<'a> {
     }
 }
 
+impl<'a, 'b> std::ops::Mul<&'b PartialSize<'a>> for PartialSize<'a> {
+    type Output = Self;
+
+    fn mul(mut self, rhs: &PartialSize<'a>) -> Self {
+        self *= rhs;
+        self
+    }
+}
+
 impl<'a, 'b> std::iter::Product<&'b PartialSize<'a>> for PartialSize<'a>
 where
     'a: 'b,

--- a/src/model/cuda_tests.rs
+++ b/src/model/cuda_tests.rs
@@ -40,11 +40,12 @@ fn partial_bound_0() {
         let local_info = LocalInfo::compute(&space, &context);
         trace!("partial nesting: {:?}", local_info.nesting[&st_z.into()]);
         sum_pressure(
-            context.device(),
+            &context,
             &space,
             &local_info,
             BottleneckLevel::Global,
             &[],
+            &ir::PartialSize::default(),
         )
     }.get_bottleneck(3);
 
@@ -58,11 +59,12 @@ fn partial_bound_0() {
         let local_info = LocalInfo::compute(&space, &context);
         trace!("final nesting: {:?}", local_info.nesting[&st_z.into()]);
         sum_pressure(
-            context.device(),
+            &context,
             &space,
             &local_info,
             BottleneckLevel::Global,
             &[],
+            &ir::PartialSize::default(),
         )
     }.get_bottleneck(3);
 
@@ -101,11 +103,12 @@ fn partial_bound_1() {
         let local_info = LocalInfo::compute(&space, &context);
         trace!("partial nesting: {:?}", local_info.nesting[&st_z.into()]);
         sum_pressure(
-            context.device(),
+            &context,
             &space,
             &local_info,
             BottleneckLevel::Global,
             &[],
+            &ir::PartialSize::default(),
         )
     }.get_bottleneck(5);
 
@@ -115,11 +118,12 @@ fn partial_bound_1() {
         let local_info = LocalInfo::compute(&space, &context);
         trace!("final nesting: {:?}", local_info.nesting[&st_z.into()]);
         sum_pressure(
-            context.device(),
+            &context,
             &space,
             &local_info,
             BottleneckLevel::Global,
             &[],
+            &ir::PartialSize::default(),
         )
     }.get_bottleneck(5);
 
@@ -242,11 +246,12 @@ fn partial_bound_3() {
         let space = builder.get_clone();
         let local_info = LocalInfo::compute(&space, &context);
         sum_pressure(
-            context.device(),
+            &context,
             &space,
             &local_info,
             BottleneckLevel::Global,
             &[],
+            &ir::PartialSize::default(),
         )
     }.get_bottleneck(4);
 
@@ -260,11 +265,12 @@ fn partial_bound_3() {
         let space = builder.get();
         let local_info = LocalInfo::compute(&space, &context);
         sum_pressure(
-            context.device(),
+            &context,
             &space,
             &local_info,
             BottleneckLevel::Global,
             &[],
+            &ir::PartialSize::default(),
         )
     }.get_bottleneck(4);
 
@@ -302,11 +308,12 @@ fn partial_bound_4() {
         let space = builder.get_clone();
         let local_info = LocalInfo::compute(&space, &context);
         sum_pressure(
-            context.device(),
+            &context,
             &space,
             &local_info,
             BottleneckLevel::Global,
             &[],
+            &ir::PartialSize::default(),
         )
     }.get_bottleneck(3);
 
@@ -320,11 +327,12 @@ fn partial_bound_4() {
         let space = builder.get();
         let local_info = LocalInfo::compute(&space, &context);
         sum_pressure(
-            context.device(),
+            &context,
             &space,
             &local_info,
             BottleneckLevel::Global,
             &[],
+            &ir::PartialSize::default(),
         )
     }.get_bottleneck(3);
 
@@ -362,11 +370,12 @@ fn partial_bound_5() {
         let space = builder.get_clone();
         let local_info = LocalInfo::compute(&space, &context);
         sum_pressure(
-            context.device(),
+            &context,
             &space,
             &local_info,
             BottleneckLevel::Global,
             &[],
+            &ir::PartialSize::default(),
         )
     }.get_bottleneck(4);
 
@@ -376,11 +385,12 @@ fn partial_bound_5() {
         let space = builder.get();
         let local_info = LocalInfo::compute(&space, &context);
         sum_pressure(
-            context.device(),
+            &context,
             &space,
             &local_info,
             BottleneckLevel::Global,
             &[],
+            &ir::PartialSize::default(),
         )
     }.get_bottleneck(4);
 

--- a/src/model/hw_pressure.rs
+++ b/src/model/hw_pressure.rs
@@ -80,14 +80,14 @@ impl FastBound {
     }
 
     /// Repeat the bound by iteration on a given loop level.
-    pub fn iterate(self, iterations: u32, level: usize) -> Self {
+    pub fn iterate(self, iterations: u64, level: usize) -> Self {
         let origin = FastOrigin::Loop {
             iterations,
             level,
             inner: self.origin,
         };
         FastBound {
-            value: self.value * f64::from(iterations),
+            value: self.value * iterations as f64,
             origin: Rc::new(origin),
             size: self.size + 1,
         }
@@ -178,7 +178,7 @@ pub enum FastOrigin {
     /// The bound is caused by a loop-carried dependency.
     Loop {
         level: usize,
-        iterations: u32,
+        iterations: u64,
         inner: Rc<FastOrigin>,
     },
     /// The bound is caused by a dependency chain.
@@ -317,7 +317,7 @@ pub enum Origin {
     /// The bound is repeated in a loop.
     Loop {
         dims: Vec<ir::DimId>,
-        iterations: u32,
+        iterations: u64,
         inner: Box<Origin>,
     },
     /// The bound is caused by a dependency chain.

--- a/src/model/level.rs
+++ b/src/model/level.rs
@@ -215,8 +215,7 @@ fn block_bound(
         .iter()
         .map(|&d| space.ir_instance().dim(d).size())
         .product::<ir::PartialSize>();
-    let pressure =
-        sum_pressure(ctx, space, info, BottleneckLevel::Block, dims, &n_iters);
+    let pressure = sum_pressure(ctx, space, info, BottleneckLevel::Block, dims, &n_iters);
     pressure.bound(BottleneckLevel::Block, &ctx.device().block_rates())
 }
 

--- a/src/model/local_info.rs
+++ b/src/model/local_info.rs
@@ -14,8 +14,6 @@ pub struct LocalInfo<'a> {
     pub nesting: HashMap<ir::BBId, Nesting<'a>>,
     /// The pressure incured by a signle instance of each BB.
     pub hw_pressure: HashMap<ir::BBId, HwPressure>,
-    /// The size of each dimensions.
-    pub dim_sizes: HashMap<ir::DimId, u32>,
     /// The pressure induced by a single iteration of each dimension and the exit latency
     /// of the loop.
     pub dim_overhead: HashMap<ir::DimId, (HwPressure, HwPressure)>,
@@ -90,7 +88,6 @@ impl<'a> LocalInfo<'a> {
             );
         }
         LocalInfo {
-            dim_sizes,
             nesting,
             hw_pressure,
             dim_overhead,

--- a/src/model/local_info.rs
+++ b/src/model/local_info.rs
@@ -128,12 +128,11 @@ fn add_indvar_pressure(
         if dim_kind.intersects(DimKind::THREAD | DimKind::BLOCK) {
             thread_overhead.add_parallel(&overhead);
         } else if size > 1 {
-            overhead.repeat_parallel(f64::from(size - 1));
-            unwrap!(hw_pressure.get_mut(&dim.into())).add_parallel(&overhead);
-            overhead.repeat_parallel(1.0 / f64::from(size - 1));
             unwrap!(dim_overhead.get_mut(&dim))
                 .0
                 .add_parallel(&overhead);
+            overhead.repeat_parallel(f64::from(size - 1));
+            unwrap!(hw_pressure.get_mut(&dim.into())).add_parallel(&overhead);
         }
     }
 }

--- a/src/model/local_info.rs
+++ b/src/model/local_info.rs
@@ -338,7 +338,7 @@ fn parallelism(
                 }
             }
             let min_num_blocks = size::bounds(&min_size_blocks, space, ctx).min;
-            let lcm_num_blocks = size::factors(&min_size_blocks, space, ctx).lcm;
+            let lcm_num_blocks = size::factors(&max_size_blocks, space, ctx).lcm;
             let size_threads_and_blocks = min_size_blocks * &size_thread_dims;
             Parallelism {
                 min_num_blocks,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -49,8 +49,14 @@ pub fn bound(space: &SearchSpace, context: &Context) -> Bound {
     trace!("local_info {:?}", local_info);
     let (mut levels, dim_maps) = level::generate(space, context, &local_info);
     let code_points = CodePointDag::build(space, &levels);
-    let mut levels_dag =
-        LevelDag::build(space, &local_info, &levels, dim_maps, code_points.len(), context);
+    let mut levels_dag = LevelDag::build(
+        space,
+        &local_info,
+        &levels,
+        dim_maps,
+        code_points.len(),
+        context,
+    );
     trace!("levels {:?}", levels);
     trace!("code_points {:?}", code_points);
     populate(
@@ -98,7 +104,7 @@ pub fn bound(space: &SearchSpace, context: &Context) -> Bound {
     let latency = block_latency.scale(block_parallelism, min_num_blocks, lcm_num_blocks);
     // Compute the throughput bound at the whole device level.
     let global_pressure = sum_pressure(
-        context.device(),
+        context,
         space,
         &local_info,
         BottleneckLevel::Global,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -5,6 +5,7 @@ mod dependency_map;
 mod hw_pressure;
 mod level;
 mod local_info;
+mod size;
 
 pub use self::hw_pressure::{BottleneckLevel, Bound, HwPressure};
 pub use self::local_info::Nesting;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -104,8 +104,14 @@ pub fn bound(space: &SearchSpace, context: &Context) -> Bound {
     let lcm_num_blocks = local_info.parallelism.lcm_num_blocks;
     let latency = block_latency.scale(block_parallelism, min_num_blocks, lcm_num_blocks);
     // Compute the throughput bound at the whole device level.
-    let global_pressure =
-        sum_pressure(context, space, &local_info, BottleneckLevel::Global, &[]);
+    let global_pressure = sum_pressure(
+        context,
+        space,
+        &local_info,
+        BottleneckLevel::Global,
+        &[],
+        &ir::PartialSize::default(),
+    );
     trace!("global pressure {:?}", global_pressure);
     let device_rates = context.device().total_rates();
     let throughput_bound = global_pressure.bound(BottleneckLevel::Global, &device_rates);

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -103,13 +103,8 @@ pub fn bound(space: &SearchSpace, context: &Context) -> Bound {
     let lcm_num_blocks = local_info.parallelism.lcm_num_blocks;
     let latency = block_latency.scale(block_parallelism, min_num_blocks, lcm_num_blocks);
     // Compute the throughput bound at the whole device level.
-    let global_pressure = sum_pressure(
-        context,
-        space,
-        &local_info,
-        BottleneckLevel::Global,
-        &[],
-    );
+    let global_pressure =
+        sum_pressure(context, space, &local_info, BottleneckLevel::Global, &[]);
     trace!("global pressure {:?}", global_pressure);
     let device_rates = context.device().total_rates();
     let throughput_bound = global_pressure.bound(BottleneckLevel::Global, &device_rates);

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -5,7 +5,8 @@ mod dependency_map;
 mod hw_pressure;
 mod level;
 mod local_info;
-mod size;
+
+pub mod size;
 
 pub use self::hw_pressure::{BottleneckLevel, Bound, HwPressure};
 pub use self::local_info::Nesting;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -47,10 +47,10 @@ pub fn bound(space: &SearchSpace, context: &Context) -> Bound {
     // Build the dependency maps dag.
     let local_info = LocalInfo::compute(space, context);
     trace!("local_info {:?}", local_info);
-    let (mut levels, dim_maps) = level::generate(space, context.device(), &local_info);
+    let (mut levels, dim_maps) = level::generate(space, context, &local_info);
     let code_points = CodePointDag::build(space, &levels);
     let mut levels_dag =
-        LevelDag::build(space, &local_info, &levels, dim_maps, code_points.len());
+        LevelDag::build(space, &local_info, &levels, dim_maps, code_points.len(), context);
     trace!("levels {:?}", levels);
     trace!("code_points {:?}", code_points);
     populate(

--- a/src/model/size.rs
+++ b/src/model/size.rs
@@ -1,0 +1,56 @@
+//! Size evaluation and manipulation primitives.
+use device::Context;
+use ir;
+use search_space::SearchSpace;
+
+/// A span of values.
+#[derive(Debug, Copy, Clone)]
+pub struct Range {
+    pub min: u64,
+    pub max: u64,
+}
+
+impl Range {
+    pub const ZERO: Self = Range { min: 0, max: 0 };
+
+    pub const ONE: Self = Range { min: 1, max: 1 };
+
+    /// Creates a `Range` containing a single value.
+    pub fn new_fixed(val: u64) -> Self {
+        Range {
+            min: val,
+            max: val,
+        }
+    }
+}
+
+/// Bounds the values a size can take, in the given context.
+pub fn bounds(size: &ir::PartialSize, space: &SearchSpace, ctx: &Context) -> Range {
+    // FIXME: the size may not have a fixed value.
+    let val = ctx.eval_size(&::codegen::Size::from_ir(size, space)) as u64;
+    Range::new_fixed(val)
+}
+
+/// A span of values, in term of factors. The actual value is a mulitpe of `gcd` and
+/// a divisor of `lcm`.
+#[derive(Debug, Copy, Clone)]
+pub struct FactorRange {
+    pub gcd: u64,
+    pub lcm: u64,
+}
+
+impl FactorRange {
+    pub const ZERO: Self = FactorRange { gcd: 0, lcm: 0 };
+
+    /// Create a `FactorRange` containing a single point.
+    pub fn new_fixed(val: u64) -> Self {
+        FactorRange { gcd: val, lcm: val }
+    }
+}
+
+/// Returns a factor and a multiple of `size`.
+pub fn factors(size: &ir::PartialSize, space: &SearchSpace, ctx: &Context) -> FactorRange {
+    // FIXME: the size may not have a fixed value.
+    let val = ctx.eval_size(&::codegen::Size::from_ir(size, space)) as u64;
+    FactorRange::new_fixed(val)
+}

--- a/src/model/size.rs
+++ b/src/model/size.rs
@@ -17,10 +17,7 @@ impl Range {
 
     /// Creates a `Range` containing a single value.
     pub fn new_fixed(val: u64) -> Self {
-        Range {
-            min: val,
-            max: val,
-        }
+        Range { min: val, max: val }
     }
 }
 
@@ -49,7 +46,11 @@ impl FactorRange {
 }
 
 /// Returns a factor and a multiple of `size`.
-pub fn factors(size: &ir::PartialSize, space: &SearchSpace, ctx: &Context) -> FactorRange {
+pub fn factors(
+    size: &ir::PartialSize,
+    space: &SearchSpace,
+    ctx: &Context,
+) -> FactorRange {
     // FIXME: the size may not have a fixed value.
     let val = ctx.eval_size(&::codegen::Size::from_ir(size, space)) as u64;
     FactorRange::new_fixed(val)

--- a/tests/common/fake.rs
+++ b/tests/common/fake.rs
@@ -130,7 +130,14 @@ impl device::Device for Device {
         HwPressure::new(1.0, vec![1.0, 1.0, 1.0])
     }
 
-    fn add_block_overhead(&self, _: u64, _: u64, _: &mut HwPressure) {}
+    fn add_block_overhead(
+        &self,
+        _: model::size::FactorRange,
+        _: model::size::FactorRange,
+        _: model::size::Range,
+        _: &mut HwPressure,
+    ) {
+    }
 }
 
 /// A fake context.


### PR DESCRIPTION
This PR update the performance model to handle partially specified implementations. In details:
- It changes adds an interface to interact with partially specified size in `model::size`. Later, we will only need to update the internals of this interface (see the FIXMEs) to handle partially specified sizes.
- It update `model::local_info` and `model::level` to evaluate the size of dimensions after they are multiplied rather than before. This is because some unknown quantities in the sizes may be eliminated by the multiplication, thus leading to more accurate results. For example, in the following, `sizeof(dim0)` is unknwon:
```
sizeof(dim0) * 1000/sizeof(dim0)   => 1000
      ^                 ^              ^
    size0             size1       simplified size0 * size1
```