### PR TITLE
Make fake context compatible with any underlying device

### DIFF
--- a/src/device/fake.rs
+++ b/src/device/fake.rs
@@ -1,0 +1,107 @@
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use codegen;
+use explorer::Candidate;
+use ir;
+
+use super::{
+    ArgMap, ArrayArgument, AsyncCallback, AsyncEvaluator, Context, Device, EvalMode,
+    ScalarArgument,
+};
+
+/// A fake context to use when we don't actually care about the
+/// evaluation results.  This wraps any device for the performance
+/// model, but always return 1 for all evaluation results.
+#[derive(Debug, Default)]
+pub struct FakeContext<D> {
+    device: D,
+    parameters: HashMap<String, Option<u32>>,
+}
+
+impl<D: Device> FakeContext<D> {
+    pub fn new(device: D) -> Self {
+        FakeContext {
+            device,
+            parameters: HashMap::new(),
+        }
+    }
+}
+
+impl<D: Device> Context for FakeContext<D> {
+    fn device(&self) -> &Device {
+        &self.device
+    }
+
+    fn evaluate(&self, _: &codegen::Function, _: EvalMode) -> Result<f64, ()> {
+        Ok(1.0)
+    }
+
+    fn benchmark(&self, _: &codegen::Function, num_samples: usize) -> Vec<f64> {
+        vec![1.0; num_samples]
+    }
+
+    fn param_as_size(&self, name: &str) -> Option<u32> {
+        self.parameters[name]
+    }
+
+    fn async_eval<'b, 'c>(
+        &self,
+        _: usize,
+        _: EvalMode,
+        inner: &(Fn(&mut AsyncEvaluator<'b, 'c>) + Sync),
+    ) {
+        struct FakeEvaluator<'a, 'b> {
+            phantom: PhantomData<(&'a (), &'b ())>,
+        }
+
+        impl<'a, 'b, 'c> AsyncEvaluator<'a, 'c> for FakeEvaluator<'a, 'b>
+        where
+            'a: 'b,
+            'c: 'b,
+        {
+            fn add_kernel(
+                &mut self,
+                candidate: Candidate<'a>,
+                callback: AsyncCallback<'a, 'c>,
+            ) {
+                codegen::Function::build(&candidate.space);
+                callback.call(candidate, 1.0);
+            }
+        }
+
+        inner(&mut FakeEvaluator {
+            phantom: PhantomData,
+        });
+    }
+}
+
+impl<D: Device> ArgMap for FakeContext<D> {
+    type Array = FakeArray;
+
+    fn bind_scalar<S: ScalarArgument>(&mut self, param: &ir::Parameter, value: S) {
+        assert_eq!(param.t, S::t());
+
+        self.parameters.insert(param.name.clone(), value.as_size());
+    }
+
+    fn bind_array<S: ScalarArgument>(
+        &mut self,
+        _: &ir::Parameter,
+        _: usize,
+    ) -> Arc<Self::Array> {
+        Arc::new(FakeArray)
+    }
+}
+
+/// A fake array implementation which doesn't read or write anything.
+pub struct FakeArray;
+
+impl ArrayArgument for FakeArray {
+    fn read_i8(&self) -> Vec<i8> {
+        Vec::new()
+    }
+
+    fn write_i8(&self, _: &[i8]) {}
+}

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,5 +1,6 @@
 //! Code generation and candidate evaluation for specific targets.
 pub mod cuda;
+pub mod fake;
 #[cfg(feature = "mppa")]
 pub mod mppa;
 pub mod x86;


### PR DESCRIPTION
This patch extract the FakeContext (and associated helper classes) from
the tests into telamon::device directly, and adds proper support for
dimension sizes (parameters) which was previously ignored due to the
test use case.  This makes it a general context for use when we want to
be able to manipulate candidates, but don't actually need to evaluate
the resulting implementations.

It can be used as follows:

```rust
extern crate serde_json;

use telamon::device::{cuda::Gpu, fake::FakeContext};

// cuda_gpus_path should contain the path to the cuda_gpus.json file to
// use.
let gpu: Gpu = unwrap!(serde_json::from_reader(
    &unwrap!(std::fs::File::open(cuda_gpus_path))));
let mut context = FakeContext::new(gpu);
```

telamon:
 * src/device/fake.rs: Added.
 * src/device/mod.rs: Expose the new `fake` module.
 * tests/common/fake.rs: Use the `FakeContext` from telamon::device.