### PR TITLE
Fix benches after 447c0c8e870190d7

### DIFF
--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -39,9 +39,9 @@ impl MMSig {
     fn build_body(&self) -> SearchSpace {
         const DATA_TYPE: ir::Type = ir::Type::F(32);
         let mut builder = helper::Builder::new(&self.signature, &*DEVICE);
-        let m_size = builder.param_size("m");
-        let n_size = builder.param_size("n");
-        let k_size = builder.param_size("k");
+        let m_size = builder.param_size("m", 32);
+        let n_size = builder.param_size("n", 32);
+        let k_size = builder.param_size("k", 32);
 
         let ld_a_m = builder.open_tiled_dim(m_size, &[16, 4]);
         let ld_a_k = builder.open_tiled_dim(k_size.clone(), &[16]);

--- a/benches/memory.rs
+++ b/benches/memory.rs
@@ -9,8 +9,6 @@ extern crate telamon_utils;
 
 mod common;
 
-use itertools::Itertools;
-
 /// Reads the amount of resident memory.
 fn resident_memory() -> usize {
     // many statistics are cached and only updated when the epoch is advanced.
@@ -18,11 +16,9 @@ fn resident_memory() -> usize {
     unwrap!(jemalloc_ctl::stats::resident())
 }
 
-const NUM_DESCENTS: usize = 1000;
-
 fn main() {
     let mem_beg = resident_memory();
-    let space = common::MM.clone();
+    let _space = common::MM.clone();
     let mem_one = resident_memory();
     println!("candidate size: {} bytes", mem_one - mem_beg);
 }


### PR DESCRIPTION
The `max_size` argument introduced in that commit was not used when
creating dimension in the performance benches.  This also fixes some
minor lints (unused imports/variable) in the benches.