### PR TITLE
Fixed wrong zero in local_selection

### DIFF
--- a/src/explorer/local_selection.rs
+++ b/src/explorer/local_selection.rs
@@ -50,13 +50,7 @@ where
 {
     let nodes = nodes.into_iter().filter(|&(_, b)| b < cut);
     match order {
-        NewNodeOrder::Api => {
-            if nodes.into_iter().next().is_some() {
-                Some(0)
-            } else {
-                None
-            }
-        }
+        NewNodeOrder::Api => nodes.into_iter().next().map(|(idx, _)| idx),
         NewNodeOrder::WeightedRandom => choose_cand_weighted(nodes, cut),
         NewNodeOrder::Bound => choose_cand_best(nodes),
         NewNodeOrder::Random => choose_cand_rand(nodes),


### PR DESCRIPTION
Problem was that api::pick_index returns 0 unconditionally when it should actually return the index of the first non-tested child (which is the first child in the list passed to pick_index, but not the first in the node of the tree)