### PR TITLE
Make it easier to work on choices.exh

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ name = "print_event_log"
 [build-dependencies]
 cc = "1.0.12"
 failure = "0.1.1"
+glob = "0.2"
 
 [build-dependencies.telamon-gen]
 path = "telamon-gen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ name = "print_event_log"
 
 [build-dependencies]
 cc = "1.0.12"
+failure = "0.1.1"
 
 [build-dependencies.telamon-gen]
 path = "telamon-gen"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 //! Rust script to compile non-rust files.
 extern crate cc;
 extern crate failure;
+extern crate glob;
 extern crate telamon_gen;
 
 use std::path::Path;
@@ -10,8 +11,8 @@ fn add_lib(lib: &str) {
     println!("cargo:rustc-link-lib={}", lib);
 }
 
-fn add_dependency(dep: &str) {
-    println!("cargo:rerun-if-changed={}", dep);
+fn add_dependency(dep: &Path) {
+    println!("cargo:rerun-if-changed={}", dep.display());
 }
 
 /// Compiles and links the cuda wrapper and libraries.
@@ -20,7 +21,7 @@ fn compile_link_cuda() {
         .flag("-Werror")
         .file("src/device/cuda/api/wrapper.c")
         .compile("libdevice_cuda_wrapper.a");
-    add_dependency("src/device/cuda/api/wrapper.c");
+    add_dependency(Path::new("src/device/cuda/api/wrapper.c"));
     add_lib("cuda");
     add_lib("curand");
     add_lib("cupti");
@@ -29,8 +30,10 @@ fn compile_link_cuda() {
 fn main() {
     let exh_file = "src/search_space/choices.exh";
     let out_dir = std::env::var_os("OUT_DIR").unwrap();
+    for file in glob::glob("src/search_space/*.exh").unwrap() {
+        add_dependency(&file.unwrap());
+    }
 
-    add_dependency(exh_file);
     let exh_out = Path::new(&out_dir).join("choices.rs");
     telamon_gen::process_file(
         &Path::new(exh_file),

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 //! Rust script to compile non-rust files.
 extern crate cc;
-extern crate telamon_gen;
 extern crate failure;
+extern crate telamon_gen;
 
 use std::path::Path;
 

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 //! Rust script to compile non-rust files.
 extern crate cc;
 extern crate telamon_gen;
+extern crate failure;
 
 use std::path::Path;
 
@@ -35,7 +36,10 @@ fn main() {
         &Path::new(exh_file),
         &exh_out,
         cfg!(feature = "format_exh"),
-    ).unwrap();
+    ).unwrap_or_else(|err| {
+        eprintln!("could not compile EXH file: {}", err);
+        std::process::exit(-1);
+    });
     if cfg!(feature = "cuda") {
         compile_link_cuda();
     }

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -12,27 +12,7 @@ set Statements:
   new_objs = "$objs.statements"
 end
 
-set Instructions subsetof Statements:
-  item_type = "ir::Instruction"
-  id_type = "ir::InstId"
-  item_getter = "$fun.inst($id)"
-  id_getter = "$item.id()"
-  iterator = "$fun.insts()"
-  var_prefix = "inst"
-  from_superset = "$item.as_inst()"
-  new_objs = "$objs.instructions"
-end
-
-set MemInsts subsetof Instructions:
-  item_type = "ir::Instruction"
-  id_type = "ir::InstId"
-  item_getter = "$fun.inst($id)"
-  id_getter = "$item.id()"
-  iterator = "$fun.mem_insts()"
-  var_prefix = "inst"
-  from_superset = "$item.as_mem_inst()"
-  new_objs = "$objs.mem_insts"
-end
+include "instructions.exh"
 
 set Dimensions subsetof Statements:
   disjoint: Instructions
@@ -58,36 +38,11 @@ set StaticDims subsetof Dimensions:
   new_objs = "$objs.static_dims"
 end
 
-set Values:
-  item_type = "ir::Value"
-  id_type = "ir::ValueId"
-  item_getter = "$fun.value($id)"
-  id_getter = "$item.id()"
-  iterator = "$fun.values()"
-  var_prefix = "value"
-  new_objs = "$objs.values"
-end
+/// The size of a dimension with a constant size.
+define integer size($dim in StaticDims): "unwrap!($dim.possible_sizes())" end
 
-set MemoryRegions:
-  item_type = "ir::mem::Block"
-  id_type = "ir::MemId"
-  item_getter = "$fun.mem_block($id)"
-  id_getter = "$item.mem_id()"
-  iterator = "$fun.mem_blocks()"
-  var_prefix = "mem"
-  new_objs = "$objs.mem_blocks"
-end
-
-set InternalMemoryRegions subsetof MemoryRegions:
-  item_type = "ir::mem::InternalBlock"
-  id_type = "ir::mem::InternalId"
-  item_getter = "$fun.internal_mem_block($id)"
-  id_getter = "$item.id()"
-  iterator = "$fun.internal_mem_blocks()"
-  var_prefix = "mem"
-  from_superset = "$item.as_internal()"
-  new_objs = "$objs.internal_mem_blocks"
-end
+include "logical_dimensions.exh"
+include "thread_dimensions.exh"
 
 quotient IterationDims($inst in Instructions) of $dim in Dimensions:
   is_iteration_dim = order($dim, $inst) is OUTER / order is MERGED
@@ -103,21 +58,7 @@ quotient IterationDims($inst in Instructions) of $dim in Dimensions:
   add_to_set = "::search_space::add_iteration_dim($fun, $inst, $item)"
 end
 
-quotient ThreadDims of $dim in StaticDims:
-  is_thread_dim = dim_kind($dim) is THREAD / thread_mapping is MAPPED
-  item_type = "ir::Dimension"
-  id_type = "ir::DimId"
-  item_getter = "$fun.dim($id)"
-  id_getter = "$item.id()"
-  iterator = "$fun.thread_dims()"
-  var_prefix = "thread_dim"
-  new_objs = "$objs.thread_dims"
-  from_superset = "(if $item.is_thread_dim() { Some($item) } else { None })"
-  add_to_set = "::search_space::add_thread_dim($fun, $item)"
-end
-
-/// The size of a dimension with a constant size.
-define integer size($dim in StaticDims): "unwrap!($dim.possible_sizes())" end
+include "values.exh"
 
 /// Specifies how iteration dimensions are implemented.
 define enum dim_kind($dim in Dimensions):
@@ -169,46 +110,6 @@ require forall $outer_dim in Dimensions:
     || order($outer_dim, $dim) is not OUTER
     || size($dim) <= "$fun.device().max_inner_block_size()"
 
-/// Indicates where a memory block is located.
-define enum mem_space($mem in MemoryRegions):
-  /// The block is in the device RAM.
-  value GLOBAL:
-    requires forall $inst in MemInsts:
-      "unwrap!($inst.operator().mem_used()) != $mem.mem_id()"
-        || inst_flag($inst) is MEM_GLOBAL
-  /// The block is in the memory shared between the threads of a block.
-  value SHARED:
-    requires "$mem.as_internal().is_some()"
-    requires forall $inst in MemInsts:
-      "unwrap!($inst.operator().mem_used()) != $mem.mem_id()"
-        || inst_flag($inst) is MEM_SHARED
-end
-
-/// Specifies the version of an instruction to use.
-define enum inst_flag($inst in MemInsts):
-  /// Access the global memory using both L1 and L2 cache. Coherence is not guaranteed
-  /// between blocks.
-  value MEM_CA:
-    requires "$fun.device().supports_l1_access()"
-  /// Access the global memory using the L2 cache.
-  value MEM_CG:
-    requires "$fun.device().supports_l2_access()"
-  /// Access the global memory without using caches.
-  value MEM_CS:
-  /// Access the global memory using the read-only cache. Coherence is not guaranteed.
-  value MEM_NC:
-    requires "$inst.operator().supports_nc_access()"
-    requires "$fun.device().supports_nc_access()"
-  /// Access the shared memory.
-  value MEM_SHARED:
-  /// Access the global memory.
-  alias MEM_GLOBAL = MEM_CA | MEM_CG | MEM_CS | MEM_NC:
-  /// Ensure coherency between memory accesses.
-  alias MEM_COHERENT = MEM_SHARED | MEM_CG | MEM_CS:
-  /// Ensure coherency within a block between memory accesses.
-  alias MEM_BLOCK_COHERENT = MEM_COHERENT | MEM_CA:
-end
-
 /// Defines how two statements are ordered.
 define enum order($lhs in Statements, $rhs in Statements):
   antisymmetric:
@@ -250,16 +151,6 @@ require forall $lhs in Statements:
       // MERGED requires similar orderings on both sides
       order($lhs, $rhs) is not MERGED || order($rhs, $mid) == order($lhs, $mid)
 
-// Intruction orders
-require forall $inst in Instructions:
-  forall $stmt in Statements:
-    order($inst, $stmt) is INNER | ORDERED
-
-require forall $inst in Instructions:
-  forall $dim in Dimensions:
-    "$inst.iteration_dims().contains(&$dim.id())" || "!$inst.has_side_effects()"
-      || is_iteration_dim($inst, $dim) is FALSE
-
 // Merge constraints.
 require forall $lhs in Dimensions:
   forall $rhs in Dimensions:
@@ -297,92 +188,6 @@ require forall $lhs in StaticDims:
   forall $rhs in StaticDims:
     dim_mapping($lhs, $rhs) is not THREAD_MAP || thread_mapping($lhs, $rhs) is MAPPED
     thread_mapping($lhs, $rhs) is not MAPPED || size($lhs) == size($rhs)
-
-/// Indicates how are thread dimensions mapped on the GPU.
-define enum thread_mapping($lhs in StaticDims, $rhs in StaticDims):
-  antisymmetric:
-    MAPPED_OUT -> MAPPED_IN
-  /// One of the dimensions is a not thread.
-  value NOT_THREADS:
-    requires dim_kind($lhs) is not THREAD || dim_kind($rhs) is not THREAD
-  /// The two dimensions are threads mapped to the same dimension on the GPU.
-  value MAPPED:
-    requires dim_kind($lhs) is THREAD
-    requires dim_kind($rhs) is THREAD
-    requires order($lhs, $rhs) is MERGED | ORDERED
-    requires size($lhs) == size($rhs)
-  /// The two dimensions are threads, but `lhs` is mapped to a dimension outside of `rhs`.
-  value MAPPED_OUT:
-    requires dim_kind($lhs) is THREAD
-    requires dim_kind($rhs) is THREAD
-    requires order($lhs, $rhs) is OUTER | ORDERED
-  /// The two dimensions are threads, but `lhs` is mapped to a dimension inside of `rhs`.
-  value MAPPED_IN:
-    requires dim_kind($lhs) is THREAD
-    requires dim_kind($rhs) is THREAD
-    requires order($lhs, $rhs) is INNER | ORDERED
-end
-
-// Enforce coherence between threads activations.
-require forall $lhs in StaticDims:
-  forall $rhs in StaticDims:
-    forall $other in StaticDims:
-      thread_mapping($lhs, $rhs) is not MAPPED ||
-        thread_mapping($lhs, $other) == thread_mapping($rhs, $other)
-      thread_mapping($lhs, $other) is not MAPPED_OUT ||
-        thread_mapping($other, $rhs) is not MAPPED_OUT ||
-        thread_mapping($lhs, $rhs) is MAPPED_OUT
-
-// Thread dimensions are grouped together
-require forall $outer in StaticDims:
-  forall $inner in StaticDims:
-    forall $mid in Dimensions:
-      order($outer, $mid) is not OUTER || order($mid, $inner) is not OUTER
-        || dim_kind($outer) is not THREAD || dim_kind($inner) is not THREAD
-        || dim_kind($mid) is THREAD
-
-// outer thread dimensions are limited to a size of 64.
-require forall $outer in StaticDims:
-  forall $inner in StaticDims:
-    thread_mapping($outer, $inner) is not MAPPED_OUT
-      || size($outer) <= "64"
-
-// A statement nested with a thread dimension is nested or merged with the other
-require forall $stmt in Statements:
-  forall $nested_thread in StaticDims:
-    forall $other_thread in StaticDims:
-      order($stmt, $nested_thread) is not NESTED || dim_kind($nested_thread) is not THREAD
-        || order($other_thread, $nested_thread) is not NESTED
-        || dim_kind($other_thread) is not THREAD
-        || order($stmt, $other_thread) is not ORDERED
-
-/// Limits the number of threads.
-///
-/// The counter iterates on `StaticDims` instead of just `ThreadDims` because we want the
-/// constraint `num_threads() <= "$fun.device().max_threads()"` to propagate to dimensions
-/// that still have the possibility of not being thread dimensions. Otherwise the
-/// constraint would only apply to dimensions for wich we already took the decision they
-/// were threads.
-define half counter num_threads():
-  forall $dim in StaticDims:
-    mul size($dim) when:
-      is_thread_dim($dim) is TRUE
-end
-
-require num_threads() <= "$fun.device().max_threads()"
-
-/// Limits the number of thread dimensions.
-///
-/// The counter iterates on `StaticDims` instead of just `ThreadDims` because we want the
-/// constraint `num_thread_dims() <= 3` to propagate to dimensions that still have the
-/// possibility of not being thread dimensions. Otherwise the constraint would only apply
-/// to dimensions for wich we already took the decision they were threads.
-define half counter num_thread_dims():
-  forall $dim in StaticDims:
-    sum "1" when: is_thread_dim($dim) is TRUE
-end
-
-require num_thread_dims() <= "3"
 
 /// Limits the number of nested unrolled loop.
 define half counter unroll_factor($inst in Instructions):
@@ -448,78 +253,6 @@ trigger forall $lhs in Dimensions:
   forall $rhs in Dimensions:
     "::search_space::merge_dims($lhs, $rhs, ir_instance)"
       when order($lhs, $rhs) is MERGED && "$lhs.id() > $rhs.id()"
-
-/// Computes the size of each memory block.
-// TODO(cleanup): use dependent sets to only iterate on necessary pairs.
-// FIXME: remove cubic choice choices
-define half counter mem_size($mem in InternalMemoryRegions):
-  base "$mem.base_size()"
-  forall $lhs in StaticDims:
-    forall $rhs in StaticDims:
-      mul size($lhs) when:
-        "$mem.maps_dims($lhs.id(), $rhs.id())"
-        order($lhs, $rhs) is not MERGED
-end
-
-/// The total amount of shared memory used.
-define half counter shared_mem_used():
-  forall $mem in InternalMemoryRegions:
-    sum mem_size($mem) when: mem_space($mem) is SHARED
-end
-
-// Cannot use more shared memory that what is available.
-require shared_mem_used() <= "$fun.device().shared_mem()"
-
-/// Groups of dimension constituing single tiled dimension.
-set LogicalDimensions:
-  item_type = "ir::LogicalDim"
-  id_type = "ir::LogicalDimId"
-  item_getter = "$fun.logical_dim($id)"
-  id_getter = "$item.id()"
-  iterator = "$fun.logical_dims()"
-  var_prefix = "ldim"
-  new_objs = "$objs.logical_dims"
-end
-
-/// Contains the dimensions composing a logical dimension that have a staticaly known
-/// size. This corresponds to tiles of a logical dimension.
-set TileDimensions($logical in LogicalDimensions) subsetof StaticDims:
-  item_type = "ir::Dimension"
-  id_type = "ir::DimId"
-  item_getter = "$fun.dim($id)"
-  id_getter = "$item.id()"
-  iterator = "$logical.tile_dimensions().map(|d| $fun.dim(d))"
-  var_prefix = "dim"
-  from_superset = "$logical.tiled_dimension().filter(|&id| id == $item.id()).map(|_| $item)"
-  reverse forall $dim in StaticDims =
-    "$dim.logical_dim().into_iter().map(|d| $fun.logical_dim(d))"
-  new_objs = "$objs.tile_dimensions"
-end
-
-/// Contains the tiled dimension of a logical dimension. Is empty if the logical dimension
-/// has a fixed size, in which case all the dimensions that compose it are considered as
-/// tile dimensions.
-set TiledDimension($logical in LogicalDimensions) subsetof Dimensions:
-  item_type = "ir::Dimension"
-  id_type = "ir::DimId"
-  item_getter = "$fun.dim($id)"
-  id_getter = "$item.id()"
-  iterator = "$logical.tiled_dimension().map(|dim| $fun.dim(dim))"
-  var_prefix = "dim"
-  from_superset = "$logical.tiled_dimension().filter(|&id| id == $item.id()).map(|_| $item)"
-  reverse forall $dim in Dimensions =
-    "$dim.logical_dim().filter(|_| $dim.possible_sizes().is_none())\
-     .map(|d| $fun.logical_dim(d))"
-  new_objs = "$objs.tiled_dimensions"
-end
-
-/// Number of iterations in the tiling dimensions of a logical dimension.
-define counter tiling_factor($logical in LogicalDimensions):
-  forall $dim in TileDimensions($logical): mul size($dim) when:
-end
-
-require forall $logical in LogicalDimensions:
-  tiling_factor($logical) == "$logical.possible_tilings()"
 
 /// List pairs of dimensions that must have the same size and can be use for
 /// point-to-point communication.

--- a/src/search_space/instructions.exh
+++ b/src/search_space/instructions.exh
@@ -1,0 +1,56 @@
+set Instructions subsetof Statements:
+  item_type = "ir::Instruction"
+  id_type = "ir::InstId"
+  item_getter = "$fun.inst($id)"
+  id_getter = "$item.id()"
+  iterator = "$fun.insts()"
+  var_prefix = "inst"
+  from_superset = "$item.as_inst()"
+  new_objs = "$objs.instructions"
+end
+
+set MemInsts subsetof Instructions:
+  item_type = "ir::Instruction"
+  id_type = "ir::InstId"
+  item_getter = "$fun.inst($id)"
+  id_getter = "$item.id()"
+  iterator = "$fun.mem_insts()"
+  var_prefix = "inst"
+  from_superset = "$item.as_mem_inst()"
+  new_objs = "$objs.mem_insts"
+end
+
+/// Specifies the version of an instruction to use.
+define enum inst_flag($inst in MemInsts):
+  /// Access the global memory using both L1 and L2 cache. Coherence is not guaranteed
+  /// between blocks.
+  value MEM_CA:
+    requires "$fun.device().supports_l1_access()"
+  /// Access the global memory using the L2 cache.
+  value MEM_CG:
+    requires "$fun.device().supports_l2_access()"
+  /// Access the global memory without using caches.
+  value MEM_CS:
+  /// Access the global memory using the read-only cache. Coherence is not guaranteed.
+  value MEM_NC:
+    requires "$inst.operator().supports_nc_access()"
+    requires "$fun.device().supports_nc_access()"
+  /// Access the shared memory.
+  value MEM_SHARED:
+  /// Access the global memory.
+  alias MEM_GLOBAL = MEM_CA | MEM_CG | MEM_CS | MEM_NC:
+  /// Ensure coherency between memory accesses.
+  alias MEM_COHERENT = MEM_SHARED | MEM_CG | MEM_CS:
+  /// Ensure coherency within a block between memory accesses.
+  alias MEM_BLOCK_COHERENT = MEM_COHERENT | MEM_CA:
+end
+
+// Intruction orders
+require forall $inst in Instructions:
+  forall $stmt in Statements:
+    order($inst, $stmt) is INNER | ORDERED
+
+require forall $inst in Instructions:
+  forall $dim in Dimensions:
+    "$inst.iteration_dims().contains(&$dim.id())" || "!$inst.has_side_effects()"
+      || is_iteration_dim($inst, $dim) is FALSE

--- a/src/search_space/logical_dimensions.exh
+++ b/src/search_space/logical_dimensions.exh
@@ -1,0 +1,52 @@
+// Defines how Telamon's dimensions map to the dimensions in the original code.
+
+/// Groups of dimension constituing single tiled dimension.
+set LogicalDimensions:
+  item_type = "ir::LogicalDim"
+  id_type = "ir::LogicalDimId"
+  item_getter = "$fun.logical_dim($id)"
+  id_getter = "$item.id()"
+  iterator = "$fun.logical_dims()"
+  var_prefix = "ldim"
+  new_objs = "$objs.logical_dims"
+end
+
+/// Contains the dimensions composing a logical dimension that have a staticaly known
+/// size. This corresponds to tiles of a logical dimension.
+set TileDimensions($logical in LogicalDimensions) subsetof StaticDims:
+  item_type = "ir::Dimension"
+  id_type = "ir::DimId"
+  item_getter = "$fun.dim($id)"
+  id_getter = "$item.id()"
+  iterator = "$logical.tile_dimensions().map(|d| $fun.dim(d))"
+  var_prefix = "dim"
+  from_superset = "$logical.tiled_dimension().filter(|&id| id == $item.id()).map(|_| $item)"
+  reverse forall $dim in StaticDims =
+    "$dim.logical_dim().into_iter().map(|d| $fun.logical_dim(d))"
+  new_objs = "$objs.tile_dimensions"
+end
+
+/// Contains the tiled dimension of a logical dimension. Is empty if the logical dimension
+/// has a fixed size, in which case all the dimensions that compose it are considered as
+/// tile dimensions.
+set TiledDimension($logical in LogicalDimensions) subsetof Dimensions:
+  item_type = "ir::Dimension"
+  id_type = "ir::DimId"
+  item_getter = "$fun.dim($id)"
+  id_getter = "$item.id()"
+  iterator = "$logical.tiled_dimension().map(|dim| $fun.dim(dim))"
+  var_prefix = "dim"
+  from_superset = "$logical.tiled_dimension().filter(|&id| id == $item.id()).map(|_| $item)"
+  reverse forall $dim in Dimensions =
+    "$dim.logical_dim().filter(|_| $dim.possible_sizes().is_none())\
+     .map(|d| $fun.logical_dim(d))"
+  new_objs = "$objs.tiled_dimensions"
+end
+
+/// Number of iterations in the tiling dimensions of a logical dimension.
+define counter tiling_factor($logical in LogicalDimensions):
+  forall $dim in TileDimensions($logical): mul size($dim) when:
+end
+
+require forall $logical in LogicalDimensions:
+  tiling_factor($logical) == "$logical.possible_tilings()"

--- a/src/search_space/thread_dimensions.exh
+++ b/src/search_space/thread_dimensions.exh
@@ -1,0 +1,100 @@
+/// Lists hardware thread dimensions.
+quotient ThreadDims of $dim in StaticDims:
+  is_thread_dim = dim_kind($dim) is THREAD / thread_mapping is MAPPED
+  item_type = "ir::Dimension"
+  id_type = "ir::DimId"
+  item_getter = "$fun.dim($id)"
+  id_getter = "$item.id()"
+  iterator = "$fun.thread_dims()"
+  var_prefix = "thread_dim"
+  new_objs = "$objs.thread_dims"
+  from_superset = "(if $item.is_thread_dim() { Some($item) } else { None })"
+  add_to_set = "::search_space::add_thread_dim($fun, $item)"
+end
+
+/// Limits the number of threads.
+///
+/// The counter iterates on `StaticDims` instead of just `ThreadDims` because we want the
+/// constraint `num_threads() <= "$fun.device().max_threads()"` to propagate to dimensions
+/// that still have the possibility of not being thread dimensions. Otherwise the
+/// constraint would only apply to dimensions for wich we already took the decision they
+/// were threads.
+define half counter num_threads():
+  forall $dim in StaticDims:
+    mul size($dim) when:
+      is_thread_dim($dim) is TRUE
+end
+
+require num_threads() <= "$fun.device().max_threads()"
+
+/// Limits the number of thread dimensions.
+///
+/// The counter iterates on `StaticDims` instead of just `ThreadDims` because we want the
+/// constraint `num_thread_dims() <= 3` to propagate to dimensions that still have the
+/// possibility of not being thread dimensions. Otherwise the constraint would only apply
+/// to dimensions for wich we already took the decision they were threads.
+define half counter num_thread_dims():
+  forall $dim in StaticDims:
+    sum "1" when: is_thread_dim($dim) is TRUE
+end
+
+require num_thread_dims() <= "3"
+
+/// Indicates how are thread dimensions mapped on the GPU.
+define enum thread_mapping($lhs in StaticDims, $rhs in StaticDims):
+  antisymmetric:
+    MAPPED_OUT -> MAPPED_IN
+  /// One of the dimensions is a not thread.
+  value NOT_THREADS:
+    requires dim_kind($lhs) is not THREAD || dim_kind($rhs) is not THREAD
+  /// The two dimensions are threads mapped to the same dimension on the GPU.
+  value MAPPED:
+    requires dim_kind($lhs) is THREAD
+    requires dim_kind($rhs) is THREAD
+    requires order($lhs, $rhs) is MERGED | ORDERED
+    requires size($lhs) == size($rhs)
+  /// The two dimensions are threads, but `lhs` is mapped to a dimension outside of `rhs`.
+  value MAPPED_OUT:
+    requires dim_kind($lhs) is THREAD
+    requires dim_kind($rhs) is THREAD
+    requires order($lhs, $rhs) is OUTER | ORDERED
+  /// The two dimensions are threads, but `lhs` is mapped to a dimension inside of `rhs`.
+  value MAPPED_IN:
+    requires dim_kind($lhs) is THREAD
+    requires dim_kind($rhs) is THREAD
+    requires order($lhs, $rhs) is INNER | ORDERED
+end
+
+// Enforce coherence between threads activations.
+require forall $lhs in StaticDims:
+  forall $rhs in StaticDims:
+    forall $other in StaticDims:
+      thread_mapping($lhs, $rhs) is not MAPPED ||
+        thread_mapping($lhs, $other) == thread_mapping($rhs, $other)
+      thread_mapping($lhs, $other) is not MAPPED_OUT ||
+        thread_mapping($other, $rhs) is not MAPPED_OUT ||
+        thread_mapping($lhs, $rhs) is MAPPED_OUT
+
+// Thread dimensions are grouped together
+require forall $outer in StaticDims:
+  forall $inner in StaticDims:
+    forall $mid in Dimensions:
+      order($outer, $mid) is not OUTER || order($mid, $inner) is not OUTER
+        || dim_kind($outer) is not THREAD || dim_kind($inner) is not THREAD
+        || dim_kind($mid) is THREAD
+
+// outer thread dimensions are limited to a size of 64.
+require forall $outer in StaticDims:
+  forall $inner in StaticDims:
+    thread_mapping($outer, $inner) is not MAPPED_OUT
+      || size($outer) <= "64"
+
+// A statement nested with a thread dimension is nested or merged with the other
+require forall $stmt in Statements:
+  forall $nested_thread in StaticDims:
+    forall $other_thread in StaticDims:
+      order($stmt, $nested_thread) is not NESTED || dim_kind($nested_thread) is not THREAD
+        || order($other_thread, $nested_thread) is not NESTED
+        || dim_kind($other_thread) is not THREAD
+        || order($stmt, $other_thread) is not ORDERED
+

--- a/src/search_space/values.exh
+++ b/src/search_space/values.exh
@@ -1,0 +1,66 @@
+set Values:
+  item_type = "ir::Value"
+  id_type = "ir::ValueId"
+  item_getter = "$fun.value($id)"
+  id_getter = "$item.id()"
+  iterator = "$fun.values()"
+  var_prefix = "value"
+  new_objs = "$objs.values"
+end
+
+set MemoryRegions:
+  item_type = "ir::mem::Block"
+  id_type = "ir::MemId"
+  item_getter = "$fun.mem_block($id)"
+  id_getter = "$item.mem_id()"
+  iterator = "$fun.mem_blocks()"
+  var_prefix = "mem"
+  new_objs = "$objs.mem_blocks"
+end
+
+set InternalMemoryRegions subsetof MemoryRegions:
+  item_type = "ir::mem::InternalBlock"
+  id_type = "ir::mem::InternalId"
+  item_getter = "$fun.internal_mem_block($id)"
+  id_getter = "$item.id()"
+  iterator = "$fun.internal_mem_blocks()"
+  var_prefix = "mem"
+  from_superset = "$item.as_internal()"
+  new_objs = "$objs.internal_mem_blocks"
+end
+
+/// Indicates where a memory block is located.
+define enum mem_space($mem in MemoryRegions):
+  /// The block is in the device RAM.
+  value GLOBAL:
+    requires forall $inst in MemInsts:
+      "unwrap!($inst.operator().mem_used()) != $mem.mem_id()"
+        || inst_flag($inst) is MEM_GLOBAL
+  /// The block is in the memory shared between the threads of a block.
+  value SHARED:
+    requires "$mem.as_internal().is_some()"
+    requires forall $inst in MemInsts:
+      "unwrap!($inst.operator().mem_used()) != $mem.mem_id()"
+        || inst_flag($inst) is MEM_SHARED
+end
+
+/// Computes the size of each memory block.
+// TODO(cleanup): use dependent sets to only iterate on necessary pairs.
+// FIXME: remove cubic choice choices
+define half counter mem_size($mem in InternalMemoryRegions):
+  base "$mem.base_size()"
+  forall $lhs in StaticDims:
+    forall $rhs in StaticDims:
+      mul size($lhs) when:
+        "$mem.maps_dims($lhs.id(), $rhs.id())"
+        order($lhs, $rhs) is not MERGED
+end
+
+/// The total amount of shared memory used.
+define half counter shared_mem_used():
+  forall $mem in InternalMemoryRegions:
+    sum mem_size($mem) when: mem_space($mem) is SHARED
+end
+
+// Cannot use more shared memory that what is available.
+require shared_mem_used() <= "$fun.device().shared_mem()"

--- a/telamon-gen/src/error.rs
+++ b/telamon-gen/src/error.rs
@@ -95,7 +95,13 @@ impl fmt::Display for Error {
                 ..
             } => {
                 if let Some(span) = span {
-                    write!(f, "Unexpected token '{:?}', {} -> {}", token, span, path.display())
+                    write!(
+                        f,
+                        "Unexpected token '{:?}', {} -> {}",
+                        token,
+                        span,
+                        path.display()
+                    )
                 } else {
                     write!(f, "Unexpected token '{:?}' -> {}", token, path.display())
                 }

--- a/telamon-gen/src/error.rs
+++ b/telamon-gen/src/error.rs
@@ -1,27 +1,23 @@
 use super::lalrpop_util::*;
 use super::lexer::{ErrorKind, LexicalError, Position, Span, Spanned, Token};
+use std::fmt;
+use std::path::PathBuf;
 
-use std::{fmt, path};
-
-#[derive(Debug)]
-pub struct ProcessError<'a> {
+#[derive(Debug, Fail)]
+pub struct Error {
     /// Display of filename.
-    pub path: path::Display<'a>,
+    pub path: PathBuf,
     /// Position of lexeme.
     pub span: Option<Span>,
     cause: ParseError<Position, Token, LexicalError>,
 }
 
-impl<'a> From<(path::Display<'a>, ParseError<Position, Token, LexicalError>)>
-    for ProcessError<'a>
-{
-    fn from(
-        (path, parse): (path::Display<'a>, ParseError<Position, Token, LexicalError>),
-    ) -> Self {
+impl From<(PathBuf, ParseError<Position, Token, LexicalError>)> for Error {
+    fn from((path, parse): (PathBuf, ParseError<Position, Token, LexicalError>)) -> Self {
         match parse {
             ParseError::InvalidToken {
                 location: Position { position: beg, .. },
-            } => ProcessError {
+            } => Error {
                 path,
                 span: Some(Span {
                     beg,
@@ -29,7 +25,7 @@ impl<'a> From<(path::Display<'a>, ParseError<Position, Token, LexicalError>)>
                 }),
                 cause: parse,
             },
-            ParseError::UnrecognizedToken { token: None, .. } => ProcessError {
+            ParseError::UnrecognizedToken { token: None, .. } => Error {
                 path,
                 span: None,
                 cause: parse,
@@ -64,7 +60,7 @@ impl<'a> From<(path::Display<'a>, ParseError<Position, Token, LexicalError>)>
                                 data: ErrorKind::InvalidInclude { .. },
                             },
                     },
-            } => ProcessError {
+            } => Error {
                 path,
                 span: Some(Span {
                     beg,
@@ -76,10 +72,10 @@ impl<'a> From<(path::Display<'a>, ParseError<Position, Token, LexicalError>)>
     }
 }
 
-impl<'a> fmt::Display for ProcessError<'a> {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ProcessError {
+            Error {
                 path,
                 span,
                 cause:
@@ -89,7 +85,7 @@ impl<'a> fmt::Display for ProcessError<'a> {
                     },
                 ..
             }
-            | ProcessError {
+            | Error {
                 path,
                 span,
                 cause:
@@ -99,21 +95,21 @@ impl<'a> fmt::Display for ProcessError<'a> {
                 ..
             } => {
                 if let Some(span) = span {
-                    write!(f, "Unexpected token '{:?}', {} -> {}", token, span, path)
+                    write!(f, "Unexpected token '{:?}', {} -> {}", token, span, path.display())
                 } else {
-                    write!(f, "Unexpected token '{:?}' -> {}", token, path)
+                    write!(f, "Unexpected token '{:?}' -> {}", token, path.display())
                 }
             }
-            ProcessError {
+            Error {
                 path,
                 span,
                 cause: ParseError::User { error },
                 ..
             } => {
                 if let Some(span) = span {
-                    write!(f, "{}, {} -> {}", error, span, path)
+                    write!(f, "{}, {} -> {}", error, span, path.display())
                 } else {
-                    write!(f, "{} -> {}", error, path)
+                    write!(f, "{} -> {}", error, path.display())
                 }
             }
             _ => Ok(()),

--- a/telamon-gen/src/lib.rs
+++ b/telamon-gen/src/lib.rs
@@ -160,37 +160,23 @@ pub fn process<T: io::Write>(
 #[cfg(test)]
 mod tests {
     use super::print;
-    use std::io::Cursor;
     use std::path::Path;
 
     /// Ensure that the output of telamon-gen is stable across calls.
     #[test]
     fn stable_output() {
-        let mut in_buf =
-            Cursor::new(include_str!("../../src/search_space/choices.exh").as_bytes());
+        let path = Path::new("../src/search_space/choices.exh");
         let ref_out = {
             let mut ref_out = Vec::new();
-            super::process(
-                Some(&mut in_buf),
-                &mut ref_out,
-                false,
-                &Path::new("choices.exh"),
-            ).unwrap();
+            super::process( None, &mut ref_out, false, &path).unwrap();
             ref_out
         };
         // Ideally we would want to run this loop more than once, but
         // generation is currently too slow to be worth it.
         for _ in 0..1 {
             print::reset();
-            in_buf.set_position(0);
-
             let mut out_buf = Vec::new();
-            super::process(
-                Some(&mut in_buf),
-                &mut out_buf,
-                false,
-                &Path::new("choices.exh"),
-            ).unwrap();
+            super::process( None, &mut out_buf, false, &path).unwrap();
             assert_eq!(
                 ::std::str::from_utf8(&out_buf),
                 ::std::str::from_utf8(&ref_out)

--- a/telamon-gen/src/lib.rs
+++ b/telamon-gen/src/lib.rs
@@ -61,11 +61,11 @@ fn to_type_name(name: &str) -> String {
 }
 
 /// Process a file and stores the result in an other file.
-pub fn process_file<'a>(
-    input_path: &'a path::Path,
+pub fn process_file(
+    input_path: &path::Path,
     output_path: &path::Path,
     format: bool,
-) -> Result<(), error::ProcessError<'a>> {
+) -> Result<(), error::Error> {
     let mut output = fs::File::create(path::Path::new(output_path)).unwrap();
     let input_path_str = input_path.to_string_lossy();
     info!(
@@ -77,12 +77,12 @@ pub fn process_file<'a>(
 }
 
 /// Parses a constraint description file.
-pub fn process<'a, T: io::Write>(
+pub fn process<T: io::Write>(
     input: Option<&mut io::Read>,
     output: &mut T,
     format: bool,
-    input_path: &'a path::Path,
-) -> Result<(), error::ProcessError<'a>> {
+    input_path: &path::Path,
+) -> Result<(), error::Error> {
     // Parse and check the input.
     let tokens = if let Some(stream) = input {
         lexer::Lexer::from_input(stream)
@@ -90,7 +90,7 @@ pub fn process<'a, T: io::Write>(
         lexer::Lexer::from_file(input_path)
     };
     let ast: ast::Ast = parser::parse_ast(tokens)
-        .map_err(|c| error::ProcessError::from((input_path.display(), c)))?;
+        .map_err(|c| error::Error::from((input_path.to_path_buf(), c)))?;
 
     let (mut ir_desc, constraints) = ast.type_check().unwrap();
     debug!("constraints: {:?}", constraints);

--- a/telamon-gen/src/lib.rs
+++ b/telamon-gen/src/lib.rs
@@ -168,7 +168,7 @@ mod tests {
         let path = Path::new("../src/search_space/choices.exh");
         let ref_out = {
             let mut ref_out = Vec::new();
-            super::process( None, &mut ref_out, false, &path).unwrap();
+            super::process(None, &mut ref_out, false, &path).unwrap();
             ref_out
         };
         // Ideally we would want to run this loop more than once, but
@@ -176,7 +176,7 @@ mod tests {
         for _ in 0..1 {
             print::reset();
             let mut out_buf = Vec::new();
-            super::process( None, &mut out_buf, false, &path).unwrap();
+            super::process(None, &mut out_buf, false, &path).unwrap();
             assert_eq!(
                 ::std::str::from_utf8(&out_buf),
                 ::std::str::from_utf8(&ref_out)

--- a/telamon-gen/tests/parser.rs
+++ b/telamon-gen/tests/parser.rs
@@ -40,7 +40,7 @@ fn parser_unexpected_token() {
         format!(
             "{}",
             parser::parse_ast(Lexer::new(b"define enum Uper".to_vec()))
-                .map_err(|c| error::ProcessError::from((Path::new("exh").display(), c)))
+                .map_err(|c| error::Error::from((Path::new("exh").to_path_buf(), c)))
                 .err()
                 .unwrap()
         ),
@@ -73,7 +73,7 @@ fn parser_invalid_token() {
         format!(
             "{}",
             parser::parse_ast(Lexer::new(b"!".to_vec()))
-                .map_err(|c| error::ProcessError::from((Path::new("exh").display(), c)))
+                .map_err(|c| error::Error::from((Path::new("exh").to_path_buf(), c)))
                 .err()
                 .unwrap()
         ),


### PR DESCRIPTION
This PR splits the choices.exh into multiple smaller files using include statements and improves the way errors are printed so it is easier to iterate on the search space encoding.