### PR TITLE
Fix two bugs in telamon-gen.

### DIFF
--- a/telamon-gen/cc_tests/src/fail.rs
+++ b/telamon-gen/cc_tests/src/fail.rs
@@ -2,8 +2,8 @@
 
 mod fail0 {
     define_ir! {
-        trait set_a;
-        struct subset_a[subset_b reverse set_a]: set_a;
+        struct set_a;
+        type subset_a[subset_b reverse set_a]: set_a;
 
         trait set_b;
         struct subset_b: set_b;

--- a/telamon-gen/cc_tests/src/ir_gen.rs
+++ b/telamon-gen/cc_tests/src/ir_gen.rs
@@ -121,7 +121,7 @@ macro_rules! define_ir {
         define_ir!(@from_super_id $super);
     };
     (@impl_super trait $super:ident) => {
-        impl<T: Obj + ?Sized> super::$superset::Obj for T {
+        impl<T: Obj + ?Sized> super::$super::Obj for T {
             define_ir!(@impl_super_methods $super);
         }
         define_ir!(@from_super_id $super);

--- a/telamon-gen/cc_tests/src/unused_set.exh
+++ b/telamon-gen/cc_tests/src/unused_set.exh
@@ -1,0 +1,49 @@
+set SetA:
+  item_type = "ir::set_a::Obj"
+  id_type = "ir::set_a::Id"
+  item_getter = "ir::set_a::get($fun, $id)"
+  id_getter = "ir::set_a::Obj::id($item)"
+  iterator = "ir::set_a::iter($fun)"
+  new_objs = "$objs.set_a"
+end
+
+set SetB:
+  item_type = "ir::set_b::Obj"
+  id_type = "ir::set_b::Id"
+  item_getter = "ir::set_b::get($fun, $id)"
+  id_getter = "ir::set_b::Obj::id($item)"
+  iterator = "ir::set_b::iter($fun)"
+  new_objs = "$objs.set_b"
+end
+
+set SubsetB subsetof SetB:
+  item_type = "ir::subset_b::Obj"
+  id_type = "ir::subset_b::Id"
+  item_getter = "ir::subset_b::get($fun, $id)"
+  id_getter = "ir::subset_b::Obj::id($item)"
+  iterator = "ir::subset_b::iter($fun)"
+  from_superset = "ir::subset_b::from_superset($fun, $item)"
+  new_objs = "$objs.subset_b"
+end
+
+set SubsubsetB($a in SetA) subsetof SubsetB:
+  item_type = "ir::subset_b::Obj"
+  id_type = "ir::subset_b::Id"
+  item_getter = "ir::subset_b::get($fun, $id)"
+  id_getter = "ir::subset_b::Obj::id($item)"
+  iterator = "ir::subsubset_b::iter($fun, ir::subset_a::Obj::id($a))"
+  from_superset = "ir::subsubset_b::from_superset($fun, $a, $item)"
+  reverse forall $b in SubsetB = "ir::subsubset_b::reverse($fun, $b.id())"
+  new_objs = "$objs.subsubset_b"
+end
+
+define enum foo($lhs in SetB, $rhs in SetB):
+  symmetric
+  value A:
+  value B:
+end
+
+require forall $a in SetA:
+  forall $lhs in SubsubsetB($a):
+    forall $rhs in SubsubsetB($a):
+      foo($rhs, $lhs) is A

--- a/telamon-gen/src/ast/mod.rs
+++ b/telamon-gen/src/ast/mod.rs
@@ -30,7 +30,7 @@ pub use self::error::{Hint, TypeError};
 pub use self::set::SetDef;
 pub use self::trigger::TriggerDef;
 
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Debug)]
 pub struct Ast {
     pub statements: Vec<Statement>,
     pub ir_desc: ir::IrDesc,

--- a/telamon-gen/src/constraint.rs
+++ b/telamon-gen/src/constraint.rs
@@ -140,6 +140,8 @@ fn gen_flat_filter(
             .iter()
             .map(|x: &(_, _)| &x.1)
             .chain(&foralls)
+            .map(|set| set.as_ref())
+            .chain(foralls.iter().flat_map(|set| set.reverse_constraint()))
             .filter(|s| s.arg().map(|v| v == var).unwrap_or(false))
             .map(|s| unwrap!(s.def().arg()))
             .any(|s| !given_set.is_subset_of(s));

--- a/telamon-gen/src/ir/choice.rs
+++ b/telamon-gen/src/ir/choice.rs
@@ -379,7 +379,6 @@ pub enum FilterRef {
         id: usize,
         args: Vec<ir::Variable>,
     },
-
 }
 
 impl Adaptable for FilterRef {

--- a/telamon-gen/src/ir/filter.rs
+++ b/telamon-gen/src/ir/filter.rs
@@ -173,6 +173,14 @@ pub struct ChoiceInstance {
 }
 
 impl ChoiceInstance {
+    /// Creates a `ChoiceInstance` that point to a choice in its own context.
+    pub fn self_choice(choice: &ir::Choice) -> Self {
+        ChoiceInstance {
+            choice: choice.name().clone(),
+            vars: (0..choice.arguments().len()).map(ir::Variable::Arg).collect(),
+        }
+    }
+
     /// Normalizes the `ChoiceInstance` and indicates if the corresponding input should be
     /// inversed.
     pub fn normalize(&mut self, ir_desc: &ir::IrDesc) -> bool {

--- a/telamon-gen/src/ir/filter.rs
+++ b/telamon-gen/src/ir/filter.rs
@@ -177,7 +177,9 @@ impl ChoiceInstance {
     pub fn self_choice(choice: &ir::Choice) -> Self {
         ChoiceInstance {
             choice: choice.name().clone(),
-            vars: (0..choice.arguments().len()).map(ir::Variable::Arg).collect(),
+            vars: (0..choice.arguments().len())
+                .map(ir::Variable::Arg)
+                .collect(),
         }
     }
 

--- a/telamon-gen/src/ir/mod.rs
+++ b/telamon-gen/src/ir/mod.rs
@@ -16,11 +16,11 @@ pub use self::filter::*;
 pub use self::set::*;
 
 /// Describes the choices that constitute the IR.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct IrDesc {
     choices: IndexMap<RcStr, Choice>,
     enums: IndexMap<RcStr, Enum>,
-    set_defs: IndexMap<RcStr, std::rc::Rc<SetDef>>,
+    set_defs: IndexMap<RcStr, (std::rc::Rc<SetDef>, set::OnNewObject)>,
     triggers: Vec<Trigger>,
 }
 
@@ -56,21 +56,29 @@ impl IrDesc {
     }
 
     /// Iterates over all the sets.
-    pub fn set_defs<'a>(&'a self) -> impl Iterator<Item = &'a std::rc::Rc<SetDef>> + 'a {
+    pub fn set_defs(
+        &self,
+    ) -> impl Iterator<Item = &(std::rc::Rc<SetDef>, OnNewObject)> + '_ {
         self.set_defs.values()
     }
 
     /// Register a set definition.
     pub fn add_set_def(&mut self, def: std::rc::Rc<SetDef>) {
         let name = def.name().clone();
-        assert!(self.set_defs.insert(name, def).is_none());
+        assert!(
+            self.set_defs
+                .insert(name, (def, OnNewObject::default()))
+                .is_none()
+        );
     }
 
     /// Returns the set definition associated with a name.
     pub fn get_set_def<'a>(&'a self, name: &str) -> &'a std::rc::Rc<SetDef> {
-        self.set_defs
+        &self
+            .set_defs
             .get(name)
             .unwrap_or_else(|| panic!("Undefined set {}", name))
+            .0
     }
 
     /// Adds a filter to a choice.
@@ -110,11 +118,18 @@ impl IrDesc {
                 .map(|(i, _)| Variable::Arg(i))
                 .chain((0..forall_vars.len()).map(|i| Variable::Forall(i)))
                 .collect();
-            FilterRef::Local {
+            FilterRef::Function {
+                choice: choice.clone(),
                 id: filter_id,
                 args: arguments,
             }
         };
+        self.register_filter_on_new_objs(
+            &filter_ref,
+            &choice,
+            &forall_vars,
+            &set_constraints,
+        );
         // Add the init call.
         let filter = FilterCall {
             forall_vars,
@@ -128,6 +143,71 @@ impl IrDesc {
             .get_mut(&choice)
             .unwrap()
             .add_filter_action(filter_action);
+    }
+
+    /// Registers to run `filter` when a new object is added to a set in `foralls`.
+    fn register_filter_on_new_objs(
+        &mut self,
+        filter: &FilterRef,
+        choice: &RcStr,
+        foralls: &[Set],
+        set_constraints: &SetConstraints,
+    ) {
+        let choice = &self.choices[choice];
+        let mut choice_args = choice.arguments()
+            .sets()
+            .cloned()
+            .collect_vec();
+        // Apply the set constraints the the choice arguments.
+        for (var, set_constraint) in set_constraints.constraints() {
+            if let Variable::Arg(i) = *var {
+                choice_args[i] = set_constraint.clone();
+            } else {
+                panic!("expected an argument variable");
+            }
+        }
+        for i in 0..foralls.len() {
+            let var = Variable::Forall(i);
+            // If the set if a reverse set, it has no proper definition so we cannot
+            // register it. Instead we re-reverse it to obtain the intial set.
+            let mut set = foralls[i].clone();
+            let arg_set;
+            let reverse = if (&set).def().name().is_empty() {
+                let (rev_arg_set, rev_set) = set
+                    .reverse(Variable::Forall(i), (&set).def().arg().unwrap())
+                    .unwrap();
+                arg_set = Some(rev_arg_set);
+                set = rev_set;
+                true
+            } else {
+                arg_set = (&set).arg().map(|var| match var {
+                    Variable::Forall(id) => foralls[id].clone(),
+                    Variable::Arg(id) => choice_args[id].clone(),
+                });
+                false
+            };
+            // Constraint the set of the argument.
+            let (new_foralls, adaptator) =
+                adapt_to_var_context(&choice_args, foralls, var, reverse);
+            let set_constraints = arg_set
+                .filter(|arg_set| !(&set).def().arg().unwrap().is_subset_of(arg_set))
+                .map(|arg_set| {
+                    let arg_set = arg_set.adapt(&adaptator);
+                    SetConstraints::new(vec![(Variable::Arg(1), arg_set)])
+                }).unwrap_or_default();
+            let remote_call = RemoteFilterCall {
+                choice: ChoiceInstance::self_choice(choice).adapt(&adaptator),
+                filter: FilterCall {
+                    // `forall_vars` are supposed to iterate on multiple filters for the
+                    // same choice.  Our foralls iterate on multiple choices so we pass
+                    // them externally.
+                    forall_vars: vec![],
+                    filter_ref: filter.adapt(&adaptator),
+                },
+            };
+            let set_def = self.set_defs.get_mut((&set).def().name()).unwrap();
+            set_def.1.filter.push((new_foralls, set_constraints, remote_call));
+        }
     }
 
     pub fn add_onchange(&mut self, choice: &str, action: OnChangeAction) {
@@ -212,13 +292,13 @@ impl IrDesc {
             .chain((0..num_foralls).map(Variable::Forall))
             .map(|v| adaptator.variable(v))
             .collect();
-        let filter_ref = FilterRef::Remote {
+        let filter_ref = FilterRef::Function {
             choice: filtered.clone(),
             id,
             args,
         };
         let filtered_args = (0..num_args).map(|i| adaptator.variable(Variable::Arg(i)));
-        let action = ChoiceAction::Filter {
+        let remote_filter = RemoteFilterCall {
             choice: ChoiceInstance {
                 choice: filtered,
                 vars: filtered_args.collect(),
@@ -231,7 +311,7 @@ impl IrDesc {
         OnChangeAction {
             forall_vars: choice_foralls,
             set_constraints,
-            action,
+            action: ChoiceAction::Filter(remote_filter),
         }
     }
 
@@ -358,6 +438,46 @@ impl Default for IrDesc {
         ir_desc.add_enum(bool_enum);
         ir_desc
     }
+}
+
+/// Adapt the environement to the point of view of a variable. In practice, this means, mapping
+/// `var` to `ir::Variable::Arg(0)`, its argument to `ir::Variable::Arg(1)` (if any) and other sets
+/// to forall variables. If reverse is `true`, Arg(0) and Arg(1) are inversed.
+fn adapt_to_var_context(
+    args: &[Set],
+    foralls: &[Set],
+    var: Variable,
+    reverse: bool,
+) -> (Vec<Set>, Adaptator) {
+    let mut adaptator = Adaptator::default();
+    adaptator.set_variable(var, Variable::Arg(if reverse { 1 } else { 0 }));
+    let arg_var = match var {
+        Variable::Arg(i) => (&args[i]).arg(),
+        Variable::Forall(i) => (&foralls[i]).arg(),
+    };
+    if let Some(arg) = arg_var {
+        adaptator.set_variable(arg, Variable::Arg(if reverse { 0 } else { 1 }));
+    } else {
+        assert!(!reverse);
+    }
+    let mut forall_index = 0;
+    let args = args
+        .iter()
+        .enumerate()
+        .map(|(i, set)| (Variable::Arg(i), set));
+    let foralls = foralls
+        .iter()
+        .enumerate()
+        .map(|(i, set)| (Variable::Forall(i), set));
+    let new_foralls = args
+        .chain(foralls)
+        .filter(|&(id, _)| id != var && Some(id) != arg_var)
+        .map(|(old_id, set)| {
+            adaptator.set_variable(old_id, Variable::Forall(forall_index));
+            forall_index += 1;
+            set.adapt(&adaptator)
+        }).collect();
+    (new_foralls, adaptator)
 }
 
 /// Indicates whether a counter sums or adds.

--- a/telamon-gen/src/ir/mod.rs
+++ b/telamon-gen/src/ir/mod.rs
@@ -154,10 +154,7 @@ impl IrDesc {
         set_constraints: &SetConstraints,
     ) {
         let choice = &self.choices[choice];
-        let mut choice_args = choice.arguments()
-            .sets()
-            .cloned()
-            .collect_vec();
+        let mut choice_args = choice.arguments().sets().cloned().collect_vec();
         // Apply the set constraints the the choice arguments.
         for (var, set_constraint) in set_constraints.constraints() {
             if let Variable::Arg(i) = *var {
@@ -205,7 +202,10 @@ impl IrDesc {
                 },
             };
             let set_def = self.set_defs.get_mut((&set).def().name()).unwrap();
-            set_def.1.filter.push((new_foralls, set_constraints, remote_call));
+            set_def
+                .1
+                .filter
+                .push((new_foralls, set_constraints, remote_call));
         }
     }
 

--- a/telamon-gen/src/ir/mod.rs
+++ b/telamon-gen/src/ir/mod.rs
@@ -166,11 +166,10 @@ impl IrDesc {
                 panic!("expected an argument variable");
             }
         }
-        for i in 0..foralls.len() {
+        for (i, mut set) in foralls.iter().cloned().enumerate() {
             let var = Variable::Forall(i);
             // If the set if a reverse set, it has no proper definition so we cannot
-            // register it. Instead we re-reverse it to obtain the intial set.
-            let mut set = foralls[i].clone();
+            // register it. Instead we re-reverse it to obtain the initial set.
             let arg_set;
             let reverse = if (&set).def().name().is_empty() {
                 let (rev_arg_set, rev_set) = set
@@ -311,7 +310,7 @@ impl IrDesc {
         OnChangeAction {
             forall_vars: choice_foralls,
             set_constraints,
-            action: ChoiceAction::Filter(remote_filter),
+            action: ChoiceAction::RemoteFilter(remote_filter),
         }
     }
 

--- a/telamon-gen/src/print/ast.rs
+++ b/telamon-gen/src/print/ast.rs
@@ -70,7 +70,6 @@ impl<'a> Serialize for Variable<'a> {
 #[derive(Clone)]
 pub struct Context<'a> {
     pub ir_desc: &'a ir::IrDesc,
-    pub choice: &'a ir::Choice,
     vars: HashMap<ir::Variable, (Variable<'a>, &'a ir::Set)>,
     inputs: Vec<print::ValueIdent>,
 }
@@ -100,9 +99,28 @@ impl<'a> Context<'a> {
             }).collect();
         Context {
             ir_desc,
-            choice,
             vars,
             inputs,
+        }
+    }
+
+    /// Create a new context, without beiing liked to a particular choice or filter.
+    pub fn new_outer(
+        ir_desc: &'a ir::IrDesc,
+        args: &[(Variable<'a>, &'a ir::Set)],
+        foralls: &'a [ir::Set],
+    ) -> Self {
+        let mut vars = HashMap::default();
+        for (id, var_def) in args.iter().enumerate() {
+            vars.insert(ir::Variable::Arg(id), var_def.clone());
+        }
+        for (id, set) in foralls.iter().enumerate() {
+            vars.insert(ir::Variable::Forall(id), (Variable::with_set(set), set));
+        }
+        Context {
+            ir_desc,
+            vars,
+            inputs: vec![],
         }
     }
 

--- a/telamon-gen/src/print/ast.rs
+++ b/telamon-gen/src/print/ast.rs
@@ -104,7 +104,7 @@ impl<'a> Context<'a> {
         }
     }
 
-    /// Create a new context, without beiing liked to a particular choice or filter.
+    /// Create a new context, without beiing linked to a particular choice or filter.
     pub fn new_outer(
         ir_desc: &'a ir::IrDesc,
         args: &[(Variable<'a>, &'a ir::Set)],

--- a/telamon-gen/src/print/choice.rs
+++ b/telamon-gen/src/print/choice.rs
@@ -294,7 +294,7 @@ impl<'a> OnChangeAction<'a> {
 #[derive(Serialize)]
 enum ChoiceAction<'a> {
     FilterSelf,
-    Filter(RemoteFilterCall<'a>),
+    FilterRemote(RemoteFilterCall<'a>),
     IncrCounter {
         counter_name: &'a str,
         arguments: Vec<(ast::Variable<'a>, ast::Set<'a>)>,
@@ -339,10 +339,10 @@ impl<'a> ChoiceAction<'a> {
     ) -> Self {
         match action {
             ir::ChoiceAction::FilterSelf => ChoiceAction::FilterSelf,
-            ir::ChoiceAction::Filter(remote_call) => {
+            ir::ChoiceAction::RemoteFilter(remote_call) => {
                 let call =
                     RemoteFilterCall::new(remote_call, conflicts, forall_offset, ctx);
-                ChoiceAction::Filter(call)
+                ChoiceAction::FilterRemote(call)
             }
             ir::ChoiceAction::IncrCounter {
                 counter,

--- a/telamon-gen/src/print/choice.rs
+++ b/telamon-gen/src/print/choice.rs
@@ -551,7 +551,7 @@ impl<'a> FilterRef<'a> {
                     .collect();
                 FilterRef::Inline { rules }
             }
-            ir::FilterRef::Function { choice, id, args, } => {
+            ir::FilterRef::Function { choice, id, args } => {
                 let arguments = args.iter().map(|&v| (ctx.var_name(v),)).collect();
                 FilterRef::Call {
                     choice,

--- a/telamon-gen/src/print/choice.rs
+++ b/telamon-gen/src/print/choice.rs
@@ -1,5 +1,5 @@
 //! Prints the definition and manipulation of choices.
-use ir;
+use ir::{self, SetRef};
 use print;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::ToTokens;
@@ -13,9 +13,9 @@ pub fn ids(choice_instance: &ir::ChoiceInstance, ctx: &print::Context) -> TokenS
         .iter()
         .zip_eq(arg_sets)
         .map(|(&var, set)| {
-            // TODO(cleanup): parse beforehand
-            let var = unwrap!(ctx.var_name(var).to_string().parse());
-            print::set::id(var, set)
+            // TODO(cleanup): use idents instead of variables in the context.
+            let var = Ident::new(&ctx.var_name(var).to_string(), Span::call_site());
+            print::set::ObjectId::from_object(&var.into(), set.def())
         });
     quote!(#(#ids,)*)
 }
@@ -115,7 +115,7 @@ impl<'a> Ast<'a> {
             full_value_type: ast::ValueType::new(choice.value_type().full_type(), ctx),
             choice_def: ChoiceDef::new(choice.choice_def()),
             restrict_counter: RestrictCounter::new(choice, ir_desc),
-            iteration_space: self::iteration_space(ctx),
+            iteration_space: self::iteration_space(choice, ctx),
             compute_counter: ComputeCounter::new(choice, ir_desc),
             arguments,
             trigger_calls,
@@ -132,9 +132,9 @@ impl<'a> Ast<'a> {
     }
 }
 
-/// Returns the iteration space associated to a choice.
-fn iteration_space<'a>(ctx: &ast::Context<'a>) -> ast::LoopNest<'a> {
-    match *ctx.choice.arguments() {
+/// Returns the iteration space associated to `choice`.
+fn iteration_space<'a>(choice: &ir::Choice, ctx: &ast::Context<'a>) -> ast::LoopNest<'a> {
+    match *choice.arguments() {
         ref args @ ir::ChoiceArguments::Plain { .. } => {
             let args = (0..args.len()).map(ir::Variable::Arg);
             ast::LoopNest::new(args, ctx, &mut vec![], false)
@@ -279,6 +279,7 @@ impl<'a> OnChangeAction<'a> {
             &action.set_constraints,
             conflicts,
             ctx,
+            choice,
             trigger_calls,
         );
         OnChangeAction {
@@ -293,13 +294,7 @@ impl<'a> OnChangeAction<'a> {
 #[derive(Serialize)]
 enum ChoiceAction<'a> {
     FilterSelf,
-    Filter {
-        choice: &'a str,
-        is_symmetric: bool,
-        filter_call: FilterCall<'a>,
-        choice_full_type: ast::ValueType,
-        arguments: Vec<(ast::Variable<'a>, ast::Set<'a>)>,
-    },
+    Filter(RemoteFilterCall<'a>),
     IncrCounter {
         counter_name: &'a str,
         arguments: Vec<(ast::Variable<'a>, ast::Set<'a>)>,
@@ -339,28 +334,15 @@ impl<'a> ChoiceAction<'a> {
         set_constraints: &'a ir::SetConstraints,
         conflicts: Vec<ast::Conflict<'a>>,
         ctx: &ast::Context<'a>,
+        current_choice: &ir::Choice,
         trigger_calls: &mut Vec<TriggerCall<'a>>,
     ) -> Self {
         match action {
             ir::ChoiceAction::FilterSelf => ChoiceAction::FilterSelf,
-            ir::ChoiceAction::Filter {
-                choice: choice_instance,
-                filter,
-            } => {
-                let set = ast::Variable::with_name("values");
-                let choice = ctx.ir_desc.get_choice(&choice_instance.choice);
-                let filter_call =
-                    FilterCall::new(filter, set, conflicts, forall_offset, ctx);
-                let arguments = ast::vars_with_sets(choice, &choice_instance.vars, ctx);
-                let adaptator = ir::Adaptator::from_arguments(&choice_instance.vars);
-                let full_type = choice.value_type().full_type().adapt(&adaptator);
-                ChoiceAction::Filter {
-                    is_symmetric: choice.arguments().is_symmetric(),
-                    choice: choice.name(),
-                    choice_full_type: ast::ValueType::new(full_type, ctx),
-                    filter_call,
-                    arguments,
-                }
+            ir::ChoiceAction::Filter(remote_call) => {
+                let call =
+                    RemoteFilterCall::new(remote_call, conflicts, forall_offset, ctx);
+                ChoiceAction::Filter(call)
             }
             ir::ChoiceAction::IncrCounter {
                 counter,
@@ -418,7 +400,7 @@ impl<'a> ChoiceAction<'a> {
                         is_half: visibility == ir::CounterVisibility::NoMax,
                         zero: kind.zero(),
                         counter_type: ast::ValueType::new(counter_type, ctx),
-                        incr_type: ast::ValueType::new(ctx.choice.value_type(), ctx),
+                        incr_type: ast::ValueType::new(current_choice.value_type(), ctx),
                         incr_args,
                         arguments,
                     }
@@ -444,7 +426,7 @@ impl<'a> ChoiceAction<'a> {
                     .map(|(pos, input)| {
                         (ctx.input_name(pos), ast::ChoiceInstance::new(input, ctx))
                     }).collect();
-                let arguments = (0..ctx.choice.arguments().len())
+                let arguments = (0..current_choice.arguments().len())
                     .map(ir::Variable::Arg)
                     .chain((0..forall_offset).map(ir::Variable::Forall))
                     .map(|v| {
@@ -477,6 +459,40 @@ impl<'a> ChoiceAction<'a> {
                     self_condition: value_set::print(&self_condition, ctx).to_string(),
                 }
             }
+        }
+    }
+}
+
+/// AST for an `ir::RemoteFilterCall`.
+#[derive(Serialize)]
+pub struct RemoteFilterCall<'a> {
+    choice: &'a str,
+    is_symmetric: bool,
+    filter_call: FilterCall<'a>,
+    choice_full_type: ast::ValueType,
+    arguments: Vec<(ast::Variable<'a>, ast::Set<'a>)>,
+}
+
+impl<'a> RemoteFilterCall<'a> {
+    pub fn new(
+        remote_call: &'a ir::RemoteFilterCall,
+        conflicts: Vec<ast::Conflict<'a>>,
+        forall_offset: usize,
+        ctx: &ast::Context<'a>,
+    ) -> Self {
+        let set = ast::Variable::with_name("values");
+        let choice = ctx.ir_desc.get_choice(&remote_call.choice.choice);
+        let filter_call =
+            FilterCall::new(&remote_call.filter, set, conflicts, forall_offset, ctx);
+        let arguments = ast::vars_with_sets(choice, &remote_call.choice.vars, ctx);
+        let adaptator = ir::Adaptator::from_arguments(&remote_call.choice.vars);
+        let full_type = choice.value_type().full_type().adapt(&adaptator);
+        RemoteFilterCall {
+            is_symmetric: choice.arguments().is_symmetric(),
+            choice: choice.name(),
+            choice_full_type: ast::ValueType::new(full_type, ctx),
+            filter_call,
+            arguments,
         }
     }
 }
@@ -527,32 +543,19 @@ impl<'a> FilterRef<'a> {
         value_var: ast::Variable<'a>,
         ctx: &ast::Context<'a>,
     ) -> Self {
-        match *filter_ref {
-            ir::FilterRef::Inline(ref rules) => {
+        match filter_ref {
+            ir::FilterRef::Inline(rules) => {
                 let rules = rules
                     .iter()
                     .map(|r| filter::Rule::new(value_var.clone(), r, ctx))
                     .collect();
                 FilterRef::Inline { rules }
             }
-            ir::FilterRef::Local { id, ref args } => {
-                let arguments = args.iter().map(|&v| (ctx.var_name(v),)).collect();
-                FilterRef::Call {
-                    choice: "self",
-                    id,
-                    arguments,
-                    value_var,
-                }
-            }
-            ir::FilterRef::Remote {
-                ref choice,
-                id,
-                ref args,
-            } => {
+            ir::FilterRef::Function { choice, id, args, } => {
                 let arguments = args.iter().map(|&v| (ctx.var_name(v),)).collect();
                 FilterRef::Call {
                     choice,
-                    id,
+                    id: *id,
                     arguments,
                     value_var,
                 }

--- a/telamon-gen/src/print/mod.rs
+++ b/telamon-gen/src/print/mod.rs
@@ -113,6 +113,7 @@ lazy_static! {
         register_template!(engine, loop_nest);
         register_template!(engine, main);
         register_template!(engine, on_change);
+        register_template!(engine, partial_init_filters);
         register_template!(engine, positive_filter);
         register_template!(engine, propagate);
         register_template!(engine, restrict_counter);
@@ -233,6 +234,7 @@ impl<T: Fn(&mut Formatter) -> fmt::Result> Display for Printer<T> {
 mod ast;
 mod choice;
 mod filter;
+mod partial_init;
 mod store;
 mod value_set;
 
@@ -277,6 +279,7 @@ pub fn print(ir_desc: &ir::IrDesc) -> String {
         choices: &'a [choice::Ast<'a>] = &choices,
         enums: String = ir_desc.enums().format("\n\n").to_string(),
         partial_iterators: PartialIters<'a> = partials,
+        partial_init_filters: String = partial_init::filters(ir_desc).to_string(),
         incr_iterators: Vec<store::IncrIterator<'a>> = incr_iterators,
         triggers: Vec<Trigger<'a>> = triggers,
         runtime: String = runtime::get().to_string()

--- a/telamon-gen/src/print/partial_init.rs
+++ b/telamon-gen/src/print/partial_init.rs
@@ -1,0 +1,92 @@
+/// Prints code that handles the insertion of new objects during the search.
+use ir::{self, SetRef};
+use print;
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::ToTokens;
+
+/// Runs necessary filters after new objects are allocated. This only runs new filters on
+/// old objects.
+pub fn filters(ir_desc: &ir::IrDesc) -> TokenStream {
+    ir_desc
+        .set_defs()
+        .map(|(set_def, on_new_object)| {
+            if on_new_object.filter.is_empty() {
+                return quote!();
+            }
+            let obj = Ident::new("obj", Span::call_site());
+            let arg = set_def.arg().map(|_| Ident::new("arg", Span::call_site()));
+            // We assume the argument variable is Arg(1) since this is what is generated
+            // by `ir::adapt_to_var_context`.
+            let set = ir::Set::new(set_def, set_def.arg().map(|_| ir::Variable::Arg(1)));
+            // We must use the old template facilities to print the filter call so
+            // generate variables for the old printer.
+            let mut vars = vec![(print::ast::Variable::with_name("obj"), &set)];
+            if let Some(arg) = set_def.arg() {
+                vars.push((print::ast::Variable::with_name("arg"), arg));
+            }
+            let body = on_new_object
+                .filter
+                .iter()
+                .map(|(foralls, constraints, filter_call)| {
+                    let ctx =
+                        print::Context::new_outer(ir_desc, &vars, foralls);
+                    let mut conflicts = vars.iter()
+                        .map(|(var, set)| print::ast::Conflict::new(var.clone(), set))
+                        .collect();
+                    let loop_vars = (0..foralls.len()).map(ir::Variable::Forall);
+                    let loop_nest = print::ast::LoopNest::new(
+                        loop_vars, &ctx, &mut conflicts, false);
+                    let filter_call = print::choice::RemoteFilterCall::new(
+                        filter_call, conflicts, foralls.len(), &ctx);
+                    let set_constraints = print::ast::SetConstraint::new(
+                        constraints, &ctx);
+                    let printed_code = render!(partial_init_filters, <'a>,
+                        loop_nest: print::ast::LoopNest<'a> = loop_nest,
+                        set_constraints: Vec<print::ast::SetConstraint<'a>> = set_constraints,
+                        filter_call: print::choice::RemoteFilterCall<'a> = filter_call);
+                    let tokens: TokenStream = printed_code.parse().unwrap();
+                    tokens
+                }).collect();
+            iter_new_objects(set_def, &obj, arg.as_ref(), &body)
+        }).collect()
+}
+
+/// Iterates on the new objects of `set` and executes `body` for each of them.
+///
+/// Warning: this method differs from the partial_iterators in `print::store`: it may
+/// call multiple times the same filter. This is because this makes it easier to handle
+/// reversed sets: we can register them in the non-reversed set instead. This doesn't
+/// work if the non-reversed set iterator skips some objects because it thinks they are
+/// handled by the reverse set. To factorize those functions, we would need to consider
+/// relations instead of parametric sets, thus removing the need to have reversed sets.
+fn iter_new_objects(
+    set: &ir::SetDef,
+    obj: &Ident,
+    arg: Option<&Ident>,
+    body: &TokenStream,
+) -> TokenStream {
+    assert_eq!(set.arg().is_some(), arg.is_some());
+    let new_objs_iter = print::set::iter_new_objects(&set);
+    let obj_id = print::set::ObjectId::new("obj_id", set);
+    let arg_id = set
+        .arg()
+        .map(|set| print::set::ObjectId::new("arg_id", set.def()));
+    let obj_arg_pattern = arg_id
+        .as_ref()
+        .map(|arg| quote! { (#arg, #obj_id) })
+        .unwrap_or(obj_id.clone().into_token_stream());
+    let arg_def = arg_id.as_ref().map(|id| {
+        let getter = id.fetch_object(None);
+        quote!{ let #arg = #getter; }
+    });
+    let arg = arg.map(|x| x.clone().into());
+    let obj_getter = obj_id.fetch_object(arg.as_ref());
+    quote! {
+        for &#obj_arg_pattern in #new_objs_iter.iter() {
+            #arg_def
+            let #obj = #obj_getter;
+            trace!("bloup");
+            #body
+        }
+    }
+}

--- a/telamon-gen/src/print/partial_init.rs
+++ b/telamon-gen/src/print/partial_init.rs
@@ -85,7 +85,6 @@ fn iter_new_objects(
         for &#obj_arg_pattern in #new_objs_iter.iter() {
             #arg_def
             let #obj = #obj_getter;
-            trace!("bloup");
             #body
         }
     }

--- a/telamon-gen/src/print/set.rs
+++ b/telamon-gen/src/print/set.rs
@@ -1,12 +1,55 @@
 //! Manipulation of sets and their items.
 use ir;
-use proc_macro2::TokenStream;
+use proc_macro2::{Delimiter, Group, Ident, Span, TokenStream, TokenTree};
+use quote;
 
-/// Prints the ID of an object.
-pub fn id<'a, S: ir::SetRef<'a>>(object: TokenStream, set: S) -> TokenStream {
-    // TODO(cleanup): parse beforehand
-    let expr = set.def().attributes()[&ir::SetDefKey::IdGetter]
-        .replace("$fun", "ir_instance")
-        .replace("$item", &object.to_string());
-    unwrap!(expr.parse())
+/// Lists the new objects of the given set.
+pub fn iter_new_objects(set: &ir::SetDef) -> TokenTree {
+    // TODO(cleanup): parse in the parser instead of after substitution.
+    let expr = set.attributes()[&ir::SetDefKey::NewObjs].replace("$objs", "new_objs");
+    Group::new(Delimiter::Parenthesis, unwrap!(expr.parse())).into()
+}
+
+/// Represents an expression that holds the ID of an object.
+#[derive(Clone)]
+pub struct ObjectId<'a> {
+    id: TokenTree,
+    set: &'a ir::SetDef,
+}
+
+impl<'a> ObjectId<'a> {
+    /// Creates a new variable to hold an object ID.
+    pub fn new(name: &str, set: &'a ir::SetDef) -> Self {
+        ObjectId {
+            id: TokenTree::Ident(Ident::new(name, Span::call_site())),
+            set,
+        }
+    }
+
+    /// Creates an expression that returns the id of an object.
+    pub fn from_object(object: &TokenTree, set: &'a ir::SetDef) -> Self {
+        let expr = set.attributes()[&ir::SetDefKey::IdGetter]
+            .replace("$fun", "ir_instance")
+            .replace("$item", &object.to_string());
+        let id = Group::new(Delimiter::None, unwrap!(expr.parse())).into();
+        ObjectId { id, set }
+    }
+
+    /// Returns code that fetches the object corresponding to the ID.
+    pub fn fetch_object(&self, arg: Option<&TokenTree>) -> TokenTree {
+        // TODO(cleanup): parse in the parser instead of after substitution.
+        let mut expr = self.set.attributes()[&ir::SetDefKey::ItemGetter]
+            .replace("$fun", "ir_instance")
+            .replace("$id", &self.id.to_string());
+        if let Some(arg) = arg {
+            expr = expr.replace("$var", &arg.to_string());
+        }
+        Group::new(Delimiter::None, unwrap!(expr.parse())).into()
+    }
+}
+
+impl<'a> quote::ToTokens for ObjectId<'a> {
+    fn to_tokens(&self, stream: &mut TokenStream) {
+        self.id.to_tokens(stream)
+    }
 }

--- a/telamon-gen/src/print/store.rs
+++ b/telamon-gen/src/print/store.rs
@@ -45,7 +45,7 @@ pub fn partial_iterators<'a>(
             let iters = PartialIterator::generate(&args, is_symmetric, ir_desc, ctx);
             iters.into_iter().map(move |(iter, ctx)| {
                 let arg_names = args.iter().map(|&(v, _)| ctx.var_name(v)).collect();
-                let value_type = ctx.choice.choice_def().value_type();
+                let value_type = choice.choice_def().value_type();
                 let value_type = ast::ValueType::new(value_type, &ctx);
                 (
                     iter,
@@ -94,7 +94,7 @@ pub fn incr_iterators<'a>(ir_desc: &'a ir::IrDesc) -> Vec<IncrIterator<'a>> {
                 let obj = ast::Variable::with_name("obj");
                 let ref mut ctx = ctx.set_var_name(ir::Variable::Forall(pos), obj);
                 if let Some(arg) = set.arg() {
-                    ctx.mut_var_name(arg, Variable::with_name("obj_var"));
+                    ctx.mut_var_name(arg, Variable::with_name("arg"));
                 }
                 // Setup the variables to loop on.
                 let num_args = choice.arguments().len();
@@ -224,7 +224,7 @@ impl<'a> PartialIterator<'a> {
                 .collect_vec();
             if let Some(set_arg) = set.arg() {
                 loop_args.retain(|&v| v != set_arg);
-                ctx.mut_var_name(set_arg, Variable::with_name("obj_var"));
+                ctx.mut_var_name(set_arg, Variable::with_name("arg"));
             }
             let arg_conflicts = {
                 let ctx = &ctx;
@@ -268,8 +268,8 @@ impl<'a> PartialIterator<'a> {
         };
         ir_desc
             .set_defs()
-            .take_while(move |s| s.name() != set.def().name())
-            .map(|set| {
+            .take_while(move |(s, _)| s.name() != set.def().name())
+            .map(|(set, _)| {
                 let list = ast::new_objs_list(set, "new_objs");
                 ast::Conflict::NewObjs { list, set }
             }).chain(iter::once(self_conflict))
@@ -283,7 +283,7 @@ impl<'a> PartialIterator<'a> {
         let arg_conflict = set
             .def()
             .arg()
-            .map(|arg| ast::Conflict::new(ast::Variable::with_name("obj_var"), arg));
+            .map(|arg| ast::Conflict::new(ast::Variable::with_name("arg"), arg));
         iter::once(obj_conflict).chain(arg_conflict)
     }
 }

--- a/telamon-gen/src/print/template/iter_new_objects.rs
+++ b/telamon-gen/src/print/template/iter_new_objects.rs
@@ -1,11 +1,11 @@
-for (pos, &{{#if set.arg~}}(obj_var, obj){{else}}obj{{/if~}})
+for (pos, &{{#if set.arg~}}(arg, obj){{else}}obj{{/if~}})
     in {{>set.new_objs def=set objs="new_objs"}}.iter().enumerate() {
     {{#if set.arg~}}
-        let obj_var = {{>set.item_getter def=set.arg id="obj_var"}};
+        let arg = {{>set.item_getter def=set.arg id="arg"}};
     {{/if~}}
-    let obj = {{>set.item_getter def=set id="obj" var="obj_var"}};
+    let obj = {{>set.item_getter def=set id="obj" var="arg"}};
     {{#each arg_conflicts~}}
-        {{>conflict var="obj_var" is_triangular=false}}
+        {{>conflict var="arg" is_triangular=false}}
     {{/each~}}
     {{#each loop_nest.levels~}}
         for {{this.[0]}} in {{>set.iterator this.[1]}} {

--- a/telamon-gen/src/print/template/main.rs
+++ b/telamon-gen/src/print/template/main.rs
@@ -126,6 +126,8 @@ pub fn init_domain_partial(store: &mut DomainStore,
             {{>account_new_incrs}}
         {{/iter_new_objects~}}
     {{/each~}}
+    // Call new propagators on existing filters.
+    {{partial_init_filters}}
     // Check if we should call the new triggers.
     {{#each triggers~}}
         let mut trigger_{{id}} = Vec::new();

--- a/telamon-gen/src/print/template/on_change.rs
+++ b/telamon-gen/src/print/template/on_change.rs
@@ -1,7 +1,7 @@
 {{#>set_constraints constraints~}}
     {{#>loop_nest loop_nest~}}
         {{#ifeq action "FilterSelf"}}{{>filter_self choice=../../../../this}}{{/ifeq~}}
-        {{#with action.Filter}}{{>choice_filter}}{{/with~}}
+        {{#with action.FilterRemote}}{{>choice_filter}}{{/with~}}
         {{#with action.IncrCounter}}{{>incr_counter}}{{/with~}}
         {{#with action.UpdateCounter}}{{>update_counter}}{{/with~}}
         {{#with action.Trigger}}{{>trigger_on_change}}{{/with~}}

--- a/telamon-gen/src/print/template/partial_init_filters.rs
+++ b/telamon-gen/src/print/template/partial_init_filters.rs
@@ -1,0 +1,5 @@
+{{#>loop_nest loop_nest~}}
+    {{#>set_constraints set_constraints}}
+        {{>choice_filter filter_call}}
+    {{/set_constraints}}
+{{/loop_nest~}}


### PR DESCRIPTION
1. Correctly run the filters when allocating new objects, even if the
filtered choice was already existing. This involves creating and
populating a structure to store such filters and generating code for
the filter calls. The printing part is awkward because the old template
system we used to generated code is only partially removed, so one part of
the printing uses rust Ast while the other use templates compiled to
strings.

2. Move some set constraints outside the forall loops nest when reverse
constraints depends on them.

This PR also makes a few small changes on the side:
- Fix a small mistake in `fail.rs`. The changes made it fail to compile.
- Fix `ir_gen`. A variable was wrongly named, but this macro case was never
  used before.

Fixes #138 