### PR TITLE
Rename value into variable.

### DIFF
--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -16,7 +16,7 @@ pub struct Function<'a> {
     induction_vars: Vec<InductionVar<'a>>,
     mem_blocks: Vec<InternalMemoryRegion<'a>>,
     init_induction_levels: Vec<InductionLevel<'a>>,
-    values: Vec<Value<'a>>,
+    variables: Vec<Variable<'a>>,
     // TODO(cleanup): remove dependency on the search space
     space: &'a SearchSpace<'a>,
 }
@@ -52,10 +52,10 @@ impl<'a> Function<'a> {
         );
         let device_code_args = device_code_args.into_iter().collect();
         debug!("compiling cfg {:?}", cfg);
-        let values = space
+        let variables = space
             .ir_instance()
-            .values()
-            .map(|v| Value::new(v, space))
+            .variables()
+            .map(|v| Variable::new(v, space))
             .collect_vec();
         Function {
             cfg,
@@ -65,7 +65,7 @@ impl<'a> Function<'a> {
             device_code_args,
             space,
             mem_blocks,
-            values,
+            variables,
             init_induction_levels,
         }
     }
@@ -80,9 +80,9 @@ impl<'a> Function<'a> {
         &self.block_dims
     }
 
-    /// Iterate on values of the function
-    pub fn values(&self) -> impl Iterator<Item = &Value> {
-        self.values.iter()
+    /// Iterate on the function variables.
+    pub fn variables(&self) -> impl Iterator<Item = &Variable> {
+        self.variables.iter()
     }
 
     /// Iterates other all `codegen::Dimension`.
@@ -363,23 +363,23 @@ impl<'a> InternalMemoryRegion<'a> {
     }
 }
 
-pub struct Value<'a> {
-    value: &'a ir::Value,
+pub struct Variable<'a> {
+    variable: &'a ir::Variable,
     t: ir::Type,
 }
 
