### PR TITLE
Use the same cache directives for all memory spaces

### DIFF
--- a/examples/matmul.rs
+++ b/examples/matmul.rs
@@ -95,7 +95,7 @@ fn main() {
     // Don't use caches to load `A`.
     builder.action(search_space::Action::InstFlag(
         ld_a.inst(),
-        search_space::InstFlag::MEM_CS,
+        search_space::InstFlag::NO_CACHE,
     ));
     let space = builder.get();
 

--- a/kernels/src/linalg.rs
+++ b/kernels/src/linalg.rs
@@ -154,9 +154,9 @@ where
 
         builder.order(&acc_dim_n, &st_y.inst(), Order::BEFORE);
         // TODO(search_space): explore inst flags
-        builder.action(Action::InstFlag(ld_x.inst(), InstFlag::MEM_CG));
-        builder.action(Action::InstFlag(ld_a.inst(), InstFlag::MEM_CG));
-        builder.action(Action::InstFlag(st_y.inst(), InstFlag::MEM_CS));
+        builder.action(Action::InstFlag(ld_x.inst(), InstFlag::CACHE_GLOBAL));
+        builder.action(Action::InstFlag(ld_a.inst(), InstFlag::CACHE_GLOBAL));
+        builder.action(Action::InstFlag(st_y.inst(), InstFlag::NO_CACHE));
         vec![build_candidate(builder.get(), ctx)]
     }
 
@@ -265,10 +265,10 @@ impl<'a, S: Scalar> Kernel<'a> for Gesummv<'a, S> {
 
         builder.order(&acc_dim_n, &y_a, Order::BEFORE);
         // TODO(search_space): explore inst flags
-        builder.action(Action::InstFlag(ld_x.inst(), InstFlag::MEM_CG));
-        builder.action(Action::InstFlag(ld_a.inst(), InstFlag::MEM_CG));
-        builder.action(Action::InstFlag(ld_b.inst(), InstFlag::MEM_CG));
-        builder.action(Action::InstFlag(st_y.inst(), InstFlag::MEM_CS));
+        builder.action(Action::InstFlag(ld_x.inst(), InstFlag::CACHE_GLOBAL));
+        builder.action(Action::InstFlag(ld_a.inst(), InstFlag::CACHE_GLOBAL));
+        builder.action(Action::InstFlag(ld_b.inst(), InstFlag::CACHE_GLOBAL));
+        builder.action(Action::InstFlag(st_y.inst(), InstFlag::NO_CACHE));
         vec![build_candidate(builder.get(), ctx)]
     }
 
@@ -418,9 +418,9 @@ impl<'a, S: Scalar> Kernel<'a> for MatMul<'a, S> {
         // Order for correctness.
         builder.order(&st_c.inst(), &acc_dim_k, Order::AFTER);
         // Arbitrary constrains to reduce the search space
-        //builder.action(Action::InstFlag(ld_a.inst(), InstFlag::MEM_CG | InstFlag::MEM_NC));
-        //builder.action(Action::InstFlag(ld_b.inst(), InstFlag::MEM_CG | InstFlag::MEM_NC));
-        //builder.action(Action::InstFlag(st_c.inst(), InstFlag::MEM_CS));
+        //builder.action(Action::InstFlag(ld_a.inst(), InstFlag::CACHE_GLOBAL));
+        //builder.action(Action::InstFlag(ld_b.inst(), InstFlag::CACHE_GLOBAL));
+        //builder.action(Action::InstFlag(st_c.inst(), InstFlag::NO_CACHE));
 
         //builder.action(Action::DimKind(init_dim_n[0], DimKind::BLOCK));
         //builder.action(Action::DimKind(init_dim_m[0], DimKind::BLOCK));

--- a/src/device/cuda/characterize/gen.rs
+++ b/src/device/cuda/characterize/gen.rs
@@ -94,7 +94,7 @@ pub fn loop_chained_adds<'a>(
     builder.close_dim(&d0);
     builder.close_dim(&d1);
     let pattern = builder.unknown_access_pattern(out_id);
-    builder.st_ex(&out, &acc, true, pattern, InstFlag::MEM_CG);
+    builder.st_ex(&out, &acc, true, pattern, InstFlag::CACHE_GLOBAL);
     builder.get()
 }
 
@@ -133,7 +133,7 @@ where
     builder.close_dim(&d0);
     builder.close_dim(&d1);
     let pattern = builder.unknown_access_pattern(ir::MemId::External(0));
-    builder.st_ex(&out, &acc, true, pattern, InstFlag::MEM_CS);
+    builder.st_ex(&out, &acc, true, pattern, InstFlag::NO_CACHE);
     builder.get()
 }
 
@@ -159,12 +159,12 @@ pub fn init_stride_array<'a>(
     };
     let next_addr = builder.mad(&byte_stride, &1i32, &addr);
     let pattern0 = builder.unknown_access_pattern(mem_id);
-    builder.st_ex(&addr, &next_addr, true, pattern0, InstFlag::MEM_CG);
+    builder.st_ex(&addr, &next_addr, true, pattern0, InstFlag::CACHE_GLOBAL);
     dim.as_ref().map(|dim| builder.close_dim(dim));
     let last_addr = builder.mad(&byte_stride, &(n as i32 - 1), &array);
 
     let pattern1 = builder.unknown_access_pattern(mem_id);
