### PR TITLE
Add support for loop-carried variables.

### DIFF
--- a/src/codegen/variable.rs
+++ b/src/codegen/variable.rs
@@ -176,8 +176,10 @@ pub fn wrap_variables<'a>(space: &'a SearchSpace) -> Vec<Variable<'a>> {
             .as_ref()
             .map(|alias| alias.find_instantiation_dims(space))
             .unwrap_or_default();
-        debug!("instantiating {:?} on {:?} with alias {:?}",
-               variable, instantiation_dims, alias_opt);
+        debug!(
+            "instantiating {:?} on {:?} with alias {:?}",
+            variable, instantiation_dims, alias_opt
+        );
         // Register instantiation dimensions in preceeding aliases.
         if let Some(ref alias) = alias_opt {
             for (&iter_dim, &size) in &instantiation_dims {

--- a/src/codegen/variable.rs
+++ b/src/codegen/variable.rs
@@ -3,6 +3,7 @@ use codegen;
 use indexmap::IndexMap;
 use ir;
 use search_space::*;
+use std;
 use utils::*;
 
 /// Wraps an `ir::Variable` to expose specified decisions.
@@ -41,6 +42,7 @@ impl<'a> Variable<'a> {
 }
 
 /// Indicates how a variable aliases with another.
+#[derive(Debug)]
 pub struct Alias {
     other_variable: ir::VarId,
     dim_mapping: HashMap<ir::DimId, Option<ir::DimId>>,
@@ -70,14 +72,12 @@ impl Alias {
     }
 
     /// Creates a new alias that takes point-to-point the values of another variable.
-    fn new_dim_map(
-        other_variable: ir::VarId,
-        mapping_ids: &[ir::DimMappingId],
-        fun: &ir::Function,
-    ) -> Self {
-        let (dim_mapping, reverse_mapping) = mapping_ids
-            .iter()
-            .map(|&id| fun.dim_mapping(id).dims())
+    fn new_dim_map<IT>(other_variable: ir::VarId, dim_mapping: IT) -> Self
+    where
+        IT: IntoIterator<Item = [ir::DimId; 2]>,
+    {
+        let (dim_mapping, reverse_mapping) = dim_mapping
+            .into_iter()
             .map(|[lhs, rhs]| ((lhs, Some(rhs)), (rhs, lhs)))
             .unzip();
         Alias {
@@ -105,19 +105,40 @@ impl Alias {
 
 /// Generates variables aliases.
 fn generate_aliases(space: &SearchSpace) -> HashMap<ir::VarId, Option<Alias>> {
-    space
+    let fun = space.ir_instance();
+    let mut aliases: HashMap<_, _> = space
         .ir_instance()
         .variables()
-        .map(|var| {
-            let alias = match var.def() {
-                ir::VarDef::Inst(..) => None,
-                ir::VarDef::Last(alias, dims) => Some(Alias::new_last(*alias, dims)),
-                ir::VarDef::DimMap(alias, mappings) => {
-                    Some(Alias::new_dim_map(*alias, mappings, space.ir_instance()))
-                }
-            };
-            (var.id(), alias)
-        }).collect()
+        .map(|var| (var.id(), None))
+        .collect();
+    for var in space.ir_instance().variables() {
+        let alias = match var.def() {
+            ir::VarDef::Inst(..) => continue,
+            ir::VarDef::Last(alias, dims) => Alias::new_last(*alias, dims),
+            ir::VarDef::DimMap(alias, mappings) => {
+                let mappings = mappings.iter().map(|&id| fun.dim_mapping(id).dims());
+                Alias::new_dim_map(*alias, mappings)
+            }
+            ir::VarDef::Fby { init, prev, .. } => {
+                // Alias with the intruction that produce prev. We known it cannot have
+                // another alias because loop-carried variables can only be used in a
+                // single `fby`.
+                let prev = unwrap!(*prev);
+                let prod_point = fun.variable(prev).def().production_inst(fun);
+                let prod_var = unwrap!(fun.inst(prod_point.inst).result_variable());
+                let mapping = prod_point.dim_map.iter().map(|(&lhs, &rhs)| [rhs, lhs]);
+                let alias = Some(Alias::new_dim_map(var.id(), mapping));
+                let alias_entry = unwrap!(aliases.get_mut(&prod_var));
+                assert!(std::mem::replace(alias_entry, alias).is_none());
+                // Also alias with init.
+                Alias::new_last(*init, &[])
+            }
+        };
+        // Set the alias and check no alias was already set.
+        let alias_entry = unwrap!(aliases.get_mut(&var.id()));
+        assert!(std::mem::replace(alias_entry, Some(alias)).is_none());
+    }
+    aliases
 }
 
 /// Sort variables by aliasing order.
@@ -146,6 +167,7 @@ fn sort_variables<'a>(
 /// alias after the variable they depend on.
 pub fn wrap_variables<'a>(space: &'a SearchSpace) -> Vec<Variable<'a>> {
     let aliases = generate_aliases(space);
+    debug!("aliases: {:?}", aliases);
     // Generate the wrappers and record the dimensions along which variables are
     // instantiated. We use an `IndexMap` so that the insertion order is preserved.
     let mut wrapped_vars = IndexMap::new();
@@ -154,6 +176,8 @@ pub fn wrap_variables<'a>(space: &'a SearchSpace) -> Vec<Variable<'a>> {
             .as_ref()
             .map(|alias| alias.find_instantiation_dims(space))
             .unwrap_or_default();
+        debug!("instantiating {:?} on {:?} with alias {:?}",
+               variable, instantiation_dims, alias_opt);
         // Register instantiation dimensions in preceeding aliases.
         if let Some(ref alias) = alias_opt {
             for (&iter_dim, &size) in &instantiation_dims {
@@ -211,10 +235,10 @@ mod tests {
         let mut builder = helper::Builder::new(&signature, &device);
         // This code builds the following function:
         // ```pseudocode
-        // for i in 0..16:
-        //   for j in 0..16:
+        // for i in 0..4:
+        //   for j in 0..8:
         //      src[i] = 0;
-        // for i in 0..16:
+        // for i in 0..4:
         //   dst = src[i]
         // ```
         // where all loops are unrolled.

--- a/src/helper/builder.rs
+++ b/src/helper/builder.rs
@@ -255,6 +255,24 @@ impl<'a> Builder<'a> {
             .unwrap()
     }
 
+    /// Creates a variable initialized with the value of `init` and then takes a value
+    /// produced at the last iteration of `dims`. The loop-carried variable must be with
+    /// `set_loop_carried_variable`.
+    pub fn create_fby_variable(
+        &mut self,
+        init: ir::VarId,
+        dims: &[&LogicalDim]
+    ) -> ir::VarId {
+        let dims = dims.iter().flat_map(|dim| dim.iter()).collect();
+        unwrap!(self.function.add_variable(ir::VarDef::Fby { init, prev: None, dims }))
+    }
+
+    /// Set the loop-carried dependency `loop_carried` of a variable `fby` created with
+    /// `create_fby_variable`.
+    pub fn set_loop_carried_variable(&mut self, fby: ir::VarId, loop_carried: ir::VarId) {
+        unwrap!(self.function.set_loop_carried_variable(fby, loop_carried))
+    }
+
     /// Applies an action on the function.
     pub fn action(&mut self, action: Action) {
         self.actions.push(action)

--- a/src/helper/builder.rs
+++ b/src/helper/builder.rs
@@ -261,10 +261,14 @@ impl<'a> Builder<'a> {
     pub fn create_fby_variable(
         &mut self,
         init: ir::VarId,
-        dims: &[&LogicalDim]
+        dims: &[&LogicalDim],
     ) -> ir::VarId {
         let dims = dims.iter().flat_map(|dim| dim.iter()).collect();
-        unwrap!(self.function.add_variable(ir::VarDef::Fby { init, prev: None, dims }))
+        unwrap!(self.function.add_variable(ir::VarDef::Fby {
+            init,
+            prev: None,
+            dims
+        }))
     }
 
     /// Set the loop-carried dependency `loop_carried` of a variable `fby` created with

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -417,7 +417,7 @@ impl<'a, L> Function<'a, L> {
     pub(super) fn register_var_use(
         &mut self,
         var: ir::VarId,
-        mut stmt: ir::statement::IdOrMut<'a, '_,  L>,
+        mut stmt: ir::statement::IdOrMut<'a, '_, L>,
     ) {
         stmt.get_statement(self).register_used_var(var);
         let pred = {
@@ -775,7 +775,12 @@ impl<'a> Function<'a> {
         }
         self.insts[st_inst].lower_layout(st_index, st_pattern, VecSet::new(st_layout));
         self.insts[ld_inst].lower_layout(ld_index, ld_pattern, VecSet::new(ld_layout));
-        trace!("lowered layout for {:?} with st={:?} and ld={:?}", id, st_inst, ld_inst);
+        trace!(
+            "lowered layout for {:?} with st={:?} and ld={:?}",
+            id,
+            st_inst,
+            ld_inst
+        );
         layout_dim_ids
     }
 }

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -125,7 +125,7 @@ impl<'a, L> Function<'a, L> {
         mem_access_layout: VecSet<ir::LayoutDimId>,
     ) -> Result<ir::Instruction<'a, L>, ir::Error> {
         // Create and check the instruction.
-        let inst = ir::Instruction::new(op, id, iter_dims, mem_access_layout, self)?;
+        let mut inst = ir::Instruction::new(op, id, iter_dims, mem_access_layout, self)?;
         // Register the instruction in iteration dimensions.
         for &dim in inst.iteration_dims() {
             self.dim_mut(dim).add_iterated(id);
@@ -138,8 +138,9 @@ impl<'a, L> Function<'a, L> {
             self.mem_blocks.register_use(mem_id, id);
         }
         // Update the usepoint of all variables
-        for &var_id in inst.used_vars() {
-            self.variables[var_id].add_use(id.into());
+        for var_id in inst.used_vars().clone() {
+            let stmt: &mut ir::Statement<L> = &mut inst;
+            self.register_var_use(var_id, stmt.into());
         }
         Ok(inst)
     }
@@ -256,6 +257,11 @@ impl<'a, L> Function<'a, L> {
     /// Returns a `Variable` given its id.
     pub fn variable(&self, id: ir::VarId) -> &ir::Variable {
         &self.variables[id]
+    }
+
+    /// Returns a mutable reference to a `Variable` given its id.
+    pub(super) fn variable_mut(&mut self, id: ir::VarId) -> &mut ir::Variable {
+        &mut self.variables[id]
     }
 
     /// Adds a variable to the function. Also register its definition into the relevant instruction
@@ -405,6 +411,37 @@ impl<'a, L> Function<'a, L> {
             self.dim_mut(dim).register_dim_mapping(&mapping);
         }
         mapping
+    }
+
+    /// Registers that `var` is used by `stmt`.
+    pub(super) fn register_var_use(
+        &mut self,
+        var: ir::VarId,
+        mut stmt: ir::statement::IdOrMut<'a, '_,  L>,
+    ) {
+        stmt.get_statement(self).register_used_var(var);
+        let pred = {
+            let var = self.variable_mut(var);
+            var.add_use(stmt.id());
+            var.def().origin()
+        };
+        if let Some(var) = pred {
+            self.register_var_use(var, stmt);
+        }
+    }
+
+    /// Sets the loop-carried dependency of a `fby` variable.
+    pub fn set_loop_carried_variable(
+        &mut self,
+        fby: ir::VarId,
+        loop_carried: ir::VarId,
+    ) -> Result<(), ir::Error> {
+        let mut fby = unwrap!(self.variables.remove(fby));
+        fby.set_loop_carried_variable(loop_carried);
+        fby.def().check(self)?;
+        fby.register(self);
+        self.variables.set_lazy(fby.id(), fby);
+        Ok(())
     }
 
     /// Returns a layout dimension given its ID.

--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -246,4 +246,8 @@ impl<'a, L> Statement<'a, L> for Instruction<'a, L> {
     fn register_defined_var(&mut self, var: ir::VarId) {
         self.defined_vars.insert(var);
     }
+
+    fn register_used_var(&mut self, var: ir::VarId) {
+        self.used_vars.insert(var);
+    }
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -76,6 +76,7 @@ pub struct NewObjs {
     pub def_statements: Vec<(VarId, StmtId)>,
     pub var_dims: Vec<(VarId, DimId)>,
     pub var_mappings: Vec<(VarId, DimMappingId)>,
+    pub predecessors: Vec<(VarId, VarId)>,
     pub layout_dims: Vec<LayoutDimId>,
     pub mem_layout_dims: Vec<LayoutDimId>,
     pub actual_layout_dims: Vec<(LayoutDimId, DimId)>,
@@ -149,6 +150,8 @@ impl NewObjs {
             .extend(var.dimensions().iter().map(|&dim| (var.id(), dim)));
         self.var_mappings
             .extend(var.def().mapped_dims().map(|id| (var.id(), id)));
+        self.predecessors
+            .extend(var.predecessors().iter().map(|&id| (var.id(), id)));
     }
 
     /// Adds a layout dimension.
@@ -305,6 +308,11 @@ where
     /// slice. Holes are skipped.
     pub fn iter_mut<'a>(&'a mut self) -> impl Iterator<Item = &'a mut T> {
         self.vec.iter_mut().filter_map(Option::as_mut)
+    }
+
+    /// Returns the value stored at a given index and replaces it with a hole.
+    pub fn remove(&mut self, index: I) -> Option<T> {
+        std::mem::replace(&mut self.vec[index.into()], None)
     }
 }
 

--- a/src/ir/statement.rs
+++ b/src/ir/statement.rs
@@ -26,7 +26,8 @@ impl From<ir::DimId> for StmtId {
     }
 }
 
-/// Either a `StmtId` or a mutable reference to a statement.
+/// Either a `StmtId` or a mutable reference to a statement. This is usefull to abstract
+/// over a statement that is either register in the functions or being created.
 pub enum IdOrMut<'a: 'b, 'b, L: 'b> {
     Id(StmtId),
     Mut(&'b mut Statement<'a, L>),

--- a/src/ir/variable.rs
+++ b/src/ir/variable.rs
@@ -107,7 +107,9 @@ impl Variable {
     /// Registers the variable in the structures it references in the function.
     pub fn register<L>(&self, fun: &mut ir::Function<L>) {
         // If the variable is not fully built, register will be called again later.
-        if !self.def().is_complete() { return; }
+        if !self.def().is_complete() {
+            return;
+        }
         for &def_point in &self.def_points {
             fun.statement_mut(def_point).register_defined_var(self.id());
         }
@@ -377,10 +379,18 @@ impl VarDef {
     pub fn predecessors(&self) -> VecSet<ir::VarId> {
         match self {
             VarDef::Inst { .. } => VecSet::default(),
-            VarDef::Last(pred, ..) |
-            VarDef::DimMap(pred, ..) |
-            VarDef::Fby { init: pred, prev: None, .. } => VecSet::new(vec![*pred]),
-            VarDef::Fby { init, prev: Some(prev), .. } => VecSet::new(vec![*init, *prev]),
+            VarDef::Last(pred, ..)
+            | VarDef::DimMap(pred, ..)
+            | VarDef::Fby {
+                init: pred,
+                prev: None,
+                ..
+            } => VecSet::new(vec![*pred]),
+            VarDef::Fby {
+                init,
+                prev: Some(prev),
+                ..
+            } => VecSet::new(vec![*init, *prev]),
         }
     }
 

--- a/src/model/level.rs
+++ b/src/model/level.rs
@@ -26,8 +26,8 @@ pub struct Level {
     /// The latency overhead at the end of each iteration.
     pub end_latency: FastBound,
     /// Dependencies between iterations of the level. A dependency is represented by
-    /// the code point ID where the edge originates and goes to and by its latency.
-    pub back_edges: Vec<(usize, FastBound)>,
+    /// `(start_point, end_point, latency)`.
+    pub back_edges: Vec<(usize, usize, FastBound)>,
     /// The latency of all the iterations of the level.
     pub repeated_latency: Option<FastBound>,
 }

--- a/src/search_space/variable.exh
+++ b/src/search_space/variable.exh
@@ -32,6 +32,46 @@ set UseStatements($var in Variables) subsetof Statements:
   new_objs = "$objs.use_statements"
 end
 
+set UseInsts($var in Variables) subsetof Instructions:
+  item_type = "ir::Instruction"
+  id_type = "ir::InstId"
+  item_getter = "$fun.inst($id)"
+  id_getter = "$item.id()"
+  iterator = "$var.use_points().flat_map(|id| $fun.statement(id).as_inst())"
+  from_superset = "if $item.used_vars().contains(&$var.id()) { Some($item) } else { None }"
+  reverse forall $inst in Instructions = "$inst.used_vars().iter().map(|&id| $fun.variable(id))"
+  var_prefix = "use"
+  new_objs = "$objs.use_insts"
+end
+
+// Forbid implicit broadcast of the fby intialization variable.
+require forall $var in Variables:
+  forall $inst in UseInsts($var):
+    forall $dim in IterationDims($inst):
+      forall $def in DefStatements($var):
+        "!$var.def().is_fby() || $var.dimensions().contains(&$dim.id())"
+        || order($dim, $def) is OUTER
+
+/// Lists variables $var depends of.
+set PredecessorVars($var in Variables) subsetof Variables:
+  item_type = "ir::Variable"
+  id_type = "ir::VarId"
+  item_getter = "$fun.variable($id)"
+  id_getter = "$item.id()"
+  iterator = "$var.predecessors().iter().map(|&id| $fun.variable(id))"
+  from_superset = "if $var.predecessors().contains(&$item.id()) { Some($item) } else { None }"
+  reverse forall $var in Variables = "$var.successors().iter().map(|&id| $fun.variable(id))"
+  var_prefix = "predecessor"
+  new_objs = "$objs.predecessors"
+end
+
+// Ensure the `fby` and its `prev` variable can be stored in the same place.
+require forall $fby in Variables:
+  forall $pred in PredecessorVars($fby):
+    forall $use in UseStatements($fby):
+      forall $def in DefStatements($pred):
+        "!$fby.def().is_fby_prev($pred.id())" || order($use, $def) is BEFORE
+
 // Enforce data dependencies.
 require forall $var in Variables:
   forall $def in DefStatements($var):
@@ -49,11 +89,6 @@ set VarDims($var in Variables) subsetof Dimensions:
   reverse forall $dim in Dimensions = "$dim.inner_vars().iter().map(|&id| $fun.variable(id))"
   new_objs = "$objs.var_dims"
 end
-
-require forall $var in Variables:
-  forall $use in UseStatements($var):
-    forall $dim in VarDims($var):
-      order($dim, $use) is OUTER
 
 /// Specifies where to store a variable.
 define enum memory_space($var in Variables):

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -624,7 +624,10 @@ fn simple_fby() {
     builder.mov(&res);
 
     let space = builder.get();
-    assert_eq!(space.domain().get_order(init.into(), dim[0].into()), Order::BEFORE);
+    assert_eq!(
+        space.domain().get_order(init.into(), dim[0].into()),
+        Order::BEFORE
+    );
     // Try to generate a fully specified candidate.
     gen_best(&context, space);
 }
@@ -648,7 +651,10 @@ fn no_additional_fby_dimension() {
     builder.set_loop_carried_variable(fby, acc_var);
     let space = builder.get();
     // Additional dimensions outside `acc` must also be outside `init`.
-    assert_eq!(space.domain().get_order(init.into(), other_dim[0].into()), Order::INNER);
+    assert_eq!(
+        space.domain().get_order(init.into(), other_dim[0].into()),
+        Order::INNER
+    );
     // Try to generate a fully specified candidate.
     gen_best(&context, space);
 }


### PR DESCRIPTION
This PR adds support for loop-carried variables. They take the form of a `VarDef::Fby` operator.

Suggested review order:
- `src/ir/variables.rs`
- `src/search_space/*`
- `src/ir/*`
- all the rest.

**Merge into variable instead of master**