-impl<'a> Value<'a> {
-    pub fn new(value: &'a ir::Value, space: &SearchSpace) -> Self {
-        let t = unwrap!(space.ir_instance().device().lower_type(value.t(), space));
-        Value { value, t }
+impl<'a> Variable<'a> {
+    pub fn new(variable: &'a ir::Variable, space: &SearchSpace) -> Self {
+        let t = unwrap!(space.ir_instance().device().lower_type(variable.t(), space));
+        Variable { variable, t }
     }
 
-    /// Returns the ID of the value.
-    pub fn id(&self) -> ir::ValueId {
-        self.value.id()
+    /// Returns the ID of the variable.
+    pub fn id(&self) -> ir::VarId {
+        self.variable.id()
     }
 
-    /// Returns the type of the value.
+    /// Returns the type of the variable.
     pub fn t(&self) -> ir::Type {
         self.t
     }

--- a/src/helper/builder.rs
+++ b/src/helper/builder.rs
@@ -2,9 +2,7 @@
 use device::Device;
 use helper::{AutoOperand, LogicalDim, MetaStatement, TilingPattern};
 use ir::{self, mem, op, Parameter, Type};
-use ir::{
-    AccessPattern, Function, InstId, Operand, Operator, Signature, ValueDef, ValueId,
-};
+use ir::{AccessPattern, Function, InstId, Operand, Operator, Signature};
 use itertools::Itertools;
 use search_space::{Action, DimKind, InstFlag, MemSpace, Order, SearchSpace};
 use std::borrow::Borrow;
@@ -215,14 +213,13 @@ impl<'a> Builder<'a> {
         unwrap!(self.function.add_inst(op, open_dims))
     }
 
-    pub fn create_inst_value(&mut self, inst_id: InstId) -> ValueId {
-        if let Some(val_id) = self.function.inst(inst_id).result_value() {
-            val_id
-        } else {
-            let value_def = ValueDef::Inst(inst_id);
-            let value_id = unwrap!(self.function.add_value(value_def));
-            value_id
-        }
+    pub fn create_inst_variable(&mut self, inst_id: InstId) -> ir::VarId {
+        self.function
+            .inst(inst_id)
+            .result_variable()
+            .unwrap_or_else(|| {
+                unwrap!(self.function.add_variable(ir::VarDef::Inst(inst_id)))
+            })
     }
 
     /// Applies an action on the function.

--- a/src/helper/operand.rs
+++ b/src/helper/operand.rs
@@ -2,7 +2,7 @@
 use device::ScalarArgument;
 use helper::{Builder, LogicalDim};
 use ir::Operand::*;
-use ir::{self, dim, mem, InstId, Operand, ValueId};
+use ir::{self, dim, mem, InstId, Operand};
 
 /// Represents values that can be turned into an `Operand`.
 pub trait AutoOperand<'a> {
@@ -93,13 +93,13 @@ impl<'a> AutoOperand<'a> for InstId {
     }
 }
 
-impl<'a> AutoOperand<'a> for ValueId {
+impl<'a> AutoOperand<'a> for ir::VarId {
     fn get<'b>(&self, builder: &mut Builder<'b>) -> Operand<'b, ()>
     where
         'a: 'b,
     {
-        let val = builder.function().value(*self);
-        Operand::Value(*self, val.t())
+        let val = builder.function().variable(*self);
+        Operand::Variable(*self, val.t())
     }
 }
 

--- a/src/ir/dimension.rs
+++ b/src/ir/dimension.rs
@@ -152,9 +152,9 @@ impl<'a> Dimension<'a> {
 
 lazy_static! {
     // This empty set is necessary because `Statement` must return references the the sets of
-    // values it uses and defines but does not contains any. Thus, instead of creating fields with
+    // variables it uses and defines but does not contains any. Thus, instead of creating fields with
     // empty set we return a reference to this global variable.
-    static ref NO_VALUES: VecSet<ir::ValueId> = VecSet::default();
+    static ref NO_VALUES: VecSet<ir::VarId> = VecSet::default();
 }
 
 impl<'a> Statement<'a> for Dimension<'a> {
@@ -166,11 +166,11 @@ impl<'a> Statement<'a> for Dimension<'a> {
         Some(self)
     }
 
-    fn def_values(&self) -> &VecSet<ir::ValueId> {
+    fn def_variables(&self) -> &VecSet<ir::VarId> {
         &NO_VALUES
     }
 
-    fn used_values(&self) -> &VecSet<ir::ValueId> {
+    fn used_variables(&self) -> &VecSet<ir::VarId> {
         &NO_VALUES
     }
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -11,7 +11,7 @@ mod operator;
 mod size;
 mod statement;
 mod types;
-mod value;
+mod variable;
 
 use itertools::Itertools;
 use std;
@@ -32,7 +32,7 @@ pub use self::operator::{BinOp, Operator, UnaryOp};
 pub use self::size::{PartialSize, Size};
 pub use self::statement::{Statement, StmtId};
 pub use self::types::Type;
-pub use self::value::{Value, ValueDef, ValueId};
+pub use self::variable::{VarDef, VarId, Variable};
 
 pub mod mem;
 
@@ -71,9 +71,9 @@ pub struct NewObjs {
     pub tiled_dimensions: Vec<(LogicalDimId, DimId)>,
     pub dim_mappings: Vec<DimMappingId>,
     pub mapped_dims: Vec<(DimMappingId, DimId)>,
-    pub values: Vec<ValueId>,
-    pub use_statements: Vec<(ValueId, StmtId)>,
-    pub def_statements: Vec<(ValueId, StmtId)>,
+    pub variables: Vec<VarId>,
+    pub use_statements: Vec<(VarId, StmtId)>,
+    pub def_statements: Vec<(VarId, StmtId)>,
 }
 
 impl NewObjs {
@@ -130,12 +130,12 @@ impl NewObjs {
         }
     }
 
-    pub fn add_value(&mut self, val: &Value) {
-        self.values.push(val.id());
+    pub fn add_variable(&mut self, var: &Variable) {
+        self.variables.push(var.id());
         self.def_statements
-            .extend(val.def_points().map(|stmt| (val.id(), stmt)));
+            .extend(var.def_points().map(|stmt| (var.id(), stmt)));
         self.use_statements
-            .extend(val.use_points().map(|stmt| (val.id(), stmt)));
+            .extend(var.use_points().map(|stmt| (var.id(), stmt)));
     }
 }
 
@@ -171,12 +171,12 @@ impl LoweredDimMap {
         st_dims.zip_eq(ld_dims)
     }
 
-    /// Returns the dimensions that store the value.
+    /// Returns the dimensions that store the variable.
     pub fn store_dims(&self) -> impl Iterator<Item = DimId> + '_ {
         self.st_dims_mapping.iter().map(|&(_, [_, dim])| dim)
     }
 
-    /// Returns the dimensions that load the value.
+    /// Returns the dimensions that load the variable.
     pub fn load_dims(&self) -> impl Iterator<Item = DimId> + '_ {
         self.ld_dims_mapping.iter().map(|&(_, [_, dim])| dim)
     }

--- a/src/ir/operand.rs
+++ b/src/ir/operand.rs
@@ -111,8 +111,8 @@ pub enum Operand<'a, L = LoweringMap> {
     Reduce(InstId, Type, DimMap, Vec<ir::DimId>),
     /// A variable increased by a fixed amount at every step of some loops.
     InductionVar(ir::IndVarId, Type),
-    /// A value that can be read from by an instruction
-    Value(ir::ValueId, Type),
+    /// A variable, stored in register.
+    Variable(ir::VarId, Type),
 }
 
 impl<'a, L> Operand<'a, L> {
@@ -124,7 +124,7 @@ impl<'a, L> Operand<'a, L> {
             Addr(mem) => ir::Type::PtrTo(mem.into()),
             Index(..) => Type::I(32),
             Param(p) => p.t,
-            Value(_, t) => t,
+            Variable(_, t) => t,
             Inst(_, t, ..) | Reduce(_, t, ..) | InductionVar(_, t) => t,
         }
     }
@@ -198,7 +198,7 @@ impl<'a, L> Operand<'a, L> {
     pub fn is_constant(&self) -> bool {
         match self {
             Int(..) | Float(..) | Addr(..) | Param(..) => true,
-            Index(..) | Inst(..) | Reduce(..) | InductionVar(..) | Value(..) => false,
+            Index(..) | Inst(..) | Reduce(..) | InductionVar(..) | Variable(..) => false,
         }
     }
 
@@ -226,7 +226,7 @@ impl<'a> Operand<'a, ()> {
             Inst(id, t, dim_map, DimMapScope::Thread) => {
                 Inst(id, t, dim_map, DimMapScope::Thread)
             }
-            Value(val, t) => Value(val, t),
+            Variable(val, t) => Variable(val, t),
             Index(id) => Index(id),
             Param(param) => Param(param),
             Addr(id) => Addr(id),

--- a/src/ir/statement.rs
+++ b/src/ir/statement.rs
@@ -42,9 +42,9 @@ pub trait Statement<'a, L = ir::LoweringMap>: std::fmt::Debug {
         None
     }
 
-    /// Lists the values defined at this statement.
-    fn def_values(&self) -> &VecSet<ir::ValueId>;
+    /// Lists the variables defined at this statement.
+    fn def_variables(&self) -> &VecSet<ir::VarId>;
 
-    /// Lists the values defined used at this statement.
-    fn used_values(&self) -> &VecSet<ir::ValueId>;
+    /// Lists the variables defined used at this statement.
+    fn used_variables(&self) -> &VecSet<ir::VarId>;
 }

--- a/src/ir/variable.rs
+++ b/src/ir/variable.rs
@@ -3,31 +3,31 @@ use ir;
 use std;
 use utils::*;
 
-/// Uniquely identifies values.
+/// Uniquely identifies variables.
 #[derive(
     Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
 )]
-pub struct ValueId(pub u16);
+pub struct VarId(pub u16);
 
-impl From<ValueId> for usize {
-    fn from(val_id: ValueId) -> Self {
+impl From<VarId> for usize {
+    fn from(val_id: VarId) -> Self {
         val_id.0 as usize
     }
 }
 
-/// A value produced by the code.
+/// A variable produced by the code.
 #[derive(Clone, Debug)]
-pub struct Value {
-    id: ValueId,
+pub struct Variable {
+    id: VarId,
     t: ir::Type,
-    def: ValueDef,
+    def: VarDef,
     use_points: VecSet<ir::StmtId>,
 }
 
-impl Value {
-    /// Creates a new value with the given Id.
-    pub fn new(id: ValueId, t: ir::Type, def: ValueDef) -> Self {
-        Value {
+impl Variable {
+    /// Creates a new variable with the given Id.
+    pub fn new(id: VarId, t: ir::Type, def: VarDef) -> Self {
+        Variable {
             id,
             t,
             def,
@@ -35,41 +35,41 @@ impl Value {
         }
     }
 
-    /// Return the unique identifiers of the `Value`.
-    pub fn id(&self) -> ValueId {
+    /// Return the unique identifiers of the `Variable`.
+    pub fn id(&self) -> VarId {
         self.id
     }
 
-    /// Specifies how the value is defined.
-    pub fn def(&self) -> &ValueDef {
+    /// Specifies how the variable is defined.
+    pub fn def(&self) -> &VarDef {
         &self.def
     }
 
-    /// Indicates the type of the value.
+    /// Indicates the type of the variable.
     pub fn t(&self) -> ir::Type {
         self.t
     }
 
-    /// Indicates the statements that define the value.
+    /// Indicates the statements that define the variable.
     pub fn def_points(&self) -> impl Iterator<Item = ir::StmtId> + '_ {
         self.def.def_statements()
     }
 
-    /// Indicates the statements that uses the value.
+    /// Indicates the statements that uses the variable.
     pub fn use_points(&self) -> impl Iterator<Item = ir::StmtId> + '_ {
         self.use_points.iter().cloned()
     }
 
-    /// Registers that the value is used by a statement.
+    /// Registers that the variable is used by a statement.
     pub fn add_use(&mut self, stmt: ir::StmtId) {
         self.use_points.insert(stmt);
     }
 }
 
-/// Specifies how is a `Value` defined.
+/// Specifies how is a `Variable` defined.
 #[derive(Clone, Debug, Copy)]
-pub enum ValueDef {
-    /// Takes the value produced by an instruction.
+pub enum VarDef {
+    /// Takes the variable produced by an instruction.
     Inst(ir::InstId),
     // TODO(value):
     // - Last
@@ -78,31 +78,31 @@ pub enum ValueDef {
     // - ExternalMem
 }
 
-impl ValueDef {
-    /// Registers the value in the structures it references in the function.
-    pub fn register<L>(self, self_id: ir::ValueId, function: &mut ir::Function<L>) {
-        let ValueDef::Inst(inst_id) = self;
-        function.inst_mut(inst_id).set_result_value(self_id);
+impl VarDef {
+    /// Registers the variable in the structures it references in the function.
+    pub fn register<L>(self, self_id: VarId, function: &mut ir::Function<L>) {
+        let VarDef::Inst(inst_id) = self;
+        function.inst_mut(inst_id).set_result_variable(self_id);
     }
 
-    /// Returns the type of the value if used on the context of `function`.
+    /// Returns the type of the variable if used on the context of `function`.
     pub fn t<L>(self, fun: &ir::Function<L>) -> ir::Type {
-        let ValueDef::Inst(inst_id) = self;
+        let VarDef::Inst(inst_id) = self;
         unwrap!(fun.inst(inst_id).t())
     }
 
     /// Ensures the definition is valid.
     pub fn check<L>(self, fun: &ir::Function<L>) -> Result<(), ir::TypeError> {
-        let ValueDef::Inst(inst) = self;
+        let VarDef::Inst(inst) = self;
         if fun.inst(inst).t().is_none() {
             Err(ir::TypeError::ExpectedReturnType { inst })?;
         }
         Ok(())
     }
 
-    /// Indicates in which statment the value is defined.
+    /// Indicates in which statment the variable is defined.
     pub fn def_statements(self) -> impl Iterator<Item = ir::StmtId> {
-        let ValueDef::Inst(inst_id) = self;
+        let VarDef::Inst(inst_id) = self;
         std::iter::once(inst_id.into())
     }
 }

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -58,7 +58,7 @@ quotient IterationDims($inst in Instructions) of $dim in Dimensions:
   add_to_set = "::search_space::add_iteration_dim($fun, $inst, $item)"
 end
 
-include "values.exh"
+include "variable.exh"
 
 /// Specifies how iteration dimensions are implemented.
 define enum dim_kind($dim in Dimensions):

--- a/src/search_space/operand.rs
+++ b/src/search_space/operand.rs
@@ -6,8 +6,7 @@ use search_space::choices::{Action, DimKind, DimMapping, Order};
 /// Generates actions to enforce operands invariants.
 pub fn invariants(fun: &ir::Function, op: &ir::Operand, user: ir::StmtId) -> Vec<Action> {
     match *op {
-        // TODO: Handles dependencies for Values
-        Int(..) | Float(..) | Param(..) | Addr(..) | Value(..) => vec![],
+        Int(..) | Float(..) | Param(..) | Addr(..) | Variable(..) => vec![],
         Inst(src, _, ref dim_map, ref scope) => {
             // Order dimensions in the dim map.
             let order = Order::BEFORE | Order::MERGED;

--- a/src/search_space/variable.exh
+++ b/src/search_space/variable.exh
@@ -1,41 +1,41 @@
-set Values:
-  item_type = "ir::Value"
-  id_type = "ir::ValueId"
-  item_getter = "$fun.value($id)"
+set Variables:
+  item_type = "ir::Variable"
+  id_type = "ir::VariableId"
+  item_getter = "$fun.variable($id)"
   id_getter = "$item.id()"
-  iterator = "$fun.values()"
-  var_prefix = "value"
-  new_objs = "$objs.values"
+  iterator = "$fun.variables()"
+  var_prefix = "variable"
+  new_objs = "$objs.variables"
 end
 
-set DefStatements($value in Values) subsetof Statements:
+set DefStatements($var in Variables) subsetof Statements:
   item_type = "ir::Statement"
   id_type = "ir::StmtId"
   item_getter = "$fun.statement($id)"
   id_getter = "$item.id()"
-  iterator = "$value.def_points().map(|id| $fun.statement(id))"
-  from_superset = "if $item.def_values().contains(&$value.id()) { Some($item) } else { None }"
-  reverse forall $stmt in Statements = "$stmt.def_values().iter().map(|&id| $fun.value(id))"
+  iterator = "$var.def_points().map(|id| $fun.statement(id))"
+  from_superset = "if $item.def_variables().contains(&$var.id()) { Some($item) } else { None }"
+  reverse forall $stmt in Statements = "$stmt.def_variables().iter().map(|&id| $fun.variable(id))"
   var_prefix = "def"
   new_objs = "$objs.def_statements"
 end
 
-set UseStatements($value in Values) subsetof Statements:
+set UseStatements($var in Variables) subsetof Statements:
   item_type = "ir::Statement"
   id_type = "ir::StmtId"
   item_getter = "$fun.statement($id)"
   id_getter = "$item.id()"
-  iterator = "$value.use_points().map(|id| $fun.statement(id))"
-  from_superset = "if $item.used_values().contains(&$value.id()) { Some($item) } else { None }"
-  reverse forall $stmt in Statements = "$stmt.used_values().iter().map(|&id| $fun.value(id))"
+  iterator = "$var.use_points().map(|id| $fun.statement(id))"
+  from_superset = "if $item.used_variables().contains(&$var.id()) { Some($item) } else { None }"
+  reverse forall $stmt in Statements = "$stmt.used_variables().iter().map(|&id| $fun.variable(id))"
   var_prefix = "use"
   new_objs = "$objs.use_statements"
 end
 
 // Enforce data dependencies.
-require forall $value in Values:
-  forall $def in DefStatements($value):
-    forall $use in UseStatements($value):
+require forall $var in Variables:
+  forall $def in DefStatements($var):
+    forall $use in UseStatements($var):
       order($def, $use) is BEFORE
 
 set MemoryRegions:

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -53,10 +53,10 @@ fn inst_dim_order() {
     let mut builder = helper::Builder::new(&signature, context.device());
     let dim0 = builder.open_dim(Size::new_const(64));
     let inst0 = builder.mov(&0i32);
-    let _ = builder.create_inst_value(inst0);
+    let _ = builder.create_inst_variable(inst0);
     let pattern = builder.unknown_access_pattern(ir::MemId::External(0));
     let addr = builder.cast(&0i64, ir::Type::PtrTo(ir::MemId::External(0)));
-    let _ = builder.create_inst_value(addr);
+    let _ = builder.create_inst_variable(addr);
     let inst1 = builder.st(&addr, &0i32, pattern);
     builder.close_dim(&dim0);
     let dim1 = builder.open_dim(Size::new_const(64));
@@ -96,7 +96,7 @@ fn inst_value_order() {
     let signature = empty_signature(1);
     let mut builder = helper::Builder::new(&signature, context.device());
     let inst0 = builder.mov(&1f32);
-    let v0 = builder.create_inst_value(inst0);
+    let v0 = builder.create_inst_variable(inst0);
     let inst1 = builder.mov(&v0);
     let space = builder.get();
     assert_eq!(


### PR DESCRIPTION
Adds nothing new. Just rename ir::Value into ir::Variable and follow the convention in related types/variables/files.