-    builder.st_ex(&last_addr, &array, true, pattern1, InstFlag::MEM_CG);
+    builder.st_ex(&last_addr, &array, true, pattern1, InstFlag::CACHE_GLOBAL);
     dim.as_ref()
         .map(|dim| builder.order(dim, &last_addr, Order::BEFORE));
     builder.get()
@@ -194,12 +194,17 @@ pub fn load_chain<'a>(
         builder.order(&d, &d0, Order::OUTER);
     }
     let pattern0 = builder.unknown_access_pattern(mem_id);
-    let ptr = builder.ld_ex(ir::Type::I(64), &Reduce(init), pattern0, InstFlag::MEM_CG);
+    let ptr = builder.ld_ex(
+        ir::Type::I(64),
+        &Reduce(init),
+        pattern0,
+        InstFlag::CACHE_GLOBAL,
+    );
     builder.order(&d0, &d1, Order::OUTER);
     builder.close_dim(&d0);
     builder.close_dim(&d1);
     let pattern1 = builder.unknown_access_pattern(out_id);
-    builder.st_ex(&out, &ptr, true, pattern1, InstFlag::MEM_CS);
+    builder.st_ex(&out, &ptr, true, pattern1, InstFlag::NO_CACHE);
     builder.get()
 }
 
@@ -236,7 +241,7 @@ pub fn shared_load_chain<'a>(
     builder.close_dim(&d0);
     builder.close_dim(&d1);
     let pattern3 = builder.unknown_access_pattern(out_id);
-    builder.st_ex(&out, &addr, true, pattern3, InstFlag::MEM_CG);
+    builder.st_ex(&out, &addr, true, pattern3, InstFlag::CACHE_GLOBAL);
 
     builder.order(&last_st, &addr_init, Order::BEFORE);
     builder.order(&d0, &d1, Order::OUTER);
@@ -295,7 +300,7 @@ pub fn parallel_load<'a>(
         strides.push((d1_1_a, ir::Size::new_const(wrap_stride)));
     }
     let addr = builder.induction_var(&array, strides);
-    let val = builder.ld_ex(ir::Type::F(32), &addr, pattern, InstFlag::MEM_CG);
+    let val = builder.ld_ex(ir::Type::F(32), &addr, pattern, InstFlag::CACHE_GLOBAL);
     let d4_1 = builder.open_mapped_dim(&d4_0);
     let acc = builder.add(&val, &Reduce(init));
     builder.close_dim(&d0);
@@ -308,7 +313,7 @@ pub fn parallel_load<'a>(
     let d1_2_b = builder.open_mapped_dim(&d1_1_b);
     builder.order(&d1_2_a, &d1_2_b, Order::OUTER);
     let out_pattern = builder.unknown_access_pattern(out_id);
-    builder.st_ex(&out, &acc, true, out_pattern, InstFlag::MEM_CS);
+    builder.st_ex(&out, &acc, true, out_pattern, InstFlag::NO_CACHE);
 
     builder.order(&d1_0_a, &d0, Order::BEFORE);
     builder.order(&d1_0_b, &d0, Order::BEFORE);
@@ -365,7 +370,7 @@ pub fn parallel_store<'a>(
         strides.push((d1_0, ir::Size::new_const(wrap_stride)));
     }
     let addr = builder.induction_var(&array, strides);
-    builder.st_ex(&addr, &42f32, true, pattern, InstFlag::MEM_CG);
+    builder.st_ex(&addr, &42f32, true, pattern, InstFlag::CACHE_GLOBAL);
 
     builder.order(&d0, &d1_0, Order::OUTER);
     builder.order(&d0, &d1_1, Order::OUTER);
@@ -437,7 +442,7 @@ pub fn chain_in_syncthread<'a>(
 
     let d5 = builder.open_mapped_dim(&d0);
     let pattern = builder.unknown_access_pattern(out_id);
-    builder.st_ex(&out, &acc, true, pattern, InstFlag::MEM_CG);
+    builder.st_ex(&out, &acc, true, pattern, InstFlag::CACHE_GLOBAL);
 
     builder.order(&d1, &d2, Order::OUTER);
     builder.order(&d1, &d3, Order::OUTER);
@@ -485,7 +490,7 @@ pub fn load_in_loop<'a>(
         ir::Type::F(32),
         &[&thread_dim_1_0, &unroll_dim_a],
     );
-    let a_val = builder.ld_ex(ir::Type::F(32), &addr, pattern, InstFlag::MEM_CG);
+    let a_val = builder.ld_ex(ir::Type::F(32), &addr, pattern, InstFlag::CACHE_GLOBAL);
     builder.close_dim(&unroll_dim_a);
     // Mad a and b
     let unroll_dims_1 = builder.open_mapped_dim(&unroll_dim_0_0);
@@ -499,7 +504,7 @@ pub fn load_in_loop<'a>(
 
     let _ = builder.open_mapped_dim(&unroll_dims_1);
     let (addr, pattern) = builder.tensor_access(&out, out_id, ir::Type::F(32), &[]);
