### PR TITLE
Groundwork to support DMA and dynamic layouts.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ name = "print_event_log"
 
 [build-dependencies]
 cc = "1.0.12"
+env_logger = "0.5.9"
 failure = "0.1.1"
 glob = "0.2"
 

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 //! Rust script to compile non-rust files.
 extern crate cc;
+extern crate env_logger;
 extern crate failure;
 extern crate glob;
 extern crate telamon_gen;
@@ -28,6 +29,7 @@ fn compile_link_cuda() {
 }
 
 fn main() {
+    env_logger::init();
     let exh_file = "src/search_space/choices.exh";
     let out_dir = std::env::var_os("OUT_DIR").unwrap();
     for file in glob::glob("src/search_space/*.exh").unwrap() {

--- a/src/device/cuda/gpu.rs
+++ b/src/device/cuda/gpu.rs
@@ -420,18 +420,14 @@ impl device::Device for Gpu {
     fn can_vectorize(&self, dim: &ir::Dimension, op: &ir::Operator) -> bool {
         match *op {
             Operator::TmpLd(..) | Operator::TmpSt(..) => true,
-            Operator::Ld(ref t, _, ref pattern)
-                if pattern.is_consecutive(dim.id(), t) =>
-            {
+            Operator::Ld(.., ref pattern) if pattern.is_layout_dimension(dim.id()) => {
                 // TODO(ulysse): hack to avoid vectorizing by a factor of 3 until we
                 // support alignment contraints.
                 dim.possible_sizes()
                     .map(|sizes| !sizes.contains(&3))
                     .unwrap_or(false)
             }
-            Operator::St(_, ref operand, _, ref pattern)
-                if pattern.is_consecutive(dim.id(), &operand.t()) =>
-            {
+            Operator::St(.., ref pattern) if pattern.is_layout_dimension(dim.id()) => {
                 // TODO(ulysse): hack to avoid vectorizing by a factor of 3 until we
                 // support alignment contraints.
                 dim.possible_sizes()

--- a/src/device/cuda/mem_model.rs
+++ b/src/device/cuda/mem_model.rs
@@ -1,6 +1,7 @@
 //! Memory accesses analysis.
 use binary_heap_plus::BinaryHeap;
 use device::{cuda, Context};
+use indexmap::IndexMap;
 use ir;
 use itertools::Itertools;
 use model::size;
@@ -89,7 +90,7 @@ fn unknown_info(is_shared_access: Trivalent, gpu: &cuda::Gpu) -> MemInfo {
 fn info(
     space: &SearchSpace,
     inst: &ir::Instruction,
-    dims: &HashMap<ir::DimId, ir::PartialSize>,
+    dims: &IndexMap<ir::DimId, ir::PartialSize>,
     is_shared_access: Trivalent,
     gpu: &cuda::Gpu,
     sizes: &HashMap<ir::DimId, size::Range>,
@@ -152,7 +153,7 @@ impl ThreadDimInfo {
 fn tensor_thread_dims(
     space: &SearchSpace,
     inst: &ir::Instruction,
-    tensor_dims: &HashMap<ir::DimId, ir::PartialSize>,
+    tensor_dims: &IndexMap<ir::DimId, ir::PartialSize>,
     sizes: &HashMap<ir::DimId, size::Range>,
     ctx: &Context,
 ) -> Vec<ThreadDimInfo> {
@@ -357,7 +358,7 @@ fn increment_index(pos: usize, dims: &[ThreadDimInfo], indexes: &mut [u64]) -> b
 /// Compute the replay factor caused by shared memory accesses.
 fn shared_replay_factor(
     thread_dims: Vec<ThreadDimInfo>,
-    tensor_dims: &HashMap<ir::DimId, ir::PartialSize>,
+    tensor_dims: &IndexMap<ir::DimId, ir::PartialSize>,
     dim_sizes: &HashMap<ir::DimId, size::Range>,
     space: &SearchSpace,
     gpu: &cuda::Gpu,

--- a/src/helper/tensor.rs
+++ b/src/helper/tensor.rs
@@ -196,7 +196,7 @@ where
                 .map(|(dim, (_, stride))| (dim, stride.into_ir_size(builder)))
                 .collect_vec();
             ptr = builder.induction_var(&self.name, increments.clone());
-            pattern = builder.tensor_access_pattern(None, increments);
+            pattern = builder.tensor_access_pattern(None, S::t(), increments);
         };
         let flag = if self.read_only {
             InstFlag::ALL

--- a/src/ir/access_pattern.rs
+++ b/src/ir/access_pattern.rs
@@ -1,6 +1,8 @@
 /// Provides a way to represent the stride of a given variable.
 use device::Device;
+use indexmap::IndexMap;
 use ir;
+use itertools::Itertools;
 use search_space::MemSpace;
 use utils::*;
 
@@ -20,21 +22,21 @@ pub enum AccessPattern<'a> {
     /// Access with a fixed stride on each dimensions. Accesses on two different
     /// dimensions should not overlap.
     Tensor {
+        /// The memory block accessed.
         mem_id: Option<ir::MemId>,
-        dims: HashMap<ir::DimId, ir::PartialSize<'a>>,
+        /// The elements type of the tensor.
+        t: ir::Type,
+        /// The dimensions of the tensor, with the innermost dimension first.
+        dims: IndexMap<ir::DimId, ir::PartialSize<'a>>,
     },
 }
 
 impl<'a> AccessPattern<'a> {
     /// Indicates if memory accesses access to consecutive elements on the given dimension.
-    pub fn is_consecutive(&self, dim: ir::DimId, t: &ir::Type) -> bool {
+    pub fn is_layout_dimension(&self, dim: ir::DimId) -> bool {
         match self {
             AccessPattern::Unknown(..) => false,
-            AccessPattern::Tensor { dims, .. } => dims
-                .get(&dim)
-                .and_then(|stride| stride.as_int())
-                .map(|stride| Some(stride) == t.len_byte())
-                .unwrap_or(false),
+            AccessPattern::Tensor { dims, .. } => dims.contains_key(&dim),
         }
     }
 
@@ -71,5 +73,129 @@ impl<'a> AccessPattern<'a> {
         self.mem_block()
             .map(ir::Type::PtrTo)
             .unwrap_or_else(|| device.pointer_type(MemSpace::GLOBAL))
+    }
+
+    /// Indicates the number of dimensions in the underlying layout.
+    pub fn num_layout_dimensions(&self) -> usize {
+        match self {
+            AccessPattern::Unknown(..) => 0,
+            AccessPattern::Tensor { dims, .. } => dims.len(),
+        }
+    }
+}
+
+/// Uniquely identifies a `LayoutDimension`.
+#[derive(
+    Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize,
+)]
+pub struct LayoutDimId(pub usize);
+
+impl From<LayoutDimId> for usize {
+    fn from(id: LayoutDimId) -> Self {
+        id.0
+    }
+}
+
+/// Represents a dimension in a tensor.
+#[derive(Clone, Debug)]
+pub struct LayoutDimension {
+    id: LayoutDimId,
+    inst: Option<ir::InstId>,
+    dim: ir::DimId,
+    is_strided: bool,
+    possible_ranks: Option<VecSet<u32>>,
+}
+
+impl LayoutDimension {
+    /// Returns the unique identifier of the `LayoutDimension`.
+    pub fn id(&self) -> LayoutDimId {
+        self.id
+    }
+
+    /// Indicates the statement dimension that maps to this layout dimension.
+    pub fn dim(&self) -> ir::DimId {
+        self.dim
+    }
+
+    /// Indicates if the layout dimension is a dimension of a memory block.
+    pub fn is_memory_layout(&self) -> bool {
+        self.possible_ranks.is_some()
+    }
+
+    /// Indicates if the layout is accessed by an instruction.
+    pub fn access_inst(&self) -> Option<ir::InstId> {
+        self.inst
+    }
+
+    /// Indicates the possible orders the dimension can have if the layout is for a
+    /// memory block.
+    pub fn possible_ranks(&self) -> Option<&VecSet<u32>> {
+        self.possible_ranks.as_ref()
+    }
+
+    /// Indicates if the layout dimension is strided with regard to the immediately inner
+    /// dimension.
+    pub fn is_strided(&self) -> bool {
+        self.is_strided
+    }
+
+    /// Creates the layout dimensions that correspond to an access pattern. Returns the patterns in
+    /// the order the ids where given.
+    ///
+    /// To obtain the number of ids to pass to this method, call
+    /// `pattern.num_layout_dimensions()`.
+    pub fn from_access_pattern<L>(
+        ids: &[ir::LayoutDimId],
+        inst: ir::InstId,
+        pattern: &AccessPattern,
+        fun: &ir::Function<L>,
+    ) -> Vec<Self> {
+        match pattern {
+            AccessPattern::Unknown { .. } => {
+                assert!(ids.is_empty());
+                vec![]
+            }
+            AccessPattern::Tensor { dims, t, .. } => {
+                let type_len = unwrap!(t.len_byte());
+                let mut current_stride = ir::PartialSize::new(type_len, vec![]);
+                dims.iter()
+                    .zip_eq(ids)
+                    .enumerate()
+                    .map(|(rank, ((&dim, stride), &id))| {
+                        let is_strided = *stride != current_stride;
+                        current_stride = stride.clone() * fun.dim(dim).size();
+                        LayoutDimension::new_static(
+                            id,
+                            dim,
+                            rank as u32 + 1, // Ranks start at 1.
+                            is_strided,
+                            inst,
+                        )
+                    }).collect()
+            }
+        }
+    }
+
+    /// Creates a new dimension for a static layout.
+    fn new_static(
+        id: ir::LayoutDimId,
+        dim: ir::DimId,
+        rank: u32,
+        is_strided: bool,
+        inst: ir::InstId,
+    ) -> Self {
+        LayoutDimension {
+            id,
+            dim,
+            possible_ranks: Some(VecSet::new(vec![rank])),
+            is_strided,
+            inst: Some(inst),
+        }
+    }
+
+    /// Registers `self` in the other `fun` structures. Does not registers `self` in
+    /// `self.inst` as inst is created as the same time as `self`.
+    pub fn register<L>(&self, fun: &mut ir::Function<L>) {
+        fun.dim_mut(self.dim).register_layout_dim(self.id);
     }
 }

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -75,6 +75,8 @@ pub struct Function<'a, L = ir::LoweringMap> {
     logical_dims: Vec<ir::LogicalDim<'a>>,
     dim_mappings: SparseVec<ir::DimMappingId, ir::DimMapping>,
     variables: SparseVec<ir::VarId, ir::Variable>,
+    layout_dims: SparseVec<ir::LayoutDimId, ir::LayoutDimension>,
+    mem_layout_dims: Vec<ir::LayoutDimId>,
 }
 
 impl<'a, L> Function<'a, L> {
@@ -94,6 +96,8 @@ impl<'a, L> Function<'a, L> {
             logical_dims: Vec::new(),
             dim_mappings: SparseVec::new(),
             variables: SparseVec::new(),
+            layout_dims: SparseVec::new(),
+            mem_layout_dims: Vec::new(),
         }
     }
 
@@ -116,9 +120,10 @@ impl<'a, L> Function<'a, L> {
         id: InstId,
         op: Operator<'a, L>,
         iter_dims: HashSet<ir::DimId>,
+        mem_access_layout: VecSet<ir::LayoutDimId>,
     ) -> Result<ir::Instruction<'a, L>, ir::Error> {
         // Create and check the instruction.
-        let inst = ir::Instruction::new(op, id, iter_dims, self)?;
+        let inst = ir::Instruction::new(op, id, iter_dims, mem_access_layout, self)?;
         // Register the instruction in iteration dimensions.
         for &dim in inst.iteration_dims() {
             self.dim_mut(dim).add_iterated(id);
@@ -145,6 +150,21 @@ impl<'a, L> Function<'a, L> {
     ) -> Result<ir::Variable, ir::Error> {
         def.check(self)?;
         Ok(ir::Variable::new(id, def, self))
+    }
+
+    /// Registers a layout dimension in the function.
+    fn register_layout_dim(&mut self, dim: ir::LayoutDimension) {
+        dim.register(self);
+        if dim.is_memory_layout() {
+            self.mem_layout_dims.push(dim.id());
+        }
+        // Create holes in the sparse vector so we can ues this function both with fresh
+        // and pre-allocated IDs.
+        let id_idx: usize = dim.id().into();
+        if self.layout_dims.len() <= id_idx {
+            self.layout_dims.expand_to(id_idx + 1);
+        }
+        self.layout_dims.set_lazy(dim.id(), dim);
     }
 
     /// Adds an induction variable.
@@ -307,50 +327,15 @@ impl<'a, L> Function<'a, L> {
             .extend(self.mem_blocks.merge_dims(src, dst));
     }
 
-    /// Lowers a layout into conventional memory accesses.
-    pub(crate) fn lower_layout(
-        &mut self,
-        id: ir::MemId,
-        st_dims: Vec<ir::DimId>,
-        ld_dims: Vec<ir::DimId>,
-    ) where
-        L: Clone,
-    {
-        let pos = unwrap!(self.layouts_to_lower.iter().position(|&x| x == id));
-        self.layouts_to_lower.swap_remove(pos);
-        self.mem_blocks.lower_layout(id);
-        let (st_index, st_pattern) = self.gen_internal_index(id, &st_dims);
-        let (ld_index, ld_pattern) = self.gen_internal_index(id, &ld_dims);
-        for &mem_use in self.mem_blocks.block(id).uses() {
-            self.insts[mem_use].lower_layout(
-                ld_index.clone(),
-                ld_pattern.clone(),
-                st_index.clone(),
-                st_pattern.clone(),
-            );
-        }
-    }
-
-    /// Generates an operand repesenting a pointer to a cell of a memory block.
-    fn gen_internal_index(
-        &mut self,
-        id: ir::MemId,
-        dims: &[ir::DimId],
-    ) -> (Operand<'a, L>, AccessPattern<'a>) {
-        let ty_len = self.mem_blocks.block(id).base_size();
-        self.gen_index(id.into(), ty_len, Operand::Addr(id), &dims)
-    }
-
     /// Generates an access pattern and the corresponding induction variable to access a
     /// memory block.
-    fn gen_index(
+    fn gen_internal_index(
         &mut self,
         mem: ir::MemId,
-        base_incr: u32,
-        base_addr: Operand<'a, L>,
         dims: &[ir::DimId],
     ) -> (Operand<'a, L>, AccessPattern<'a>) {
-        let var_type = base_addr.t();
+        let base_incr = self.mem_blocks.block(mem).base_size();
+        let var_type = ir::Type::PtrTo(mem);
         let base_size = ir::PartialSize::new(base_incr, vec![]);
         let increments = dims
             .iter()
@@ -361,10 +346,11 @@ impl<'a, L> Function<'a, L> {
                 Some((dim, old_size))
             }).collect_vec();
         let pattern = ir::AccessPattern::Tensor {
+            t: self.mem_block(mem).elements_type(),
             mem_id: Some(mem),
             dims: increments.iter().cloned().collect(),
         };
-        let ind_var = unwrap!(ir::InductionVar::new(increments, base_addr));
+        let ind_var = unwrap!(ir::InductionVar::new(increments, Operand::Addr(mem)));
         let ind_var = self.add_ind_var(ind_var);
         let addr = ir::Operand::InductionVar(ind_var, var_type);
         (addr, pattern)
@@ -418,6 +404,25 @@ impl<'a, L> Function<'a, L> {
         }
         mapping
     }
+
+    /// Returns a layout dimension given its ID.
+    pub fn layout_dimension(&self, id: ir::LayoutDimId) -> &ir::LayoutDimension {
+        &self.layout_dims[id]
+    }
+
+    /// Iterates over all layout dimensions.
+    pub fn layout_dimensions(&self) -> impl Iterator<Item = &ir::LayoutDimension> + '_ {
+        self.layout_dims.iter()
+    }
+
+    /// Iterate over memory layout dimensions.
+    pub fn mem_layout_dimensions(
+        &self,
+    ) -> impl Iterator<Item = &ir::LayoutDimension> + '_ {
+        self.mem_layout_dims
+            .iter()
+            .map(move |&id| self.layout_dimension(id))
+    }
 }
 
 impl<'a> Function<'a, ()> {
@@ -438,14 +443,32 @@ impl<'a> Function<'a, ()> {
             }
         }
         let id = ir::InstId(self.insts.len() as u32);
-        let inst = self.create_inst(id, op, iter_dims)?;
+        let mem_access_layout = op
+            .mem_access_pattern()
+            .map(|pattern| {
+                let layout_ids: VecSet<_> = (self.layout_dims.len()..)
+                    .take(pattern.num_layout_dimensions())
+                    .map(ir::LayoutDimId)
+                    .collect();
+                let dims = ir::LayoutDimension::from_access_pattern(
+                    &layout_ids,
+                    id,
+                    &pattern,
+                    self,
+                );
+                for dim in dims {
+                    self.register_layout_dim(dim);
+                }
+                layout_ids
+            }).unwrap_or_default();
+        let inst = self.create_inst(id, op, iter_dims, mem_access_layout)?;
         self.insts.push(inst);
         Ok(id)
     }
 
     /// Allocates a new memory block.
-    pub fn add_mem_block(&mut self, size: u32) -> ir::MemId {
-        self.mem_blocks.alloc_block(size, None)
+    pub fn add_mem_block(&mut self, t: ir::Type, len: u32) -> ir::MemId {
+        self.mem_blocks.alloc_block(t, len)
     }
 
     /// Create a new logical dimension composed of multiple dimensions to implement
@@ -464,28 +487,30 @@ impl<'a> Function<'a, ()> {
         // Create the objects, but don't add anythin yet so we can rollback if an error
         // occurs.
         let mut dims = Vec::new();
+        let mut possible_tiled_sizes = VecSet::default();
         let logical_dim = if let Some(size) = size.as_constant() {
-            let possible_sizes =
+            possible_tiled_sizes =
                 tiling_factors.iter().map(|factor| size / factor).collect();
-            let dim =
-                Dimension::new_static(dim_ids[0], possible_sizes, Some(logical_id))?;
-            dims.push(dim);
             ir::LogicalDim::new_static(logical_id, dim_ids.clone(), size)
         } else {
-            let static_dims = dim_ids[1..].to_vec();
-            let mut tiled_size: ir::PartialSize = size.clone().into();
-            tiled_size.add_divisors(&VecSet::new(static_dims.clone()));
-            dims.push(Dimension::new(dim_ids[0], tiled_size, Some(logical_id))?);
             ir::LogicalDim::new_dynamic(
                 logical_id,
                 dim_ids[0],
-                static_dims,
+                dim_ids[1..].to_vec(),
                 tiling_factors,
-                size,
+                size.clone(),
             )
         };
+        let mut tiled_size: ir::PartialSize = size.into();
+        tiled_size.add_divisors(&VecSet::new(dim_ids[1..].to_vec()));
+        dims.push(Dimension::new(
+            dim_ids[0],
+            tiled_size,
+            possible_tiled_sizes,
+            Some(logical_id),
+        )?);
         for (&id, sizes) in dim_ids[1..].iter().zip_eq(possible_tile_sizes) {
-            dims.push(Dimension::new_static(id, sizes, Some(logical_id))?);
+            dims.push(Dimension::new_tile(id, sizes, logical_id)?);
         }
         // Register the new objects.
         for dim in &dims {
@@ -515,6 +540,7 @@ impl<'a> Function<'a, ()> {
             next_inst: self.insts.len(),
             next_dim: self.dims.len(),
             next_dim_mapping: self.dim_mappings.len() as u16,
+            next_layout_dim: self.layout_dims.len(),
         };
         let Function {
             signature,
@@ -530,6 +556,8 @@ impl<'a> Function<'a, ()> {
             logical_dims,
             mut dim_mappings,
             variables,
+            mut layout_dims,
+            mem_layout_dims,
         } = self;
 
         let mut insts = SparseVec::from_vec(
@@ -553,11 +581,13 @@ impl<'a> Function<'a, ()> {
             next_inst,
             next_dim,
             next_dim_mapping,
+            next_layout_dim,
         } = counter;
         insts.expand_to(next_inst);
         dims.expand_to(next_dim);
         mem_blocks.expand_blocks_to(next_mem);
         dim_mappings.expand_to(next_dim_mapping as usize);
+        layout_dims.expand_to(next_layout_dim);
 
         Function {
             signature,
@@ -573,6 +603,8 @@ impl<'a> Function<'a, ()> {
             logical_dims,
             dim_mappings,
             variables,
+            layout_dims,
+            mem_layout_dims,
         }
     }
 }
@@ -585,7 +617,7 @@ impl<'a> Function<'a> {
         dst_operand_pos: usize,
     ) -> Result<ir::LoweredDimMap, ()> {
         // TODO(search_space): allow temporary memory generation for reduce operators.
-        let (src_inst, data_type, lowered) = {
+        let (src_inst, data_type, (lowered, layout_dims)) = {
             match self.insts[dst_inst].operands()[dst_operand_pos] {
                 Operand::Inst(src_id, t, dim_map, ir::DimMapScope::Global(lowering)) => {
                     (*src_id, *t, lowering.lower(dim_map))
@@ -606,8 +638,14 @@ impl<'a> Function<'a> {
         let ld_dim_map = self.activate_mapped_dims(&lowered.ld_dims_mapping, false);
 
         // Activate the temporary memory block
-        self.mem_blocks
-            .set_lazy_tmp(lowered.mem, data_type, lowered.mem_dimensions());
+        self.mem_blocks.set_lazy_tmp(
+            lowered.mem,
+            data_type,
+            lowered.mem_dimensions(),
+            layout_dims,
+            lowered.store,
+            lowered.load,
+        );
 
         // Build and activate the store instruction
         let st_operand =
@@ -616,6 +654,7 @@ impl<'a> Function<'a> {
             lowered.store,
             Operator::TmpSt(st_operand, lowered.mem.into()),
             lowered.store_dims().collect(),
+            VecSet::default(),
         ));
         self.insts.set_lazy(lowered.store, st);
 
@@ -624,6 +663,7 @@ impl<'a> Function<'a> {
             lowered.load,
             Operator::TmpLd(data_type, lowered.mem.into()),
             lowered.load_dims().collect(),
+            VecSet::default(),
         ));
         self.insts.set_lazy(lowered.load, ld);
         self.insts[dst_inst].lower_dim_map(dst_operand_pos, lowered.load, ld_dim_map);
@@ -663,6 +703,40 @@ impl<'a> Function<'a> {
     pub(crate) fn dim_not_merged(&mut self, lhs: ir::DimId, rhs: ir::DimId) {
         let to_lower = self.mem_blocks.not_merged(&self.dims[lhs], rhs);
         self.layouts_to_lower.extend(to_lower);
+    }
+
+    /// Lowers a layout into conventional memory accesses.
+    pub(crate) fn lower_layout(
+        &mut self,
+        id: ir::MemId,
+        st_dims: Vec<ir::DimId>,
+        ld_dims: Vec<ir::DimId>,
+    ) -> Vec<ir::LayoutDimId> {
+        let pos = unwrap!(self.layouts_to_lower.iter().position(|&x| x == id));
+        self.layouts_to_lower.swap_remove(pos);
+        let (st_inst, st_layout, ld_inst, ld_layout) = self.mem_blocks.lower_layout(id);
+        let layout_dim_ids = ld_layout.iter().chain(&st_layout).cloned().collect();
+        let (st_index, st_pattern) = self.gen_internal_index(id, &st_dims);
+        let (ld_index, ld_pattern) = self.gen_internal_index(id, &ld_dims);
+        // Register the layout dimensions.
+        let st_layout_dims = ir::LayoutDimension::from_access_pattern(
+            &st_layout,
+            st_inst,
+            &st_pattern,
+            self,
+        );
+        let ld_layout_dims = ir::LayoutDimension::from_access_pattern(
+            &ld_layout,
+            ld_inst,
+            &ld_pattern,
+            self,
+        );
+        for layout_dim in st_layout_dims.into_iter().chain(ld_layout_dims) {
+            self.register_layout_dim(layout_dim);
+        }
+        self.insts[st_inst].lower_layout(st_index, st_pattern, VecSet::new(st_layout));
+        self.insts[ld_inst].lower_layout(ld_index, ld_pattern, VecSet::new(ld_layout));
+        layout_dim_ids
     }
 }
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -17,7 +17,7 @@ use itertools::Itertools;
 use std;
 use std::marker::PhantomData;
 
-pub use self::access_pattern::{AccessPattern, Stride};
+pub use self::access_pattern::*;
 pub use self::dim_map::DimMap;
 pub use self::dimension::{
     DimId, DimMapping, DimMappingId, Dimension, LogicalDim, LogicalDimId,
@@ -76,15 +76,20 @@ pub struct NewObjs {
     pub def_statements: Vec<(VarId, StmtId)>,
     pub var_dims: Vec<(VarId, DimId)>,
     pub var_mappings: Vec<(VarId, DimMappingId)>,
+    pub layout_dims: Vec<LayoutDimId>,
+    pub mem_layout_dims: Vec<LayoutDimId>,
+    pub actual_layout_dims: Vec<(LayoutDimId, DimId)>,
+    pub mem_access_layout: Vec<(InstId, LayoutDimId)>,
 }
 
 impl NewObjs {
     /// Registers a new instruction.
     pub fn add_instruction(&mut self, inst: &Instruction) {
         self.add_stmt(inst);
-        for &dim in inst.iteration_dims() {
-            self.iteration_dims.push((inst.id(), dim));
-        }
+        self.iteration_dims
+            .extend(inst.iteration_dims().iter().map(|&dim| (inst.id(), dim)));
+        self.mem_access_layout
+            .extend(inst.mem_access_layout().iter().map(|&dim| (inst.id(), dim)));
         if inst.as_mem_inst().is_some() {
             self.mem_insts.push(inst.id());
         }
@@ -144,6 +149,15 @@ impl NewObjs {
             .extend(var.dimensions().iter().map(|&dim| (var.id(), dim)));
         self.var_mappings
             .extend(var.def().mapped_dims().map(|id| (var.id(), id)));
+    }
+
+    /// Adds a layout dimension.
+    pub fn add_layout_dim(&mut self, dim: &LayoutDimension) {
+        self.layout_dims.push(dim.id());
+        self.actual_layout_dims.push((dim.id(), dim.dim()));
+        if dim.is_memory_layout() {
+            self.mem_layout_dims.push(dim.id());
+        }
     }
 }
 
@@ -360,6 +374,7 @@ pub struct Counter {
     pub next_inst: usize,
     pub next_dim: usize,
     pub next_dim_mapping: u16,
+    pub next_layout_dim: usize,
 }
 
 impl Counter {
@@ -382,8 +397,14 @@ impl Counter {
     }
 
     pub fn next_dim_mapping(&mut self) -> DimMappingId {
-        let next = DimMappingId(self.next_dim_mapping as u16);
+        let next = DimMappingId(self.next_dim_mapping);
         self.next_dim_mapping += 1;
+        next
+    }
+
+    pub fn next_layout_dim(&mut self) -> LayoutDimId {
+        let next = LayoutDimId(self.next_layout_dim);
+        self.next_layout_dim += 1;
         next
     }
 }

--- a/src/search_space/layout.exh
+++ b/src/search_space/layout.exh
@@ -1,0 +1,90 @@
+/// Indicates the layout of a memory block or variable.
+set LayoutDimensions:
+  item_type = "ir::LayoutDimension"
+  id_type = "ir::LayoutDimId"
+  item_getter = "$fun.layout_dimension($id)"
+  id_getter = "$item.id()"
+  iterator = "$fun.layout_dimensions()"
+  var_prefix = "layout"
+  new_objs = "$objs.layout_dims"
+end
+
+/// Maps layout dimensions to actual dimensions.
+// TODO(ulysse): support layouts with dynamic dimensions.
+set ActualDimension($layout in LayoutDimensions) subsetof StaticDims:
+  item_type = "ir::Dimension"
+  id_type = "ir::DimId"
+  item_getter = "$fun.dim($id)"
+  id_getter = "$item.id()"
+  iterator = "{ let dim = $fun.dim($layout.dim()); dim.possible_sizes().map(|_| dim) }"
+  from_superset =
+    "if $item.layout_dims().contains(&$layout.id()) { Some($item) } else { None }"
+  reverse forall $dim in StaticDims = "$dim.layout_dims().iter().map(|&id| $fun.dim(id))"
+  var_prefix = "dim"
+  new_objs = "$objs.actual_layout_dims"
+end
+
+/// Layout dimensions of a memory block.
+set MemLayoutDimensions subsetof LayoutDimensions:
+  item_type = "ir::LayoutDimension"
+  id_type = "ir::LayoutDimId"
+  item_getter = "$fun.layout_dimension($id)"
+  id_getter = "$item.id()"
+  iterator = "$fun.mem_layout_dimensions()"
+  from_superset = "if $item.is_memory_layout() { Some($item) } else { None }"
+  var_prefix = "mem_layout"
+  new_objs = "$objs.mem_layout_dims"
+end
+
+/// Indicates the layout dimensions of a memory accessed by an instruction.
+set MemAccessLayout($access in MemInsts) subsetof MemLayoutDimensions:
+  item_type = "ir::LayoutDimension"
+  id_type = "ir::LayoutDimId"
+  item_getter = "$fun.layout_dimension($id)"
+  id_getter = "$item.id()"
+  iterator = "$access.mem_access_layout().iter().map(|&id| $fun.layout_dimension(id))"
+  from_superset =
+    "if $item.access_inst() == Some($access.id()) { Some($item) } else { None }"
+  reverse forall $dim in MemLayoutDimensions =
+    "$dim.access_inst().map(|id| $fun.inst(id)).into_iter()"
+  var_prefix = "mem_layout"
+  new_objs = "$objs.mem_access_layout"
+end
+
+/// Indicates the order in which layout dimensions are ordered in memory.
+define integer rank($dim in MemLayoutDimensions): "unwrap!($dim.possible_ranks())" end
+
+require forall $inst in MemInsts:
+  forall $outer in MemAccessLayout($inst):
+    forall $inner in MemAccessLayout($inst):
+      forall $outer_dim in ActualDimension($outer):
+        forall $inner_dim in ActualDimension($inner):
+          // Vector dimensions order matches the rank.
+          order($outer_dim, $inner_dim) is not OUTER
+          || dim_kind($inner_dim) is not VECTOR
+          || dim_kind($outer_dim) is not VECTOR
+          || rank($outer) > rank($inner)
+          // Inner vectorization is on contiguous elements.
+          rank($outer) < rank($inner)
+          || dim_kind($outer_dim) is not INNER_VECTOR
+          || dim_kind($inner_dim) is INNER_VECTOR
+          || rank($inner) == "0"
+          // Ensure we don't vectorize if there is a stride.
+          order($outer_dim, $inner_dim) is not OUTER
+          || "!$outer.is_strided()"
+          || dim_kind($outer_dim) is not VECTOR
+          || dim_kind($outer_dim) != dim_kind($inner_dim)
+
+// Vectorization is on contiguous dimensions.
+require forall $inst in MemInsts:
+  forall $outer in MemAccessLayout($inst):
+    forall $mid in MemAccessLayout($inst):
+      forall $inner in MemAccessLayout($inst):
+        forall $outer_dim in ActualDimension($outer):
+          forall $mid_dim in ActualDimension($mid):
+            forall $inner_dim in ActualDimension($inner):
+              dim_kind($outer_dim) is not VECTOR
+              || dim_kind($inner_dim) is not VECTOR
+              || rank($outer) < rank($mid)
+              || rank($mid) < rank($inner)
+              || dim_kind($mid_dim) is VECTOR

--- a/src/search_space/variable.exh
+++ b/src/search_space/variable.exh
@@ -124,6 +124,9 @@ require forall $mapping in DimMappings:
   forall $lhs in MappedDims($mapping):
     forall $rhs in MappedDims($mapping):
       order($lhs, $rhs) is ORDERED | MERGED
+      // For now, limit mappings to dimensions with a known size.
+      // TODO(ulysse): allow generating memory blocks with a dynamic size.
+      "$lhs.possible_sizes().is_some()" || order($lhs, $rhs) is MERGED
 
 require forall $var in Variables:
   forall $mapping in DimMappings:
@@ -200,3 +203,5 @@ end
 
 // Cannot use more shared memory that what is available.
 require shared_mem_used() <= "$fun.device().shared_mem()"
+
+include "layout.exh"

--- a/telamon-capi/include/telamon.h
+++ b/telamon-capi/include/telamon.h
@@ -125,6 +125,11 @@ typedef struct Function Function;
 typedef struct KernelParameters KernelParameters;
 
 /*
+ * Uniquely identifies a `LayoutDimension`.
+ */
+typedef struct LayoutDimId LayoutDimId;
+
+/*
  * Opaque type that abstracts away the lifetime parameter of `ir::Operand` so that
  * cbindgen can generate bindings.
  */
@@ -241,7 +246,7 @@ typedef struct {
 } MemSpace;
 
 /*
- * Specifies how iteration dimensions are implemented.
+ * Indicates the layout of a memory block or variable. Specifies how iteration dimensions are implemented.
  */
 typedef struct {
     uint8_t bits;
@@ -311,6 +316,7 @@ typedef enum {
     Action_IsIterationDim,
     Action_MemorySpace,
     Action_MemSpace,
+    Action_Rank,
     Action_DimKind,
     Action_Order,
     Action_DimMapping,
@@ -370,6 +376,11 @@ typedef struct {
     MemId mem;
     MemSpace domain;
 } Action_MemSpace_Body;
+
+typedef struct {
+    LayoutDimId dim;
+    NumericSet domain;
+} Action_Rank_Body;
 
 typedef struct {
     DimId dim;
@@ -493,6 +504,7 @@ typedef struct {
         Action_IsIterationDim_Body is_iteration_dim;
         Action_MemorySpace_Body memory_space;
         Action_MemSpace_Body mem_space;
+        Action_Rank_Body rank;
         Action_DimKind_Body dim_kind;
         Action_Order_Body order;
         Action_DimMapping_Body dim_mapping;
@@ -819,6 +831,7 @@ Operator *telamon_ir_operator_new_tensor_store(Function *function,
  * Adds an array parameter to the function signature.
  */
 void telamon_ir_signature_add_array(Signature *signature,
+                                    const Device *device,
                                     const char *name,
                                     const Type *element_type,
                                     const Device *device);

--- a/telamon-gen/cc_tests/src/chained_parameter.exh
+++ b/telamon-gen/cc_tests/src/chained_parameter.exh
@@ -1,0 +1,71 @@
+// Tests constraints with chained parametric sets: a in SetA, b in SetB(a), c in Set(b).
+set SetA:
+  item_type = "ir::set_a::Obj"
+  id_type = "ir::set_a::Id"
+  item_getter = "ir::set_a::get($fun, $id)"
+  id_getter = "ir::set_a::Obj::id($item)"
+  iterator = "ir::set_a::iter($fun)"
+  var_prefix = "set_a"
+  new_objs = "$objs.set_a"
+end
+
+set SetB:
+  item_type = "ir::set_b::Obj"
+  id_type = "ir::set_b::Id"
+  item_getter = "ir::set_b::get($fun, $id)"
+  id_getter = "ir::set_b::Obj::id($item)"
+  iterator = "ir::set_b::iter($fun)"
+  var_prefix = "set_b"
+  new_objs = "$objs.set_b"
+end
+
+set BOfA($a in SetA) subsetof SetB:
+  item_type = "ir::set_b::Obj"
+  id_type = "ir::set_b::Id"
+  item_getter = "ir::set_b::get($fun, $id)"
+  id_getter = "ir::set_b::Obj::id($item)"
+  iterator = "ir::b_of_a::iter($fun, ir::set_a::Obj::id($a))"
+  var_prefix = "b_of_a"
+  new_objs = "$objs.b_of_a"
+  from_superset = "ir::b_of_a::from_superset($fun, $a, $item)"
+  reverse forall $b in SetB = "ir::b_of_a::reverse($fun, $b.id())"
+end
+
+set SetC:
+  item_type = "ir::set_c::Obj"
+  id_type = "ir::set_c::Id"
+  item_getter = "ir::set_c::get($fun, $id)"
+  id_getter = "ir::set_c::Obj::id($item)"
+  iterator = "ir::set_c::iter($fun)"
+  var_prefix = "set_c"
+  new_objs = "$objs.set_c"
+end
+
+set COfB($b in SetB) subsetof SetC:
+  item_type = "ir::set_c::Obj"
+  id_type = "ir::set_c::Id"
+  item_getter = "ir::set_c::get($fun, $id)"
+  id_getter = "ir::set_c::Obj::id($item)"
+  iterator = "ir::c_of_b::iter($fun, ir::set_b::Obj::id($b))"
+  var_prefix = "c_of_b"
+  new_objs = "$objs.c_of_b"
+  from_superset = "ir::c_of_b::from_superset($fun, $b, $item)"
+  reverse forall $c in SetC = "ir::c_of_b::reverse($fun, $c.id())"
+end
+
+define enum foo($lhs in SetC, $rhs in SetC):
+  value A:
+  value B:
+  antisymmetric: A -> B
+end
+
+define integer bar($b in SetB): "&[0, 1]" end
+
+require forall $a in SetA:
+  forall $b_lhs in BOfA($a):
+    forall $b_rhs in BOfA($a):
+      forall $c_lhs in COfB($b_lhs):
+        forall $c_rhs in COfB($b_rhs):
+          foo($c_lhs, $c_rhs) is A || bar($b_lhs) > bar($b_rhs)
+
+

--- a/telamon-gen/src/constraint.rs
+++ b/telamon-gen/src/constraint.rs
@@ -144,7 +144,7 @@ fn gen_flat_filter(
             .chain(foralls.iter().flat_map(|set| set.reverse_constraint()))
             .filter(|s| s.arg().map(|v| v == var).unwrap_or(false))
             .map(|s| unwrap!(s.def().arg()))
-            .any(|s| !given_set.is_subset_of(s));
+            .any(|s| !given_set.is_subset_of(&s));
         if is_used {
             input_set_constraints.push((var, subset));
         } else {

--- a/telamon-gen/src/print/runtime/integer_domain.rs
+++ b/telamon-gen/src/print/runtime/integer_domain.rs
@@ -23,6 +23,7 @@ pub fn get() -> TokenStream {
                 let start = new_universe.binary_search(&self.min(self_universe))
                     .unwrap_or_else(|x| x);
                 let len = new_universe.binary_search(&self.max(self_universe))
+                    .map(|x| x + 1)
                     .unwrap_or_else(|x| x) - start;
                 let enabled_values = ((1 << len) - 1) << start;
                 NumericSet { enabled_values }

--- a/telamon-gen/src/print/runtime/integer_set.rs
+++ b/telamon-gen/src/print/runtime/integer_set.rs
@@ -165,5 +165,14 @@ pub fn get() -> TokenStream {
                 eq.into_num_set(eq_universe, universe)
             }
         }
+
+        impl std::ops::BitOr for NumericSet {
+            type Output = Self;
+
+            /// Computes the union oftwo sets with the same universe.
+            fn bitor(self, rhs: Self) -> Self {
+                NumericSet { enabled_values: self.enabled_values | rhs.enabled_values }
+            }
+        }
     }
 }

--- a/tests/common/fake.rs
+++ b/tests/common/fake.rs
@@ -48,10 +48,8 @@ impl device::Device for Device {
             Operator::TmpLd(..)
             | Operator::TmpSt(..)
             | Operator::BinOp(ir::BinOp::Add, ..) => true,
-            Operator::Ld(ref t, _, ref pattern) => pattern.is_consecutive(dim.id(), t),
-            Operator::St(_, ref operand, _, ref pattern) => {
-                pattern.is_consecutive(dim.id(), &operand.t())
-            }
+            Operator::Ld(.., ref pattern) => pattern.is_layout_dimension(dim.id()),
+            Operator::St(.., ref pattern) => pattern.is_layout_dimension(dim.id()),
             _ => false,
         }
     }
@@ -59,7 +57,7 @@ impl device::Device for Device {
     fn max_vectorization(&self, _: &ir::Operator) -> [u32; 2] {
         // No need to discriminate on the operator since this is already handled by
         // `can_vectorize`.
-        [4, 8]
+        [8, 4]
     }
 
     fn has_vector_registers(&self) -> bool {

--- a/tools/bench_perf_model/memory.rs
+++ b/tools/bench_perf_model/memory.rs
@@ -40,9 +40,9 @@ impl PerfModelTest for L1LinesPressure {
         let d2_1 = builder.open_mapped_dim(&d2_0);
         let d3 = builder.open_dim_ex(ir::Size::new_const(UNROLL), DimKind::UNROLL);
         let strides = vec![
-            (&d3, ir::Size::new_const(THREAD_Y * THREAD_X * 32 * 4)),
-            (&d1_1, ir::Size::new_const(THREAD_X * 32 * 4)),
             (&d2_1, ir::Size::new_const(STRIDE * 4)),
+            (&d1_1, ir::Size::new_const(THREAD_X * 32 * 4)),
+            (&d3, ir::Size::new_const(THREAD_Y * THREAD_X * 32 * 4)),
         ];
         let pattern = builder.tensor_access_pattern(None, strides.clone());
         let addr = builder.induction_var(&"array", strides);
@@ -101,9 +101,9 @@ impl PerfModelTest for L2LinesPressure {
         let d2_1 = builder.open_mapped_dim(&d2_0);
         let d3 = builder.open_dim_ex(ir::Size::new_const(UNROLL), DimKind::UNROLL);
         let strides = vec![
-            (&d3, ir::Size::new_const(THREAD_Y * THREAD_X * 8 * 4)),
-            (&d1_1, ir::Size::new_const(THREAD_X * 8 * 4)),
             (&d2_1, ir::Size::new_const(STRIDE * 4)),
+            (&d1_1, ir::Size::new_const(THREAD_X * 8 * 4)),
+            (&d3, ir::Size::new_const(THREAD_Y * THREAD_X * 8 * 4)),
         ];
         let pattern = builder.tensor_access_pattern(None, strides.clone());
         let addr = builder.induction_var(&"array", strides);
@@ -339,9 +339,9 @@ impl PerfModelTest for VectorSharedReplay {
         let pattern = builder.tensor_access_pattern(
             mem.into(),
             vec![
-                (&d0, ir::Size::new_const(4 * 4 * 32)),
-                (&d1, ir::Size::new_const(4 * 4)),
                 (&d3_0, ir::Size::new_const(4)),
+                (&d1, ir::Size::new_const(4 * 4)),
+                (&d0, ir::Size::new_const(4 * 4 * 32)),
             ],
         );
         let val = builder.ld(ir::Type::F(32), &addr, pattern);


### PR DESCRIPTION
This change exposes memory layouts to the search space. A memory layout
has a set of dimensions. A `rank` variable specifies the order or the
layout dimensions. It is currently fixed but will ater be dynamic.

This change then express vectorization constraints in term of `rank`. It
also adds a test in telamon-gen and fixes minor errors in code paths
that were unused before.

**Merging in a separate branch until we get the paper done**