### PR TITLE
Enforce that all code must typecheck with Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ before_script:
 jobs:
   include:
     - stage: test
-      script: cargo test
+      script: cargo check --all --all-targets --tests --benches
+    - script: cargo test
     - script: cd telamon-utils && cargo test
     - script: cd telamon-gen && cargo test
     - script: cd telamon-gen/cc_tests && cargo test

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -43,16 +43,16 @@ impl MMSig {
         let n_size = builder.param_size("n", 32);
         let k_size = builder.param_size("k", 32);
 
-        let ld_a_m = builder.open_tiled_dim(m_size, &[16, 4]);
-        let ld_a_k = builder.open_tiled_dim(k_size.clone(), &[16]);
+        let ld_a_m = builder.open_tiled_dim(m_size, [16, 4][..].into());
+        let ld_a_k = builder.open_tiled_dim(k_size.clone(), [16][..].into());
         let (ptr, pattern) =
             builder.tensor_access(&"a", self.a, DATA_TYPE, &[&ld_a_m, &ld_a_k]);
         let ld_a = builder.ld_nc(DATA_TYPE.clone(), &ptr, pattern);
         builder.close_dim(&ld_a_m);
         builder.close_dim(&ld_a_k);
 
-        let ld_b_k = builder.open_tiled_dim(k_size, &[16]);
-        let ld_b_n = builder.open_tiled_dim(n_size, &[16, 4]);
+        let ld_b_k = builder.open_tiled_dim(k_size, [16][..].into());
+        let ld_b_n = builder.open_tiled_dim(n_size, [16, 4][..].into());
         let (ptr, pattern) =
             builder.tensor_access(&"b", self.b, DATA_TYPE, &[&ld_b_k, &ld_b_n]);
         let ld_b = builder.ld_nc(DATA_TYPE, &ptr, pattern);
@@ -93,12 +93,11 @@ impl MMSig {
 /// Descends in the search tree without saving the candidates.
 pub fn descend_without_copies(mut space: SearchSpace) {
     while let Some(mut choice) = {
-        let choice = explorer::choice::list(&space).next();
+        let choice = explorer::choice::default_list(&space).next();
         choice
     } {
         let id = rand::thread_rng().gen_range(0, choice.len());
         let res = match choice.swap_remove(id) {
-            ActionEx::TileSizes(..) => panic!(),
             ActionEx::Action(action) => space.apply_decisions(vec![action]),
             ActionEx::LowerLayout {
                 mem,
@@ -116,12 +115,11 @@ pub fn descend_without_copies(mut space: SearchSpace) {
 pub fn descend_with_copies(mut space: SearchSpace) -> Vec<SearchSpace> {
     let mut spaces = vec![];
     while let Some(mut choice) = {
-        let choice = explorer::choice::list(&space).next();
+        let choice = explorer::choice::default_list(&space).next();
         choice
     } {
         let id = rand::thread_rng().gen_range(0, choice.len());
         let res = match choice.swap_remove(id) {
-            ActionEx::TileSizes(..) => panic!(),
             ActionEx::Action(action) => space.apply_decisions(vec![action]),
             ActionEx::LowerLayout {
                 mem,

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -126,6 +126,12 @@ impl TilingPattern {
     }
 }
 
+impl<'a> From<&'a [u32]> for TilingPattern {
+    fn from(dim_sizes: &'a [u32]) -> Self {
+        TilingPattern::new_fixed(dim_sizes)
+    }
+}
+
 impl Default for TilingPattern {
     fn default() -> Self {
         TilingPattern {

--- a/telamon-capi/src/ir.rs
+++ b/telamon-capi/src/ir.rs
@@ -138,12 +138,12 @@ pub unsafe extern "C" fn telamon_ir_function_add_dimensions(
     dim_ids: *mut ir::DimId,
 ) -> TelamonStatus {
     let tile_sizes = std::slice::from_raw_parts(tile_sizes, num_tiles);
-    let tiling_factors = vec![tile_sizes.iter().product()];
+    let tiling_factors = vec![tile_sizes.iter().product::<u32>()];
     let tile_sizes = tile_sizes.iter().map(|&s| VecSet::new(vec![s])).collect();
     let size = Box::from_raw(size).0;
     let (ldim, dims) = unwrap_or_exit!((*function).0.add_logical_dim(
         size,
-        tiling_factors,
+        tiling_factors.into(),
         tile_sizes
     ));
     *logical_id = ldim;
@@ -336,7 +336,7 @@ pub struct Operator(ir::Operator<'static, ()>);
 pub unsafe extern "C" fn telamon_ir_operator_new_mov(
     operand: *mut Operand,
 ) -> *mut Operator {
-    let operator = ir::Operator::Mov(Box::from_raw(operand).0);
+    let operator = ir::Operator::UnaryOp(ir::UnaryOp::Mov, Box::from_raw(operand).0);
     Box::into_raw(Box::new(Operator(operator)))
 }
 
@@ -397,7 +397,7 @@ pub unsafe extern "C" fn telamon_ir_operator_new_cast(
     return_type: *const ir::Type,
 ) -> *mut Operator {
     let operand = Box::from_raw(operand).0;
-    let operator = ir::Operator::Cast(operand, *return_type);
+    let operator = ir::Operator::UnaryOp(ir::UnaryOp::Cast(*return_type), operand);
     Box::into_raw(Box::new(Operator(operator)))
 }
 

--- a/telamon-gen/benches/lexer.rs
+++ b/telamon-gen/benches/lexer.rs
@@ -20,7 +20,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 name.push_str(path.file_stem().unwrap().to_str().unwrap());
 
                 c.bench_function(&name, move |b| {
-                    b.iter(|| lexer::Lexer::new(&mut input))
+                    b.iter(|| lexer::Lexer::from_input(&mut input))
                 });
             }
         }

--- a/telamon-utils/src/vec_set.rs
+++ b/telamon-utils/src/vec_set.rs
@@ -223,6 +223,12 @@ where
     }
 }
 
+impl<T: Ord> From<Vec<T>> for VecSet<T> {
+    fn from(vec: Vec<T>) -> Self {
+        Self::new(vec)
+    }
+}
+
 impl<T> Default for VecSet<T> {
     fn default() -> Self {
         VecSet { data: Vec::new() }


### PR DESCRIPTION
There are some rarely used code paths (some benches and the C API) which
frequently gets broken by changes in Telamon APIs.  This patch fixes
them (for the time being) and adds a Travis check that all the tests,
benches, and binaries from all the crates in the repo must typecheck.