-    let _ = builder.st_ex(&addr, &acc, true, pattern, InstFlag::MEM_CS);
+    let _ = builder.st_ex(&addr, &acc, true, pattern, InstFlag::NO_CACHE);
 
     builder.order(&k_dim, &thread_dim_1_0, Order::INNER);
     builder.order(&unroll_dim_a, &unroll_dims_1[0], Order::BEFORE);

--- a/src/device/cuda/gpu.rs
+++ b/src/device/cuda/gpu.rs
@@ -229,36 +229,25 @@ impl Gpu {
     /// Returns the description of a load instruction.
     fn load_desc(&self, mem_info: &MemInfo, flags: InstFlag) -> InstDesc {
         // TODO(search_space,model): support CA and NC flags.
-        assert!(InstFlag::MEM_COHERENT.contains(flags));
+        assert!(InstFlag::COHERENT.contains(flags));
         // Compute possible latencies.
-        let gbl_latency = if flags.intersects(InstFlag::MEM_GLOBAL) {
+        let gbl_latency = if mem_info.access_global {
             let miss = mem_info.l2_miss_ratio / mem_info.l2_coalescing;
             miss * self.load_ram_latency + (1.0 - miss) * self.load_l2_latency
         } else {
             std::f64::INFINITY
         };
-        let shared_latency = if flags.intersects(InstFlag::MEM_SHARED) {
+        let shared_latency = if mem_info.access_shared {
             self.load_shared_latency as f64
         } else {
             std::f64::INFINITY
-        };
-        // Compute the smx bandwidth used.
-        let l1_lines_from_l2 = if flags.intersects(InstFlag::MEM_SHARED) {
-            0.0
-        } else {
-            mem_info.l1_coalescing
-        };
-        let l2_lines_read = if flags.intersects(InstFlag::MEM_SHARED) {
-            0.0
-        } else {
-            mem_info.l2_coalescing
         };
         InstDesc {
             latency: f64::min(gbl_latency, shared_latency),
             issue: mem_info.replay_factor,
             mem: mem_info.replay_factor,
-            l1_lines_from_l2,
-            l2_lines_read,
+            l1_lines_from_l2: mem_info.l1_coalescing,
+            l2_lines_read: mem_info.l2_coalescing,
             ram_bw: mem_info.l2_miss_ratio * f64::from(self.l2_cache_line),
             ..InstDesc::default()
         }
@@ -268,17 +257,12 @@ impl Gpu {
     fn store_desc(&self, mem_info: &MemInfo, flags: InstFlag) -> InstDesc {
         // TODO(search_space,model): support CA flags.
         // TODO(model): understand how writes use the BW.
-        assert!(InstFlag::MEM_COHERENT.contains(flags));
-        let l2_lines_stored = if flags.intersects(InstFlag::MEM_SHARED) {
-            0.0
-        } else {
-            mem_info.l2_coalescing
-        };
+        assert!(InstFlag::COHERENT.contains(flags));
         // L1 lines per L2 is not limiting.
         InstDesc {
             issue: mem_info.replay_factor,
             mem: mem_info.replay_factor,
-            l2_lines_stored,
+            l2_lines_stored: mem_info.l2_coalescing,
             ram_bw: 2.0 * mem_info.l2_miss_ratio * f64::from(self.l2_cache_line),
             ..InstDesc::default()
         }

--- a/src/device/cuda/printer.rs
+++ b/src/device/cuda/printer.rs
@@ -3,7 +3,7 @@ use codegen::*;
 use device::cuda::{Gpu, Namer};
 use ir::{self, op, Type};
 use itertools::Itertools;
-use search_space::{DimKind, Domain, InstFlag};
+use search_space::{DimKind, Domain, InstFlag, MemSpace};
 use std;
 use std::borrow::Cow;
 use std::fmt::Write as WriteFmt;
@@ -39,25 +39,31 @@ impl CudaPrinter {
     }
 
     /// Prints a load operator.
-    fn ld_operator(flag: InstFlag) -> &'static str {
-        match flag {
-            InstFlag::MEM_SHARED => "ld.shared",
-            InstFlag::MEM_CA => "ld.global.ca",
-            InstFlag::MEM_CG => "ld.global.cg",
-            InstFlag::MEM_CS => "ld.global.cs",
-            InstFlag::MEM_NC => "ld.global.nc",
-            _ => panic!("invalid load flag {:?}", flag),
+    fn ld_operator(space: MemSpace, flag: InstFlag) -> &'static str {
+        if space == MemSpace::SHARED {
+            "ld.shared"
+        } else {
+            match flag {
+                InstFlag::CACHE_SHARED => "ld.global.ca",
+                InstFlag::CACHE_GLOBAL => "ld.global.cg",
+                InstFlag::CACHE_READ_ONLY => "ld.global.nc",
+                InstFlag::NO_CACHE => "ld.global.cs",
+                _ => panic!("invalid load flag {:?}", flag),
+            }
         }
     }
 
     /// Prints a store operator.
-    fn st_operator(flag: InstFlag) -> &'static str {
-        match flag {
-            InstFlag::MEM_SHARED => "st.shared",
-            InstFlag::MEM_CA => "st.global.wb",
-            InstFlag::MEM_CG => "st.global.cg",
-            InstFlag::MEM_CS => "st.global.cs",
-            _ => panic!("invalid store flag {:?}", flag),
+    fn st_operator(space: MemSpace, flag: InstFlag) -> &'static str {
+        if space == MemSpace::SHARED {
+            "st.shared"
+        } else {
+            match flag {
+                InstFlag::CACHE_SHARED => "st.global.wb",
+                InstFlag::CACHE_GLOBAL => "st.global.cg",
+                InstFlag::NO_CACHE => "st.global.cs",
+                _ => panic!("invalid store flag {:?}", flag),
+            }
         }
     }
 
@@ -463,11 +469,12 @@ impl Printer for CudaPrinter {
         &mut self,
         vector_factors: &[u32],
         return_type: Type,
+        mem_space: MemSpace,
         flag: InstFlag,
         result: &str,
         addr: &str,
     ) {
-        let operator = Self::ld_operator(flag);
+        let operator = Self::ld_operator(mem_space, flag);
         let vector = match vector_factors {
             [] => "",
             [2] => ".v2",
@@ -490,6 +497,7 @@ impl Printer for CudaPrinter {
         &mut self,
         vector_factors: &[u32],
         val_type: Type,
+        mem_space: MemSpace,
         mem_flag: InstFlag,
         predicate: Option<&str>,
         addr: &str,
@@ -504,7 +512,7 @@ impl Printer for CudaPrinter {
         if let Some(predicate) = predicate {
             unwrap!(write!(self.buffer, "@{} ", predicate));
         }
-        let operator = Self::st_operator(mem_flag);
+        let operator = Self::st_operator(mem_space, mem_flag);
         unwrap!(writeln!(
             self.buffer,
             "{}{}.{} [{}], {};",

--- a/src/device/x86/printer.rs
+++ b/src/device/x86/printer.rs
@@ -2,7 +2,7 @@ use codegen::*;
 use device::x86::Namer;
 use ir::{self, op, Type};
 use itertools::Itertools;
-use search_space::{DimKind, Domain, InstFlag};
+use search_space::{DimKind, Domain, InstFlag, MemSpace};
 use std::borrow::Cow;
 use std::fmt::Write as WriteFmt;
 // TODO(cc_perf): avoid concatenating strings.
@@ -427,6 +427,7 @@ impl Printer for X86printer {
         &mut self,
         vector_factors: &[u32],
         return_type: Type,
+        _: MemSpace,
         _: InstFlag,
         result: &str,
         addr: &str,
@@ -445,6 +446,7 @@ impl Printer for X86printer {
         &mut self,
         vector_factors: &[u32],
         val_type: Type,
+        _: MemSpace,
         _: InstFlag,
         predicate: Option<&str>,
         addr: &str,

--- a/src/helper/builder.rs
+++ b/src/helper/builder.rs
@@ -138,7 +138,7 @@ impl<'a> Builder<'a> {
         addr: &AutoOperand<'b>,
         pattern: AccessPattern<'a>,
     ) -> InstId {
-        self.ld_ex(ret_type, addr, pattern, InstFlag::MEM_COHERENT)
+        self.ld_ex(ret_type, addr, pattern, InstFlag::COHERENT)
     }
 
     /// Adds a non-coherent load from global memory instruction to the function.

--- a/src/helper/tensor.rs
+++ b/src/helper/tensor.rs
@@ -205,7 +205,7 @@ where
         let flag = if self.read_only {
             InstFlag::ALL
         } else {
-            InstFlag::MEM_COHERENT
+            InstFlag::COHERENT
         };
         let inst = builder.ld_ex(S::t(), &ptr, pattern, flag);
         for dim in &dims {

--- a/src/model/cuda_tests.rs
+++ b/src/model/cuda_tests.rs
@@ -182,9 +182,9 @@ fn partial_bound_2() {
     builder.order(&ld_a[0][1], &ld_x.inst(), Order::BEFORE);
     builder.order(&acc_dim_m[1], &ld_x.inst(), Order::AFTER);
 
-    builder.action(Action::InstFlag(ld_x.inst(), InstFlag::MEM_CG));
-    builder.action(Action::InstFlag(ld_a.inst(), InstFlag::MEM_CG));
-    builder.action(Action::InstFlag(st_y.inst(), InstFlag::MEM_CS));
+    builder.action(Action::InstFlag(ld_x.inst(), InstFlag::CACHE_GLOBAL));
+    builder.action(Action::InstFlag(ld_a.inst(), InstFlag::CACHE_GLOBAL));
+    builder.action(Action::InstFlag(st_y.inst(), InstFlag::NO_CACHE));
 
     let partial_bound = model::bound(&builder.get_clone(), &context);
     builder.action(Action::DimKind(ld_a[0][0], DimKind::BLOCK));
@@ -302,7 +302,7 @@ fn partial_bound_4() {
     builder.action(Action::DimKind(ld_a[1][0], DimKind::THREAD));
     builder.action(Action::DimKind(ld_a[2][0], DimKind::LOOP));
 
-    builder.action(Action::InstFlag(ld_a.inst(), InstFlag::MEM_CS));
+    builder.action(Action::InstFlag(ld_a.inst(), InstFlag::NO_CACHE));
 
     let partial_pressure = {
         let space = builder.get_clone();
@@ -445,9 +445,9 @@ fn final_bound_0() {
     builder.order(&ld_x[0][1], &ld_y.inst(), Order::BEFORE);
     builder.order(&ld_y[0][1], &mad.inst(), Order::BEFORE);
     builder.order(&mad_dim[1], &st_z.inst(), Order::OUTER);
-    builder.action(Action::InstFlag(ld_x.inst(), InstFlag::MEM_CS));
-    builder.action(Action::InstFlag(ld_y.inst(), InstFlag::MEM_CG));
-    builder.action(Action::InstFlag(st_z.inst(), InstFlag::MEM_CG));
+    builder.action(Action::InstFlag(ld_x.inst(), InstFlag::NO_CACHE));
+    builder.action(Action::InstFlag(ld_y.inst(), InstFlag::CACHE_GLOBAL));
+    builder.action(Action::InstFlag(st_z.inst(), InstFlag::CACHE_GLOBAL));
     let space = builder.get();
     let bound = model::bound(&space, &context);
     let kernel = codegen::Function::build(&space);

--- a/src/search_space/dim_map.rs
+++ b/src/search_space/dim_map.rs
@@ -3,7 +3,7 @@ use ir;
 use itertools::Itertools;
 use search_space::choices::dim_kind;
 use search_space::operand;
-use search_space::{Action, DimKind, DomainStore, InstFlag, Order};
+use search_space::{Action, DimKind, DomainStore, MemSpace, Order};
 
 /// Lowers a layout
 pub fn lower_layout(
@@ -52,13 +52,12 @@ fn lower_dim_map(
         ));
     }
     // FIXME: allow global memory
-    actions.push(Action::InstFlag(
-        lowered_dim_map.store,
-        InstFlag::MEM_SHARED,
+    actions.push(Action::MemSpace(
+        lowered_dim_map.mem.into(),
+        MemSpace::SHARED,
     ));
-    actions.push(Action::InstFlag(lowered_dim_map.load, InstFlag::MEM_SHARED));
-    //actions.push(Action::InstFlag(st, InstFlag::MEM_COHERENT));
-    //actions.push(Action::InstFlag(ld, InstFlag::MEM_COHERENT));
+    //actions.push(Action::InstFlag(st, InstFlag::COHERENT));
+    //actions.push(Action::InstFlag(ld, InstFlag::COHERENT));
     let store = lowered_dim_map.store;
     actions.push(Action::Order(
         store.into(),

--- a/src/search_space/instructions.exh
+++ b/src/search_space/instructions.exh
@@ -22,27 +22,22 @@ end
 
 /// Specifies the version of an instruction to use.
 define enum inst_flag($inst in MemInsts):
-  /// Access the global memory using both L1 and L2 cache. Coherence is not guaranteed
-  /// between blocks.
-  value MEM_CA:
-    requires "$fun.device().supports_l1_access()"
-  /// Access the global memory using the L2 cache.
-  value MEM_CG:
+  /// Don't use caches.
+  value NO_CACHE:
+  /// Use a global cache, coherent between all threads.
+  value CACHE_GLOBAL:
     requires "$fun.device().supports_l2_access()"
-  /// Access the global memory without using caches.
-  value MEM_CS:
-  /// Access the global memory using the read-only cache. Coherence is not guaranteed.
-  value MEM_NC:
+  /// Use a cache only coherent between threads of the same block.
+  value CACHE_SHARED:
+    requires "$fun.device().supports_l1_access()"
+  /// Use a read-only cache, not guaranteed to see any read.
+  value CACHE_READ_ONLY:
     requires "$inst.operator().supports_nc_access()"
     requires "$fun.device().supports_nc_access()"
-  /// Access the shared memory.
-  value MEM_SHARED:
-  /// Access the global memory.
-  alias MEM_GLOBAL = MEM_CA | MEM_CG | MEM_CS | MEM_NC:
   /// Ensure coherency between memory accesses.
-  alias MEM_COHERENT = MEM_SHARED | MEM_CG | MEM_CS:
+  alias COHERENT = NO_CACHE | CACHE_GLOBAL:
   /// Ensure coherency within a block between memory accesses.
-  alias MEM_BLOCK_COHERENT = MEM_COHERENT | MEM_CA:
+  alias BLOCK_COHERENT = COHERENT | CACHE_SHARED:
 end
 
 // Intruction orders

--- a/src/search_space/variable.exh
+++ b/src/search_space/variable.exh
@@ -63,15 +63,12 @@ end
 define enum mem_space($mem in MemoryRegions):
   /// The block is in the device RAM.
   value GLOBAL:
-    requires forall $inst in MemInsts:
-      "unwrap!($inst.operator().mem_used()) != $mem.mem_id()"
-        || inst_flag($inst) is MEM_GLOBAL
   /// The block is in the memory shared between the threads of a block.
   value SHARED:
     requires "$mem.as_internal().is_some()"
     requires forall $inst in MemInsts:
       "unwrap!($inst.operator().mem_used()) != $mem.mem_id()"
-        || inst_flag($inst) is MEM_SHARED
+        || inst_flag($inst) is NO_CACHE
 end
 
 /// Computes the size of each memory block.

--- a/tests/cuda.rs
+++ b/tests/cuda.rs
@@ -87,8 +87,13 @@ fn cache_directive() {
     };
     let mut builder = helper::Builder::new(&signature, context.device());
     let pattern = builder.unknown_access_pattern(mem_id);
-    builder.ld_ex(ir::Type::F(32), &"a", pattern.clone(), InstFlag::MEM_CG);
-    builder.st_ex(&"a", &0i32, true, pattern, InstFlag::MEM_CG);
+    builder.ld_ex(
+        ir::Type::F(32),
+        &"a",
+        pattern.clone(),
+        InstFlag::CACHE_GLOBAL,
+    );
+    builder.st_ex(&"a", &0i32, true, pattern, InstFlag::CACHE_GLOBAL);
     gen_best(&context, builder.get());
 }
 
@@ -225,11 +230,11 @@ fn global_vector_load() {
     let d0 = builder.open_dim_ex(d0_size, DimKind::VECTOR);
     let (addr, input_pattern) =
         builder.tensor_access(&"input", input.0, DATA_TYPE, &[&d0]);
-    let ld = builder.ld_ex(DATA_TYPE, &addr, input_pattern, InstFlag::MEM_CS);
+    let ld = builder.ld_ex(DATA_TYPE, &addr, input_pattern, InstFlag::NO_CACHE);
     builder.close_dim(&d0);
     // Store B in shared memory.
     let output_pattern = builder.unknown_access_pattern(output.0);
-    builder.st_ex(&"output", &ld, true, output_pattern, InstFlag::MEM_CS);
+    builder.st_ex(&"output", &ld, true, output_pattern, InstFlag::NO_CACHE);
 
     check_candidates(builder.get(), &context, || {
         let res = read_array::<i32>(output.1.as_ref())[0];

--- a/tools/bench_perf_model/latency.rs
+++ b/tools/bench_perf_model/latency.rs
@@ -92,7 +92,7 @@ impl PerfModelTest for InstChain {
         let i2 = builder.mul(&"x", &i1);
         builder.close_dim(&d0);
         let pattern = builder.unknown_access_pattern(ir::MemId::External(0));
-        builder.st_ex(&"out", &i2, true, pattern, InstFlag::MEM_CS);
+        builder.st_ex(&"out", &i2, true, pattern, InstFlag::NO_CACHE);
         InstChain
     }
 }
@@ -124,7 +124,7 @@ impl PerfModelTest for LongInstChain {
         }
         builder.close_dim(&d0);
         let pattern = builder.unknown_access_pattern(ir::MemId::External(0));
-        builder.st_ex(&"out", &inst, true, pattern, InstFlag::MEM_CS);
+        builder.st_ex(&"out", &inst, true, pattern, InstFlag::NO_CACHE);
         LongInstChain
     }
 }
@@ -160,7 +160,7 @@ impl PerfModelTest for UnrollReduction {
         builder.close_dim(&d0);
         builder.close_dim(&d1);
         let pattern = builder.unknown_access_pattern(ir::MemId::External(0));
-        builder.st_ex(&"out", &inst, true, pattern, InstFlag::MEM_CS);
+        builder.st_ex(&"out", &inst, true, pattern, InstFlag::NO_CACHE);
         UnrollReduction {
             d0: d0[0],
             d1: d1[0],
@@ -236,7 +236,8 @@ impl PerfModelTest for OrderedThreadDims {
         builder.open_dim_ex(size_n, DimKind::LOOP);
         let d1 = builder.open_dim_ex(size_0.clone(), DimKind::THREAD);
         let pattern = builder.unknown_access_pattern(ir::MemId::External(0));
-        let init = builder.ld_ex(ir::Type::I(32), &"out", pattern, InstFlag::MEM_CG);
+        let init =
+            builder.ld_ex(ir::Type::I(32), &"out", pattern, InstFlag::CACHE_GLOBAL);
         let d1_1 = builder.open_dim_ex(size_1.clone(), DimKind::LOOP);
         let d1_2 = builder.open_dim_ex(size_2.clone(), DimKind::UNROLL);
         let inst = builder.mul(&"x", &Reduce(init));
@@ -248,7 +249,7 @@ impl PerfModelTest for OrderedThreadDims {
         let d2_1 = builder.open_dim_ex(size_1.clone(), DimKind::LOOP);
         let d2_2 = builder.open_dim_ex(size_2.clone(), DimKind::UNROLL);
         let pattern = builder.unknown_access_pattern(ir::MemId::External(0));
-        builder.st_ex(&"out", &inst, true, pattern, InstFlag::MEM_CG);
+        builder.st_ex(&"out", &inst, true, pattern, InstFlag::CACHE_GLOBAL);
 
         builder.order(&d1, &d1_1, Order::OUTER);
         builder.order(&d1_1, &d1_2, Order::OUTER);
@@ -293,7 +294,7 @@ impl PerfModelTest for DimMap {
         builder.close_dim(&d2);
         builder.close_dim(&d0);
         let pattern = builder.unknown_access_pattern(ir::MemId::External(0));
-        builder.st_ex(&"out", &i2, true, pattern, InstFlag::MEM_CS);
+        builder.st_ex(&"out", &i2, true, pattern, InstFlag::NO_CACHE);
         builder.order(&d1, &d2, Order::BEFORE);
         DimMap
     }
@@ -327,7 +328,7 @@ impl PerfModelTest for OperandPositionSlow {
         builder.close_dim(&d0);
         builder.close_dim(&d1);
         let pattern = builder.unknown_access_pattern(ir::MemId::External(0));
-        builder.st_ex(&"out", &inst, true, pattern, InstFlag::MEM_CS);
+        builder.st_ex(&"out", &inst, true, pattern, InstFlag::NO_CACHE);
         builder.order(&d0, &d1, Order::OUTER);
         OperandPositionSlow
     }
@@ -361,7 +362,7 @@ impl PerfModelTest for OperandPositionFast {
         builder.close_dim(&d0);
         builder.close_dim(&d1);
         let pattern = builder.unknown_access_pattern(ir::MemId::External(0));
-        builder.st_ex(&"out", &inst, true, pattern, InstFlag::MEM_CS);
+        builder.st_ex(&"out", &inst, true, pattern, InstFlag::NO_CACHE);
         builder.order(&d0, &d1, Order::OUTER);
         OperandPositionFast
     }

--- a/tools/bench_perf_model/memory.rs
+++ b/tools/bench_perf_model/memory.rs
@@ -47,7 +47,7 @@ impl PerfModelTest for L1LinesPressure {
         let mem0 = ir::MemId::External(0);
         let pattern = builder.tensor_access_pattern(mem0, strides.clone());
         let addr = builder.induction_var(&"array", strides);
-        let val = builder.ld_ex(t, &addr, pattern, InstFlag::MEM_CG);
+        let val = builder.ld_ex(t, &addr, pattern, InstFlag::CACHE_GLOBAL);
         let acc = builder.add(&val, &Reduce(init));
         builder.close_dim(&d0);
         builder.close_dim(&d3);
@@ -55,7 +55,7 @@ impl PerfModelTest for L1LinesPressure {
         let d1_2 = builder.open_mapped_dim(&d1_1)[0];
         let d2_2 = builder.open_mapped_dim(&d2_1)[0];
         let out_pattern = builder.unknown_access_pattern(ir::MemId::External(1));
-        builder.st_ex(&"out", &acc, true, out_pattern, InstFlag::MEM_CS);
+        builder.st_ex(&"out", &acc, true, out_pattern, InstFlag::NO_CACHE);
 
         builder.order(&d1_0, &d2_0, Order::OUTER);
         builder.order(&d1_0, &d0, Order::BEFORE);
@@ -109,7 +109,7 @@ impl PerfModelTest for L2LinesPressure {
         let mem0 = ir::MemId::External(0);
         let pattern = builder.tensor_access_pattern(mem0, strides.clone());
         let addr = builder.induction_var(&"array", strides);
-        let val = builder.ld_ex(t, &addr, pattern, InstFlag::MEM_CG);
+        let val = builder.ld_ex(t, &addr, pattern, InstFlag::CACHE_GLOBAL);
         let acc = builder.add(&val, &Reduce(init));
         builder.close_dim(&d0);
         builder.close_dim(&d3);
@@ -117,7 +117,7 @@ impl PerfModelTest for L2LinesPressure {
         let d1_2 = builder.open_mapped_dim(&d1_1)[0];
         let d2_2 = builder.open_mapped_dim(&d2_1)[0];
         let out_pattern = builder.unknown_access_pattern(ir::MemId::External(1));
-        builder.st_ex(&"out", &acc, true, out_pattern, InstFlag::MEM_CS);
+        builder.st_ex(&"out", &acc, true, out_pattern, InstFlag::NO_CACHE);
 
         builder.order(&d1_0, &d2_0, Order::OUTER);
         builder.order(&d1_0, &d0, Order::BEFORE);
@@ -173,7 +173,7 @@ impl PerfModelTest for SharedLoad {
         builder.close_dim(&d2);
         builder.close_dim(&d3);
         let out_pattern = builder.unknown_access_pattern(ir::MemId::External(0));
-        builder.st_ex(&"out", &acc, true, out_pattern, InstFlag::MEM_CS);
+        builder.st_ex(&"out", &acc, true, out_pattern, InstFlag::NO_CACHE);
         SharedLoad {
             d0: d0[0],
             d1: d1[0],
@@ -233,7 +233,7 @@ impl PerfModelTest for VectorSharedLoad {
         builder.close_dim(&d3);
         builder.close_dim(&d4_2);
         let out_pattern = builder.unknown_access_pattern(ir::MemId::External(0));
-        builder.st_ex(&"out", &acc, true, out_pattern, InstFlag::MEM_CS);
+        builder.st_ex(&"out", &acc, true, out_pattern, InstFlag::NO_CACHE);
 
         VectorSharedLoad {
             d0: d0[0],
@@ -294,7 +294,7 @@ impl PerfModelTest for SharedReplay {
         builder.close_dim(&d3_1);
         let out_pattern = builder.unknown_access_pattern(ir::MemId::External(0));
 
-        builder.st_ex(&"out", &acc, true, out_pattern, InstFlag::MEM_CS);
+        builder.st_ex(&"out", &acc, true, out_pattern, InstFlag::NO_CACHE);
         builder.order(&d0, &d1, Order::OUTER);
         builder.order(&d1, &d2, Order::OUTER);
         builder.order(&d4, &d3_0, Order::OUTER);
@@ -354,7 +354,7 @@ impl PerfModelTest for VectorSharedReplay {
         builder.close_dim(&d3_1);
         let out_pattern = builder.unknown_access_pattern(ir::MemId::External(0));
 
-        builder.st_ex(&"out", &acc, true, out_pattern, InstFlag::MEM_CS);
+        builder.st_ex(&"out", &acc, true, out_pattern, InstFlag::NO_CACHE);
         builder.order(&d0, &d1, Order::OUTER);
         builder.order(&d1, &d2, Order::OUTER);
         builder.order(&d4, &d3_0, Order::OUTER);

--- a/tools/bench_perf_model/tests.rs
+++ b/tools/bench_perf_model/tests.rs
@@ -59,7 +59,8 @@ impl PerfModelTest for Test0 {
             ir::Type::F(32),
             &[&b1, &thread_dim_1, &a_ld_unroll_dim, &k0_dim, &thread_dim_0],
         );
-        let a_ld = builder.ld_ex(ir::Type::F(32), &a_addr, a_pattern, InstFlag::MEM_CG);
+        let a_ld =
+            builder.ld_ex(ir::Type::F(32), &a_addr, a_pattern, InstFlag::CACHE_GLOBAL);
         builder.close_dim(&a_ld_unroll_dim);
         // Load B from global memory
         let b_ld_unroll_dim = builder.open_dim_ex(tile_2_size.clone(), DimKind::VECTOR);
@@ -69,7 +70,8 @@ impl PerfModelTest for Test0 {
             ir::Type::F(32),
             &[&k0_dim, &thread_dim_1, &b0, &thread_dim_0, &b_ld_unroll_dim],
         );
-        let b_ld = builder.ld_ex(ir::Type::F(32), &b_addr, b_pattern, InstFlag::MEM_CG);
+        let b_ld =
+            builder.ld_ex(ir::Type::F(32), &b_addr, b_pattern, InstFlag::CACHE_GLOBAL);
         builder.close_dim(&b_ld_unroll_dim);
         // Store A in shared memory.
         let a_st_tmp_unroll_dim = builder.open_mapped_dim(&a_ld_unroll_dim);
@@ -146,7 +148,8 @@ impl PerfModelTest for Test1 {
             ir::Type::F(32),
             &[&thread_dim_1_0, &unroll_dim_a],
         );
-        let a_val = builder.ld_ex(ir::Type::F(32), &addr, pattern, InstFlag::MEM_CG);
+        let a_val =
+            builder.ld_ex(ir::Type::F(32), &addr, pattern, InstFlag::CACHE_GLOBAL);
         builder.close_dim(&unroll_dim_a);
         // Mad a and b
         let unroll_dims_1 = builder.open_mapped_dim(&unroll_dim_0_0);
@@ -160,7 +163,7 @@ impl PerfModelTest for Test1 {
 
         let _ = builder.open_mapped_dim(&unroll_dims_1);
         let (addr, pattern) = builder.tensor_access(&"out", out, ir::Type::F(32), &[]);
-        let _ = builder.st_ex(&addr, &acc, true, pattern, InstFlag::MEM_CS);
+        let _ = builder.st_ex(&addr, &acc, true, pattern, InstFlag::NO_CACHE);
 
         builder.order(&k_dim, &thread_dim_1_0, Order::INNER);
         builder.order(&unroll_dim_a, &unroll_dims_1[0], Order::BEFORE);
@@ -230,7 +233,8 @@ impl PerfModelTest for Test2 {
             ir::Type::F(32),
             &[&thread_dims_0_1, &unroll_dim_a],
         );
-        let a_val = builder.ld_ex(ir::Type::F(32), &addr, pattern, InstFlag::MEM_CG);
+        let a_val =
+            builder.ld_ex(ir::Type::F(32), &addr, pattern, InstFlag::CACHE_GLOBAL);
         builder.close_dim(&unroll_dim_a);
         // Load B
         let unroll_dim_b = builder.open_dim_ex(tile_2_size.clone(), DimKind::VECTOR);
@@ -240,7 +244,8 @@ impl PerfModelTest for Test2 {
             ir::Type::F(32),
             &[&thread_dims_1_1, &unroll_dim_b],
         );
-        let b_val = builder.ld_ex(ir::Type::F(32), &addr, pattern, InstFlag::MEM_SHARED);
+        let b_val = builder.ld_ex(ir::Type::F(32), &addr, pattern, InstFlag::NO_CACHE);
+        builder.action(Action::MemSpace(b_tmp_mem, MemSpace::SHARED));
         builder.close_dim(&unroll_dim_b);
         // Mad a and b
         let unroll_dims_0_1 = builder.open_mapped_dim(&unroll_dim_0_0);
@@ -273,7 +278,7 @@ impl PerfModelTest for Test2 {
                 &unroll_dims_1_2,
             ],
         );
-        let _ = builder.st_ex(&addr, &acc, true, pattern, InstFlag::MEM_CS);
+        let _ = builder.st_ex(&addr, &acc, true, pattern, InstFlag::NO_CACHE);
 
         builder.order(&k_dim, &thread_dims_0_1, Order::OUTER);
         builder.order(&thread_dim_0_0, &thread_dim_1_0, Order::OUTER);


### PR DESCRIPTION
This commit changes the cache directives (InstFlag) so all the memory
spaces use the same directives. This should make it simpler to add
memory spaces. It requires changes to pass the memory space where it
could previously be infered from the memory flags.