### PR TITLE
Improve vectorization decisions expressiveness.

### DIFF
--- a/src/codegen/dimension.rs
+++ b/src/codegen/dimension.rs
@@ -311,7 +311,7 @@ fn get_ind_var_levels<'a>(
     for &(dim, ref size) in ind_var.dims() {
         let size = codegen::Size::from_ir(size, space);
         match space.domain().get_dim_kind(dim) {
-            DimKind::VECTOR => (),
+            DimKind::INNER_VECTOR | DimKind::OUTER_VECTOR => (),
             DimKind::LOOP | DimKind::UNROLL => mut_levels.push((dim, size)),
             DimKind::BLOCK | DimKind::THREAD => const_levels.push((dim, size)),
             x => panic!("unspecified dim kind {:?}", x),

--- a/src/codegen/printer.rs
+++ b/src/codegen/printer.rs
@@ -34,7 +34,7 @@ pub trait Printer {
     /// Print return_id = lhs op rhs
     fn print_binop(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         op: ir::BinOp,
         operands_type: Type,
         rounding: op::Rounding,
@@ -46,7 +46,7 @@ pub trait Printer {
     /// Print return_id = op
     fn print_unary_op(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         operator: ir::UnaryOp,
         operand_type: Type,
         return_id: &str,
@@ -57,7 +57,7 @@ pub trait Printer {
     // FIXME: can we encode it in BinOp
     fn print_mul(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         return_type: Type,
         round: op::Rounding,
         mul_mode: MulMode,
@@ -69,7 +69,7 @@ pub trait Printer {
     /// Print return_id = mlhs * mrhs + arhs
     fn print_mad(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         ret_type: Type,
         round: op::Rounding,
         mul_mode: MulMode,
@@ -82,7 +82,7 @@ pub trait Printer {
     /// Print return_id = load [addr]
     fn print_ld(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         return_type: Type,
         flag: InstFlag,
         return_id: &str,
@@ -92,7 +92,7 @@ pub trait Printer {
     /// Print store val [addr]
     fn print_st(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         val_type: Type,
         mem_flag: InstFlag,
         predicate: Option<&str>,
@@ -111,14 +111,14 @@ pub trait Printer {
 
     /// Name an operand, vectorized on the given dimensions.
     fn name_operand<'a>(
-        vector_dims: &[&Dimension],
+        vector_levels: &[Vec<Dimension>; 2],
         op: &ir::Operand,
         namer: &'a NameMap,
     ) -> Cow<'a, str>;
 
     /// Names an instruction, vectorized on the given dimensions.
     fn name_inst<'a>(
-        vector_dims: &[&Dimension],
+        vector_levels: &[Vec<Dimension>; 2],
         inst: ir::InstId,
         namer: &'a NameMap,
     ) -> Cow<'a, str>;
@@ -126,30 +126,30 @@ pub trait Printer {
     /// Prints a scalar less-than on integers.
     fn print_lt_int(&mut self, t: ir::Type, result: &str, lhs: &str, rhs: &str) {
         let rounding = ir::op::Rounding::Exact;
-        self.print_binop(&[], ir::BinOp::Lt, t, rounding, result, lhs, rhs);
+        self.print_binop([1, 1], ir::BinOp::Lt, t, rounding, result, lhs, rhs);
     }
 
     /// Prints a scalar equals instruction.
     fn print_equals(&mut self, t: ir::Type, result: &str, lhs: &str, rhs: &str) {
         let rounding = ir::op::Rounding::Exact;
-        self.print_binop(&[], ir::BinOp::Equals, t, rounding, result, lhs, rhs);
+        self.print_binop([1, 1], ir::BinOp::Equals, t, rounding, result, lhs, rhs);
     }
 
     /// Prints a scalar addition on integers.
     fn print_add_int(&mut self, t: ir::Type, result: &str, lhs: &str, rhs: &str) {
         let rounding = ir::op::Rounding::Exact;
-        self.print_binop(&[], ir::BinOp::Add, t, rounding, result, lhs, rhs);
+        self.print_binop([1, 1], ir::BinOp::Add, t, rounding, result, lhs, rhs);
     }
 
     /// Prints an AND operation.
     fn print_and(&mut self, t: ir::Type, result: &str, lhs: &str, rhs: &str) {
         let rounding = ir::op::Rounding::Exact;
-        self.print_binop(&[], ir::BinOp::And, t, rounding, result, lhs, rhs);
+        self.print_binop([1, 1], ir::BinOp::And, t, rounding, result, lhs, rhs);
     }
 
     /// Prints a move instruction.
     fn print_move(&mut self, t: ir::Type, result: &str, operand: &str) {
-        self.print_unary_op(&[], ir::UnaryOp::Mov, t, result, operand);
+        self.print_unary_op([1, 1], ir::UnaryOp::Mov, t, result, operand);
     }
 
     fn cfg_vec(&mut self, fun: &Function, cfgs: &[Cfg], namer: &mut NameMap) {
@@ -160,10 +160,10 @@ pub trait Printer {
 
     /// Prints a cfg.
     fn cfg<'a>(&mut self, fun: &Function, c: &Cfg<'a>, namer: &mut NameMap) {
-        match *c {
-            Cfg::Root(ref cfgs) => self.cfg_vec(fun, cfgs, namer),
-            Cfg::Loop(ref dim, ref cfgs) => self.gen_loop(fun, dim, cfgs, namer),
-            Cfg::Threads(ref dims, ref ind_levels, ref inner) => {
+        match c {
+            Cfg::Root(cfgs) => self.cfg_vec(fun, cfgs, namer),
+            Cfg::Loop(dim, cfgs) => self.gen_loop(fun, dim, cfgs, namer),
+            Cfg::Threads(dims, ind_levels, inner) => {
                 self.enable_threads(fun, dims, namer);
                 for level in ind_levels {
                     self.parallel_induction_level(level, namer);
@@ -171,7 +171,7 @@ pub trait Printer {
                 self.cfg_vec(fun, inner, namer);
                 self.print_sync();
             }
-            Cfg::Instruction(ref i) => self.inst(&[], i, namer, fun),
+            Cfg::Instruction(vec_dims, inst) => self.inst(vec_dims, inst, namer, fun),
         }
     }
 
@@ -187,7 +187,7 @@ pub trait Printer {
             let mode = MulMode::from_type(Type::I(32), level.t());
             match base_components[..] {
                 [] => self.print_mul(
-                    &[],
+                    [1, 1],
                     level.t(),
                     op::Rounding::Exact,
                     mode,
@@ -196,7 +196,7 @@ pub trait Printer {
                     &step,
                 ),
                 [ref base] => self.print_mad(
-                    &[],
+                    [1, 1],
                     level.t(),
                     op::Rounding::Exact,
                     mode,
@@ -250,10 +250,6 @@ pub trait Printer {
         match dim.kind() {
             DimKind::LOOP => self.standard_loop(fun, dim, cfgs, namer),
             DimKind::UNROLL => self.unroll_loop(fun, dim, cfgs, namer),
-            DimKind::VECTOR => match *cfgs {
-                [Cfg::Instruction(ref inst)] => self.inst(&[dim], inst, namer, fun),
-                ref body => panic!("invalid vector dimension body: {:?}", body),
-            },
             _ => panic!("{:?} loop should not be printed here !", dim.kind()),
         }
     }
@@ -322,7 +318,7 @@ pub trait Printer {
                 }
                 _ => panic!(),
             };
-            self.print_unary_op(&[], ir::UnaryOp::Mov, level.t(), &ind_var, &base);
+            self.print_unary_op([1, 1], ir::UnaryOp::Mov, level.t(), &ind_var, &base);
             if let Some((_, ref incr)) = level.increment {
                 incr_levels.push((level, ind_var, incr, base));
             }
@@ -363,7 +359,7 @@ pub trait Printer {
             let size = namer.name_size(dim.size(), Type::I(32));
             let idx = namer.name_index(dim.id());
             self.print_mad(
-                &[],
+                [1, 1],
                 Type::I(32),
                 op::Rounding::Exact,
                 MulMode::Low,
@@ -376,7 +372,7 @@ pub trait Printer {
         });
         let mode = MulMode::from_type(Type::I(32), addr_type);
         self.print_mad(
-            &[],
+            [1, 1],
             addr_type,
             op::Rounding::Exact,
             mode,
@@ -390,26 +386,34 @@ pub trait Printer {
     /// Prints an instruction.
     fn inst(
         &mut self,
-        vector_dims: &[&Dimension],
+        vector_levels: &[Vec<Dimension>; 2],
         inst: &Instruction,
         namer: &mut NameMap,
         fun: &Function,
     ) {
-        let vector_factors = vector_dims
-            .iter()
-            .map(|d| unwrap!(d.size().as_int()))
-            .collect_vec();
+        // Multiple dimension can be mapped to the same vectorization level so we combine
+        // them when computing the vectorization factor.
+        let vector_factors = [
+            vector_levels[0]
+                .iter()
+                .map(|d| unwrap!(d.size().as_int()))
+                .product(),
+            vector_levels[1]
+                .iter()
+                .map(|d| unwrap!(d.size().as_int()))
+                .product(),
+        ];
         match inst.operator() {
             op::BinOp(op, lhs, rhs, round) => {
                 let t = Self::lower_type(lhs.t(), fun);
                 self.print_binop(
-                    &vector_factors,
+                    vector_factors,
                     *op,
                     t,
                     *round,
-                    &Self::name_inst(vector_dims, inst.id(), namer),
-                    &Self::name_operand(vector_dims, lhs, namer),
-                    &Self::name_operand(vector_dims, rhs, namer),
+                    &Self::name_inst(vector_levels, inst.id(), namer),
+                    &Self::name_operand(vector_levels, lhs, namer),
+                    &Self::name_operand(vector_levels, rhs, namer),
                 )
             }
             op::Mul(lhs, rhs, round, return_type) => {
@@ -417,13 +421,13 @@ pub trait Printer {
                 let low_ret_type = Self::lower_type(*return_type, fun);
                 let mode = MulMode::from_type(low_lhs_type, low_ret_type);
                 self.print_mul(
-                    &vector_factors,
+                    vector_factors,
                     low_ret_type,
                     *round,
                     mode,
-                    &Self::name_inst(vector_dims, inst.id(), namer),
-                    &Self::name_operand(vector_dims, lhs, namer),
-                    &Self::name_operand(vector_dims, rhs, namer),
+                    &Self::name_inst(vector_levels, inst.id(), namer),
+                    &Self::name_operand(vector_levels, lhs, namer),
+                    &Self::name_operand(vector_levels, rhs, namer),
                 )
             }
             op::Mad(mul_lhs, mul_rhs, add_rhs, round) => {
@@ -431,14 +435,14 @@ pub trait Printer {
                 let low_arhs_type = Self::lower_type(add_rhs.t(), fun);
                 let mode = MulMode::from_type(low_mlhs_type, low_arhs_type);
                 self.print_mad(
-                    &vector_factors,
+                    vector_factors,
                     unwrap!(inst.t()),
                     *round,
                     mode,
-                    &Self::name_inst(vector_dims, inst.id(), namer),
-                    &Self::name_operand(vector_dims, mul_lhs, namer),
-                    &Self::name_operand(vector_dims, mul_rhs, namer),
-                    &Self::name_operand(vector_dims, add_rhs, namer),
+                    &Self::name_inst(vector_levels, inst.id(), namer),
+                    &Self::name_operand(vector_levels, mul_lhs, namer),
+                    &Self::name_operand(vector_levels, mul_rhs, namer),
+                    &Self::name_operand(vector_levels, add_rhs, namer),
                 )
             }
             op::UnaryOp(operator, operand) => {
@@ -447,16 +451,16 @@ pub trait Printer {
                     op => op,
                 };
                 let t = Self::lower_type(operand.t(), fun);
-                let name = Self::name_inst(vector_dims, inst.id(), namer);
-                let operand = Self::name_operand(vector_dims, operand, namer);
-                self.print_unary_op(&vector_factors, operator, t, &name, &operand)
+                let name = Self::name_inst(vector_levels, inst.id(), namer);
+                let operand = Self::name_operand(vector_levels, operand, namer);
+                self.print_unary_op(vector_factors, operator, t, &name, &operand)
             }
             op::Ld(ld_type, addr, _) => self.print_ld(
-                &vector_factors,
+                vector_factors,
                 Self::lower_type(*ld_type, fun),
                 unwrap!(inst.mem_flag()),
-                &Self::name_inst(vector_dims, inst.id(), namer),
-                &Self::name_operand(&[], addr, namer),
+                &Self::name_inst(vector_levels, inst.id(), namer),
+                &Self::name_operand(&[vec![], vec![]], addr, namer),
             ),
             op::St(addr, val, _, _) => {
                 let guard = if inst.has_side_effects() {
@@ -465,12 +469,12 @@ pub trait Printer {
                     None
                 };
                 self.print_st(
-                    &vector_factors,
+                    vector_factors,
                     Self::lower_type(val.t(), fun),
                     unwrap!(inst.mem_flag()),
                     guard.as_ref().map(|x| x as _),
-                    &Self::name_operand(&[], addr, namer),
-                    &Self::name_operand(vector_dims, val, namer),
+                    &Self::name_operand(&[vec![], vec![]], addr, namer),
+                    &Self::name_operand(vector_levels, val, namer),
                 );
             }
             op @ op::TmpLd(..) | op @ op::TmpSt(..) => {

--- a/src/device/cuda/gpu.rs
+++ b/src/device/cuda/gpu.rs
@@ -433,22 +433,35 @@ impl device::Device for Gpu {
         512
     }
 
-    fn vectorization_factors(&self, dim: &ir::Dimension, op: &ir::Operator) -> &[u32] {
-        const LD_ST_FACTORS: [u32; 2] = [2, 4];
+    fn can_vectorize(&self, dim: &ir::Dimension, op: &ir::Operator) -> bool {
         match *op {
-            Operator::TmpLd(..) | Operator::TmpSt(..) => &LD_ST_FACTORS,
+            Operator::TmpLd(..) | Operator::TmpSt(..) => true,
             Operator::Ld(ref t, _, ref pattern)
                 if pattern.is_consecutive(dim.id(), t) =>
             {
-                &LD_ST_FACTORS
+                // TODO(ulysse): hack to avoid vectorizing by a factor of 3 until we
+                // support alignment contraints.
+                dim.possible_sizes()
+                    .map(|sizes| !sizes.contains(&3))
+                    .unwrap_or(false)
             }
             Operator::St(_, ref operand, _, ref pattern)
                 if pattern.is_consecutive(dim.id(), &operand.t()) =>
             {
-                &LD_ST_FACTORS
+                // TODO(ulysse): hack to avoid vectorizing by a factor of 3 until we
+                // support alignment contraints.
+                dim.possible_sizes()
+                    .map(|sizes| !sizes.contains(&3))
+                    .unwrap_or(false)
             }
-            _ => &[],
+            _ => false,
         }
+    }
+
+    fn max_vectorization(&self, _: &ir::Operator) -> [u32; 2] {
+        // No need to discriminate on the operator since this is already handled by
+        // `can_vectorize`.
+        [1, 4]
     }
 
     fn shared_mem(&self) -> u32 {

--- a/src/device/cuda/printer.rs
+++ b/src/device/cuda/printer.rs
@@ -230,7 +230,7 @@ impl CudaPrinter {
                         if let Some(name) = name {
                             let old_name = name_map.name_size(incr, Type::I(32));
                             self.print_unary_op(
-                                &[],
+                                [1, 1],
                                 ir::UnaryOp::Cast(level.t()),
                                 Type::I(32),
                                 &name,
@@ -354,7 +354,7 @@ impl Printer for CudaPrinter {
     /// Print result = op1 op op2
     fn print_binop(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         op: ir::BinOp,
         operands_type: Type,
         rounding: op::Rounding,
@@ -362,7 +362,7 @@ impl Printer for CudaPrinter {
         lhs: &str,
         rhs: &str,
     ) {
-        assert!(vector_factors.is_empty());
+        assert_eq!(vector_factors, [1, 1]);
         let op = Self::binary_op(op);
         let rounding = Self::rounding(rounding);
         let operands_type = Self::get_type(operands_type);
@@ -376,13 +376,13 @@ impl Printer for CudaPrinter {
     /// Prints result = operator operand.
     fn print_unary_op(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         operator: ir::UnaryOp,
         operand_type: ir::Type,
         result: &str,
         operand: &str,
     ) {
-        assert!(vector_factors.is_empty());
+        assert_eq!(vector_factors, [1, 1]);
         let operator = match operator {
             ir::UnaryOp::Mov => std::borrow::Cow::from("mov"),
             ir::UnaryOp::Cast(cast_type) => {
@@ -410,7 +410,7 @@ impl Printer for CudaPrinter {
     /// Print result = op1 * op2
     fn print_mul(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         return_type: Type,
         round: op::Rounding,
         mul_mode: MulMode,
@@ -418,7 +418,7 @@ impl Printer for CudaPrinter {
         lhs: &str,
         rhs: &str,
     ) {
-        assert!(vector_factors.is_empty());
+        assert_eq!(vector_factors, [1, 1]);
         let operator = if round == op::Rounding::Exact {
             format!("mul{}", Self::mul_mode(mul_mode))
         } else {
@@ -435,7 +435,7 @@ impl Printer for CudaPrinter {
     /// Print result = mlhs * mrhs + arhs
     fn print_mad(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         return_type: Type,
         round: op::Rounding,
         mul_mode: MulMode,
@@ -444,7 +444,7 @@ impl Printer for CudaPrinter {
         mrhs: &str,
         arhs: &str,
     ) {
-        assert!(vector_factors.is_empty());
+        assert_eq!(vector_factors, [1, 1]);
         let operator = if round == op::Rounding::Exact {
             format!("mad{}", Self::mul_mode(mul_mode))
         } else {
@@ -461,7 +461,7 @@ impl Printer for CudaPrinter {
     /// Print result = load [addr]
     fn print_ld(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         return_type: Type,
         flag: InstFlag,
         result: &str,
@@ -469,9 +469,9 @@ impl Printer for CudaPrinter {
     ) {
         let operator = Self::ld_operator(flag);
         let vector = match vector_factors {
-            [] => "",
-            [2] => ".v2",
-            [4] => ".v4",
+            [1, 1] => "",
+            [1, 2] => ".v2",
+            [1, 4] => ".v4",
             p => panic!("invalid vector pattern: {:?}", p),
         };
         unwrap!(writeln!(
@@ -488,7 +488,7 @@ impl Printer for CudaPrinter {
     /// Print store val [addr]
     fn print_st(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         val_type: Type,
         mem_flag: InstFlag,
         predicate: Option<&str>,
@@ -496,9 +496,9 @@ impl Printer for CudaPrinter {
         val: &str,
     ) {
         let vector = match vector_factors {
-            [] => "",
-            [2] => ".v2",
-            [4] => ".v4",
+            [1, 1] => "",
+            [1, 2] => ".v2",
+            [1, 4] => ".v4",
             p => panic!("invalid vector pattern: {:?}", p),
         };
         if let Some(predicate) = predicate {
@@ -536,20 +536,21 @@ impl Printer for CudaPrinter {
     }
 
     fn name_operand<'a>(
-        vector_dims: &[&Dimension],
+        vector_levels: &[Vec<Dimension>; 2],
         op: &ir::Operand,
         namer: &'a NameMap,
     ) -> Cow<'a, str> {
-        if vector_dims.is_empty() {
+        assert!(vector_levels[0].is_empty());
+        if vector_levels[1].is_empty() {
             namer.name_op(op)
         } else {
-            let sizes = vector_dims
+            let sizes = vector_levels[1]
                 .iter()
                 .map(|d| unwrap!(d.size().as_int()))
                 .collect_vec();
             let names = NDRange::new(&sizes)
                 .map(|indexes| {
-                    let indexes_map = vector_dims
+                    let indexes_map = vector_levels[1]
                         .iter()
                         .zip_eq(indexes)
                         .map(|(d, idx)| (d.id(), idx))
@@ -561,20 +562,21 @@ impl Printer for CudaPrinter {
     }
 
     fn name_inst<'a>(
-        vector_dims: &[&Dimension],
+        vector_levels: &[Vec<Dimension>; 2],
         inst: ir::InstId,
         namer: &'a NameMap,
     ) -> Cow<'a, str> {
-        if vector_dims.is_empty() {
+        assert!(vector_levels[0].is_empty());
+        if vector_levels[1].is_empty() {
             Cow::Borrowed(namer.name_inst(inst))
         } else {
-            let sizes = vector_dims
+            let sizes = vector_levels[1]
                 .iter()
                 .map(|d| unwrap!(d.size().as_int()))
                 .collect_vec();
             let names = NDRange::new(&sizes)
                 .map(|indexes| {
-                    let indexes_map = vector_dims
+                    let indexes_map = vector_levels[1]
                         .iter()
                         .zip_eq(indexes)
                         .map(|(d, idx)| (d.id(), idx))

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -31,9 +31,10 @@ pub trait Device: Sync {
     fn max_threads(&self) -> u32;
     /// Returns the maximal unrolling factor.
     fn max_unrolling(&self) -> u32;
-    /// Indicates the valid vectorization factors for the given operator, on the given
-    /// dimension.
-    fn vectorization_factors(&self, dim: &ir::Dimension, op: &ir::Operator) -> &[u32];
+    /// Indicates if the operator can be vectorized along the dimension.
+    fn can_vectorize(&self, dim: &ir::Dimension, op: &ir::Operator) -> bool;
+    /// Indicates the maximal vectorization factor for the given operator.
+    fn max_vectorization(&self, op: &ir::Operator) -> [u32; 2];
     /// Returns the amount of shared memory available for each thread block.
     fn shared_mem(&self) -> u32;
     /// Indicates if the device supports non-coherent memory accesses.

--- a/src/device/x86/cpu.rs
+++ b/src/device/x86/cpu.rs
@@ -53,8 +53,12 @@ impl device::Device for Cpu {
         512
     }
 
-    fn vectorization_factors(&self, _: &ir::Dimension, _: &ir::Operator) -> &[u32] {
-        &[]
+    fn can_vectorize(&self, _: &ir::Dimension, _: &ir::Operator) -> bool {
+        false
+    }
+
+    fn max_vectorization(&self, _: &ir::Operator) -> [u32; 2] {
+        [1, 1]
     }
 
     fn shared_mem(&self) -> u32 {

--- a/src/device/x86/printer.rs
+++ b/src/device/x86/printer.rs
@@ -121,7 +121,7 @@ impl X86printer {
                         if let Some(name) = name {
                             let old_name = name_map.name_size(incr, Type::I(32));
                             self.print_unary_op(
-                                &[],
+                                [1, 1],
                                 ir::UnaryOp::Cast(level.t()),
                                 Type::I(32),
                                 &name,
@@ -343,7 +343,7 @@ impl Printer for X86printer {
 
     fn print_binop(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         op: ir::BinOp,
         _: Type,
         _: op::Rounding,
@@ -351,7 +351,7 @@ impl Printer for X86printer {
         lhs: &str,
         rhs: &str,
     ) {
-        assert!(vector_factors.is_empty());
+        assert_eq!(vector_factors, [1, 1]);
         let op = match op {
             ir::BinOp::Add => "+",
             ir::BinOp::Sub => "-",
@@ -371,13 +371,13 @@ impl Printer for X86printer {
 
     fn print_unary_op(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         operator: ir::UnaryOp,
         _: Type,
         result: &str,
         operand: &str,
     ) {
-        assert!(vector_factors.is_empty());
+        assert_eq!(vector_factors, [1, 1]);
         unwrap!(write!(self.buffer, "{} = ", result));
         match operator {
             ir::UnaryOp::Mov => (),
@@ -390,7 +390,7 @@ impl Printer for X86printer {
 
     fn print_mul(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         _: Type,
         _: op::Rounding,
         mode: MulMode,
@@ -399,13 +399,13 @@ impl Printer for X86printer {
         op2: &str,
     ) {
         assert_ne!(mode, MulMode::High);
-        assert!(vector_factors.is_empty());
+        assert_eq!(vector_factors, [1, 1]);
         unwrap!(writeln!(self.buffer, "{} = {} * {};", result, op1, op2));
     }
 
     fn print_mad(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         _: Type,
         _: op::Rounding,
         mode: MulMode,
@@ -414,7 +414,7 @@ impl Printer for X86printer {
         mrhs: &str,
         arhs: &str,
     ) {
-        assert!(vector_factors.is_empty());
+        assert_eq!(vector_factors, [1, 1]);
         assert_ne!(mode, MulMode::High);
         unwrap!(writeln!(
             self.buffer,
@@ -425,13 +425,13 @@ impl Printer for X86printer {
 
     fn print_ld(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         return_type: Type,
         _: InstFlag,
         result: &str,
         addr: &str,
     ) {
-        assert!(vector_factors.is_empty());
+        assert_eq!(vector_factors, [1, 1]);
         unwrap!(writeln!(
             self.buffer,
             "{} = *({}*){} ;",
@@ -443,14 +443,14 @@ impl Printer for X86printer {
 
     fn print_st(
         &mut self,
-        vector_factors: &[u32],
+        vector_factors: [u32; 2],
         val_type: Type,
         _: InstFlag,
         predicate: Option<&str>,
         addr: &str,
         val: &str,
     ) {
-        assert!(vector_factors.is_empty());
+        assert_eq!(vector_factors, [1, 1]);
         if let Some(predicate) = predicate {
             unwrap!(write!(self.buffer, "if ({})", predicate));
         }
@@ -480,20 +480,22 @@ impl Printer for X86printer {
     }
 
     fn name_operand<'a>(
-        vector_dims: &[&Dimension],
+        vector_dims: &[Vec<Dimension>; 2],
         op: &ir::Operand,
         namer: &'a NameMap,
     ) -> Cow<'a, str> {
-        assert!(vector_dims.is_empty());
+        assert!(vector_dims[0].is_empty());
+        assert!(vector_dims[1].is_empty());
         namer.name_op(op)
     }
 
     fn name_inst<'a>(
-        vector_dims: &[&Dimension],
+        vector_dims: &[Vec<Dimension>; 2],
         inst: ir::InstId,
         namer: &'a NameMap,
     ) -> Cow<'a, str> {
-        assert!(vector_dims.is_empty());
+        assert!(vector_dims[0].is_empty());
+        assert!(vector_dims[1].is_empty());
         namer.name_inst(inst).into()
     }
 }

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -70,11 +70,11 @@ define enum dim_kind($dim in Dimensions):
     // It doesn't makes sens to unroll outer loops.
     requires forall $other_dim in Dimensions:
       order($other_dim, $dim) is not INNER || dim_kind($other_dim) is VECTOR | UNROLL
-  /// The dimension is implemented by using a vector instruction.
-  value VECTOR:
-    requires "$dim.possible_sizes().is_some()"
+  /// The dimension is mapped to the inner vector dimension.
+  value INNER_VECTOR:
     requires forall $other_dim in Dimensions:
-      order($dim, $other_dim) is not OUTER
+      order($dim, $other_dim) is not OUTER || dim_kind($other_dim) is INNER_VECTOR
+  value OUTER_VECTOR:
   /// The dimension is mapped to a block dimension on the device.
   value BLOCK:
     requires forall $other_dim in Dimensions:
@@ -84,6 +84,11 @@ define enum dim_kind($dim in Dimensions):
   /// The dimension is mapped to a thread dimension on the device.
   value THREAD:
     requires "$dim.possible_sizes().is_some()"
+  /// The dimension is implemented by vectorizing the instruction inside it.
+  alias VECTOR = INNER_VECTOR | OUTER_VECTOR:
+    requires "$dim.possible_sizes().is_some()"
+    requires forall $other_dim in Dimensions:
+      order($dim, $other_dim) is not OUTER || dim_kind($other_dim) is VECTOR
   /// The dimension is parallel.
   alias PARALLEL = BLOCK | THREAD | VECTOR:
   /// The dimension is sequential.
@@ -191,6 +196,22 @@ define half counter unroll_factor($inst in Instructions):
       dim_kind($dim) is UNROLL
 end
 
+/// Limits the inner vectorization factor.
+define half counter inner_vector_factor($inst in Instructions):
+  forall $dim in StaticDims:
+    mul size($dim) when:
+      is_iteration_dim($inst, $dim) is TRUE
+      dim_kind($dim) is INNER_VECTOR
+end
+
+/// Limits the outer vectorization factor.
+define half counter outer_vector_factor($inst in Instructions):
+  forall $dim in StaticDims:
+    mul size($dim) when:
+      is_iteration_dim($inst, $dim) is TRUE
+      dim_kind($dim) is OUTER_VECTOR
+end
+
 /// Limits the number of block dimensions.
 define half counter num_block_dims($inst in Instructions):
   forall $dim in Dimensions:
@@ -201,6 +222,8 @@ end
 
 require forall $inst in Instructions:
   unroll_factor($inst) <= "$fun.device().max_unrolling()"
+  outer_vector_factor($inst) <= "$fun.device().max_vectorization($inst.operator())[0]"
+  inner_vector_factor($inst) <= "$fun.device().max_vectorization($inst.operator())[1]"
   num_block_dims($inst) <= "$fun.device().max_block_dims()"
 
 /// Counts the number on instructions nested in each dimension.
@@ -222,7 +245,7 @@ require forall $dim in StaticDims:
     // If we ever want to merge VECTOR dimensions, we will need to restric this constraint
     // to iteration dimensions.
     dim_kind($dim) is not VECTOR || order($dim, $inst) is not OUTER
-      || size($dim) == "$fun.device().vectorization_factors($dim, $inst.operator())"
+      || "$fun.device().can_vectorize($dim, $inst.operator())"
 
 require forall $dim in Dimensions:
   forall $init in Instructions:


### PR DESCRIPTION
This commit adds two features:
- It exposes two levels of vectorization instead of one (INNER_VECTOR
  and OUTER_VECTOR dimension kinds).
- It allows multiple dimensions to be mapped to the same level. This
  is usefull when we have multiple small dimensions and wants to map
  them to the same big hardware dimension.

It also fixes a test that was using dimensions with no instructions
inside, which is not supported by Telamon.