### PR TITLE
Fix Cuda Characterization

### DIFF
--- a/src/device/cuda/characterize/gpu.rs
+++ b/src/device/cuda/characterize/gpu.rs
@@ -245,7 +245,10 @@ pub fn performance_desc(executor: &Executor, gpu: &mut cuda::Gpu) {
     let syncthread_end_latency =
         instruction::syncthread_end_latency(gpu, executor, addf32_lat);
     if syncthread_end_latency > std::f64::EPSILON {
-        warn!("syncthread end latency not taken into account: {}", syncthread_end_latency);
+        warn!(
+            "syncthread end latency not taken into account: {}",
+            syncthread_end_latency
+        );
     }
     gpu.loop_end_latency = instruction::loop_iter_end_latency(gpu, executor, addf32_lat);
     gpu.loop_iter_overhead = instruction::loop_iter_overhead(gpu, executor);

--- a/src/device/cuda/characterize/gpu.rs
+++ b/src/device/cuda/characterize/gpu.rs
@@ -244,7 +244,9 @@ pub fn performance_desc(executor: &Executor, gpu: &mut cuda::Gpu) {
     let addf32_lat = gpu.add_f32_inst.latency;
     let syncthread_end_latency =
         instruction::syncthread_end_latency(gpu, executor, addf32_lat);
-    assert!(syncthread_end_latency < std::f64::EPSILON);
+    if syncthread_end_latency > std::f64::EPSILON {
+        warn!("syncthread end latency not taken into account: {}", syncthread_end_latency);
+    }
     gpu.loop_end_latency = instruction::loop_iter_end_latency(gpu, executor, addf32_lat);
     gpu.loop_iter_overhead = instruction::loop_iter_overhead(gpu, executor);
     gpu.loop_init_overhead = cuda::InstDesc {


### PR DESCRIPTION
This PR fixes two bugs:
- it handles the case where the `cuda_gpus.json` file was missing
- it emits a warning instead of failing when  the syncthread latency is not 0. This does not impact correctness but we could improve the model by taking this lantency into account. 