### PR TITLE
Implement Statement for non-forzen instructions and dimensions (+random fixes)

### DIFF
--- a/src/explorer/choice.rs
+++ b/src/explorer/choice.rs
@@ -91,7 +91,7 @@ pub fn fix_order(mut space: SearchSpace) -> SearchSpace {
     // Fix the order between instructions and dimensions.
     let pairs = space
         .ir_instance()
-        .blocks()
+        .statements()
         .cartesian_product(space.ir_instance().dims())
         .map(|(lhs, rhs)| (lhs.stmt_id(), rhs.stmt_id()))
         .filter(|&(lhs, rhs)| lhs != rhs)

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -55,6 +55,10 @@ impl Signature {
 }
 
 /// Describes a function and the set of its possible implementation.
+///
+/// The type parameter `L` indicates if the function is fozen (`L = ir::LoweringMap`) or
+/// not (`L = ())`. A frozen function cannot have any more IDs allocated. We use this to
+/// know the exact list of potential decisions before we run the exploration.
 #[derive(Clone)]
 pub struct Function<'a, L = ir::LoweringMap> {
     signature: &'a Signature,

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -209,7 +209,9 @@ impl<'a, L> Function<'a, L> {
 
     /// Lists all `Statement`s.
     pub fn statements<'b>(&'b self) -> impl Iterator<Item = &'b Statement<'a, L>> {
-        self.insts().map(|x| x as _).chain(self.dims().map(|x| x as _))
+        self.insts()
+            .map(|x| x as _)
+            .chain(self.dims().map(|x| x as _))
     }
 
     /// Retrives a logical dimension given its ID.
@@ -499,7 +501,6 @@ impl<'a> Function<'a, ()> {
         })
     }
 
-
     pub(crate) fn freeze(self) -> Function<'a> {
         let mut counter = ir::Counter {
             next_mem: self.mem_blocks.num_internal_blocks(),
@@ -534,7 +535,9 @@ impl<'a> Function<'a, ()> {
             .map(|induction_var| induction_var.freeze(&mut counter))
             .collect();
         let mut dims = SparseVec::from_vec(
-            dims.into_iter().map(|dim| dim.map(|dim| dim.freeze())).collect()
+            dims.into_iter()
+                .map(|dim| dim.map(|dim| dim.freeze()))
+                .collect(),
         );
 
         let ir::Counter {

--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -206,12 +206,12 @@ impl<'a> Instruction<'a> {
     }
 }
 
-impl<'a> Statement<'a> for Instruction<'a> {
+impl<'a, L> Statement<'a, L> for Instruction<'a, L> {
     fn stmt_id(&self) -> StmtId {
         self.id.into()
     }
 
-    fn as_inst(&self) -> Option<&Instruction<'a>> {
+    fn as_inst(&self) -> Option<&Instruction<'a, L>> {
         Some(self)
     }
 

--- a/src/ir/operator.rs
+++ b/src/ir/operator.rs
@@ -84,7 +84,7 @@ impl BinOp {
     }
 
     /// Returns the type of the binay operator given the type of its operands.
-    fn t(&self, operand_type: ir::Type) -> ir::Type {
+    pub fn t(&self, operand_type: ir::Type) -> ir::Type {
         match self {
             BinOp::Lt | BinOp::Leq | BinOp::Equals => ir::Type::I(1),
             _ => operand_type,

--- a/src/ir/statement.rs
+++ b/src/ir/statement.rs
@@ -1,6 +1,5 @@
 //! Provides a generic decription of basic blocks.
 use ir;
-use std;
 use utils::*;
 
 /// Provides a unique identifer for a basic block.
@@ -28,7 +27,7 @@ impl From<ir::DimId> for StmtId {
 }
 
 /// Represents a basic block in an Exhaust function.
-pub trait Statement<'a, L = ir::LoweringMap>: std::fmt::Debug {
+pub trait Statement<'a, L = ir::LoweringMap> {
     /// Returns the unique identifier of the `Statement`.
     fn stmt_id(&self) -> StmtId;
 
@@ -38,7 +37,7 @@ pub trait Statement<'a, L = ir::LoweringMap>: std::fmt::Debug {
     }
 
     /// Returns 'self' if it is a dimension
-    fn as_dim(&self) -> Option<&ir::Dimension<'a>> {
+    fn as_dim(&self) -> Option<&ir::Dimension<'a, L>> {
         None
     }
 

--- a/src/model/level.rs
+++ b/src/model/level.rs
@@ -118,7 +118,7 @@ pub fn sum_pressure(
         .unwrap_or_else(|| space.ir_instance().dims().map(|d| d.id()).collect());
     let inner_sum_dims = inner_dims
         .filter(|&d| bound_level.accounts_for_dim(space.domain().get_dim_kind(d)));
-    // Get the list of inner basic blocks.
+    // Get the list of inner statements.
     let inner_stmts_sets = nest
         .iter()
         .map(|&d| &local_info.nesting[&d.into()].inner_stmts);
@@ -126,7 +126,7 @@ pub fn sum_pressure(
         .map(|x| itertools::Either::Left(x.into_iter()))
         .unwrap_or_else(|| {
             itertools::Either::Right(
-                space.ir_instance().blocks().map(|stmt| stmt.stmt_id()),
+                space.ir_instance().statements().map(|stmt| stmt.stmt_id()),
             )
         });
     // Sum the pressure on all stmts.
@@ -164,7 +164,7 @@ pub fn sum_pressure(
             let (max_active_threads, predication_factor);
             let is_predicated = space
                 .ir_instance()
-                .block(stmt)
+                .statement(stmt)
                 .as_inst()
                 .map(|i| i.has_side_effects())
                 .unwrap_or(false);

--- a/src/model/local_info.rs
+++ b/src/model/local_info.rs
@@ -33,12 +33,12 @@ impl<'a> LocalInfo<'a> {
             .collect();
         let nesting: HashMap<_, _> = space
             .ir_instance()
-            .blocks()
+            .statements()
             .map(|stmt| (stmt.stmt_id(), Nesting::compute(space, stmt.stmt_id())))
             .collect();
         let mut hw_pressure = space
             .ir_instance()
-            .blocks()
+            .statements()
             .map(|stmt| {
                 let is_thread = if let ir::StmtId::Dim(id) = stmt.stmt_id() {
                     space.domain().get_dim_kind(id) == DimKind::THREAD
@@ -170,7 +170,7 @@ impl<'a> Nesting<'a> {
         let mut after_self = Vec::new();
         let mut bigger_merged_dims = Vec::new();
         let mut has_inner_thread_dims = false;
-        for other_stmt in space.ir_instance().blocks() {
+        for other_stmt in space.ir_instance().statements() {
             if other_stmt.stmt_id() == stmt {
                 continue;
             }

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -5,9 +5,9 @@
 set Statements:
   item_type = "ir::Statement"
   id_type = "ir::StmtId"
-  item_getter = "$fun.block($id)"
+  item_getter = "$fun.statement($id)"
   id_getter = "$item.stmt_id()"
-  iterator = "$fun.blocks()"
+  iterator = "$fun.statements()"
   var_prefix = "stmt"
   new_objs = "$objs.statements"
 end


### PR DESCRIPTION
This PR implements Statement for not yet frozen instructions and dimensions. This allows us to manipulate then in a uniform way when needed. It also rename statement accessors from `block` to `statement` and make public the return type of binary operators.