### PR TITLE
Update the builder to use variables.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
     - master
 language: rust
 cache: cargo
-sudo: false
+sudo: required
 rust:
   - stable
 addons:

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -83,7 +83,7 @@ impl MMSig {
         let st_n = builder.open_mapped_dim(&acc_n);
         let (ptr, pattern) =
             builder.tensor_access(&"c", None, DATA_TYPE, &[&st_m, &st_n]);
-        let st = builder.st(&ptr, &Last(acc, &[&acc_k]), pattern);
+        let st = builder.st(&ptr, &helper::Last(acc, &[&acc_k]), pattern);
         // order for correctness.
         builder.order(&st, &acc_k, Order::AFTER);
         builder.get()

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -74,14 +74,16 @@ impl MMSig {
             &[(&ld_b_k, &acc_k), (&ld_b_n, &acc_n)],
             ir::DimMapScope::Global(()),
         );
-        let acc = builder.mad(&a_op, &b_op, &helper::Reduce(init));
+        let fby = builder.create_fby_variable(init, &[&acc_k]);
+        let acc = builder.mad(&a_op, &b_op, &fby);
+        builder.set_loop_carried_variable(fby, acc);
 
         builder.close_dim(&acc_k);
         let st_m = builder.open_mapped_dim(&acc_m);
         let st_n = builder.open_mapped_dim(&acc_n);
         let (ptr, pattern) =
             builder.tensor_access(&"c", None, DATA_TYPE, &[&st_m, &st_n]);
-        let st = builder.st(&ptr, &acc, pattern);
+        let st = builder.st(&ptr, &Last(acc, &[&acc_k]), pattern);
         // order for correctness.
         builder.order(&st, &acc_k, Order::AFTER);
         builder.get()

--- a/kernels/src/linalg.rs
+++ b/kernels/src/linalg.rs
@@ -4,8 +4,8 @@ use kernel::Kernel;
 use ndarray::{Array1, Array2, Array3, ArrayD};
 use rand;
 use telamon::explorer::Candidate;
+use telamon::helper::*;
 use telamon::helper::tensor::*;
-use telamon::helper::{self, Builder, SignatureBuilder};
 use telamon::ir::DimMapScope::Global as GlobalScope;
 use telamon::search_space::*;
 use telamon::{device, ir};
@@ -54,7 +54,7 @@ where
         signature: &'b ir::Signature,
         ctx: &'b device::Context,
     ) -> Vec<Candidate<'b>> {
-        let tiling = helper::TilingPattern::infer_pattern(self.n as u32, &[1024, 4]);
+        let tiling = TilingPattern::infer_pattern(self.n as u32, &[1024, 4]);
         let mut builder = Builder::new(signature, ctx.device());
 
         let ld_x = self.x.load(vec![tiling.clone()], &mut builder);
@@ -63,7 +63,7 @@ where
         let x_op = ld_x.dim_map(&[&mad_dim], GlobalScope(()), &mut builder);
         let y_op = ld_y.dim_map(&[&mad_dim], GlobalScope(()), &mut builder);
         let mad = VirtualTensor::new(builder.mad(&x_op, &"alpha", &y_op), vec![mad_dim]);
-        mad.store(&self.z, &mut builder);
+        mad.store(&self.z, &[], &mut builder);
         vec![build_candidate(builder.get(), ctx)]
     }
 
@@ -136,8 +136,8 @@ where
         signature: &'b ir::Signature,
         ctx: &'b device::Context,
     ) -> Vec<Candidate<'b>> {
-        let m_tiling = helper::TilingPattern::infer_pattern(self.m as u32, &[128, 16]);
-        let n_tiling = helper::TilingPattern::infer_pattern(self.n as u32, &[128]);
+        let m_tiling = TilingPattern::infer_pattern(self.m as u32, &[128, 16]);
+        let n_tiling = TilingPattern::infer_pattern(self.n as u32, &[128]);
         let mut builder = Builder::new(&signature, ctx.device());
         let ld_x = self.x.load(vec![n_tiling.clone()], &mut builder);
         let ld_a = self.a.load(vec![m_tiling, n_tiling], &mut builder);
@@ -147,10 +147,12 @@ where
         let acc_dim_n = builder.open_mapped_dim(&ld_x[0]);
         let a_op = ld_a.dim_map(&[&acc_dim_m, &acc_dim_n], GlobalScope(()), &mut builder);
         let x_op = ld_x.dim_map(&[&acc_dim_n], GlobalScope(()), &mut builder);
-        let acc = builder.mad(&a_op, &x_op, &helper::Reduce(init));
+        let fby = builder.create_fby_variable(init, &[&acc_dim_n]);
+        let acc = builder.mad(&a_op, &x_op, &fby);
+        builder.set_loop_carried_variable(fby, acc);
         builder.close_dim(&acc_dim_n);
         let sum = VirtualTensor::new(acc, vec![acc_dim_m]);
-        let st_y = sum.store(&self.y, &mut builder);
+        let st_y = sum.store(&self.y, &[&acc_dim_n], &mut builder);
 
         builder.order(&acc_dim_n, &st_y.inst(), Order::BEFORE);
         // TODO(search_space): explore inst flags
@@ -240,9 +242,9 @@ impl<'a, S: Scalar> Kernel<'a> for Gesummv<'a, S> {
         signature: &'b ir::Signature,
         ctx: &'b device::Context,
     ) -> Vec<Candidate<'b>> {
-        let m_tiling = helper::TilingPattern::infer_pattern(self.m as u32, &[128, 16]);
-        let n_tiling = helper::TilingPattern::infer_pattern(self.n as u32, &[128]);
-        let mut builder = helper::Builder::new(&signature, ctx.device());
+        let m_tiling = TilingPattern::infer_pattern(self.m as u32, &[128, 16]);
+        let n_tiling = TilingPattern::infer_pattern(self.n as u32, &[128]);
+        let mut builder = Builder::new(&signature, ctx.device());
         let ld_x = self.x.load(vec![n_tiling.clone()], &mut builder);
         let ab_tiling = vec![m_tiling, n_tiling];
         let ld_a = self.a.load(ab_tiling.clone(), &mut builder);
@@ -255,13 +257,17 @@ impl<'a, S: Scalar> Kernel<'a> for Gesummv<'a, S> {
         let a_op = ld_a.dim_map(&[&acc_dim_m, &acc_dim_n], GlobalScope(()), &mut builder);
         let b_op = ld_b.dim_map(&[&acc_dim_m, &acc_dim_n], GlobalScope(()), &mut builder);
         let x_op = ld_x.dim_map(&[&acc_dim_n], GlobalScope(()), &mut builder);
-        let acc_a = builder.mad(&a_op, &x_op, &helper::Reduce(init_a));
-        let acc_b = builder.mad(&b_op, &x_op, &helper::Reduce(init_b));
+        let fby_a = builder.create_fby_variable(init_a, &[&acc_dim_n]);
+        let acc_a = builder.mad(&a_op, &x_op, &fby_a);
+        builder.set_loop_carried_variable(fby_a, acc_a);
+        let fby_b = builder.create_fby_variable(init_b, &[&acc_dim_n]);
+        let acc_b = builder.mad(&b_op, &x_op, &fby_b);
+        builder.set_loop_carried_variable(fby_b, acc_b);
         builder.close_dim(&acc_dim_n);
-        let y_a = builder.mul(&acc_a, &"alpha");
-        let sum = builder.mad(&acc_b, &"beta", &y_a);
+        let y_a = builder.mul(&Last(acc_a, &[&acc_dim_n]), &"alpha");
+        let sum = builder.mad(&Last(acc_b, &[&acc_dim_n]), &"beta", &y_a);
         let sum = VirtualTensor::new(sum, vec![acc_dim_m]);
-        let st_y = sum.store(&self.y, &mut builder);
+        let st_y = sum.store(&self.y, &[&acc_dim_n], &mut builder);
 
         builder.order(&acc_dim_n, &y_a, Order::BEFORE);
         // TODO(search_space): explore inst flags
@@ -318,9 +324,9 @@ pub struct MatMulP {
     pub transpose_a: bool,
     pub transpose_b: bool,
     pub generic: bool,
-    pub m_tiling: Option<helper::TilingPattern>,
-    pub n_tiling: Option<helper::TilingPattern>,
-    pub k_tiling: Option<helper::TilingPattern>,
+    pub m_tiling: Option<TilingPattern>,
+    pub n_tiling: Option<TilingPattern>,
+    pub k_tiling: Option<TilingPattern>,
 }
 
 impl MatMulP {
@@ -396,7 +402,7 @@ impl<'a, S: Scalar> Kernel<'a> for MatMul<'a, S> {
         let m_tiling = infer_tiling(self.params.m, &self.params.m_tiling, &[32, 4]);
         let n_tiling = infer_tiling(self.params.n, &self.params.n_tiling, &[32, 4]);
         let k_tiling = infer_tiling(self.params.k, &self.params.k_tiling, &[32]);
-        let mut builder = helper::Builder::new(signature, ctx.device());
+        let mut builder = Builder::new(signature, ctx.device());
 
         let ld_a = self.a.load(vec![m_tiling, k_tiling.clone()], &mut builder);
         let ld_b = self.b.load(vec![k_tiling, n_tiling], &mut builder);
@@ -409,11 +415,13 @@ impl<'a, S: Scalar> Kernel<'a> for MatMul<'a, S> {
         let acc_dim_k = builder.open_mapped_dim(&ld_a[1]);
         let a_op = ld_a.dim_map(&[&acc_dim_m, &acc_dim_k], GlobalScope(()), &mut builder);
         let b_op = ld_b.dim_map(&[&acc_dim_k, &acc_dim_n], GlobalScope(()), &mut builder);
-        let acc = builder.mad(&a_op, &b_op, &helper::Reduce(acc_init));
+        let fby = builder.create_fby_variable(acc_init, &[&acc_dim_k]);
+        let acc = builder.mad(&a_op, &b_op, &fby);
+        builder.set_loop_carried_variable(fby, acc);
         builder.close_dim(&acc_dim_k);
 
         let acc = VirtualTensor::new(acc, vec![acc_dim_m, acc_dim_n]);
-        let st_c = acc.store(&self.c, &mut builder);
+        let st_c = acc.store(&self.c, &[&acc_dim_k], &mut builder);
 
         // Order for correctness.
         builder.order(&st_c.inst(), &acc_dim_k, Order::AFTER);
@@ -587,12 +595,12 @@ impl<'a, S: Scalar> Kernel<'a> for BatchMM<'a, S> {
         signature: &'b ir::Signature,
         ctx: &'b device::Context,
     ) -> Vec<Candidate<'b>> {
-        let m_tiling = helper::TilingPattern::infer_pattern(self.params.m as u32, &[64]);
-        let n_tiling = helper::TilingPattern::infer_pattern(self.params.n as u32, &[64]);
-        let k_tiling = helper::TilingPattern::infer_pattern(self.params.k as u32, &[64]);
+        let m_tiling = TilingPattern::infer_pattern(self.params.m as u32, &[64]);
+        let n_tiling = TilingPattern::infer_pattern(self.params.n as u32, &[64]);
+        let k_tiling = TilingPattern::infer_pattern(self.params.k as u32, &[64]);
         let batch_tiling =
-            helper::TilingPattern::infer_pattern(self.params.batch as u32, &[128]);
-        let mut builder = helper::Builder::new(signature, ctx.device());
+            TilingPattern::infer_pattern(self.params.batch as u32, &[128]);
+        let mut builder = Builder::new(signature, ctx.device());
         let a_tiling = vec![batch_tiling.clone(), m_tiling, k_tiling.clone()];
         let ld_a = self.a.load(a_tiling, &mut builder);
         let b_tiling = if self.params.batch_b {
@@ -625,11 +633,13 @@ impl<'a, S: Scalar> Kernel<'a> for BatchMM<'a, S> {
             };
             ld_b.dim_map(b_dims, GlobalScope(()), &mut builder)
         };
-        let acc = builder.mad(&a_op, &b_op, &helper::Reduce(acc_init));
+        let fby = builder.create_fby_variable(acc_init, &[&acc_dim_k]);
+        let acc = builder.mad(&a_op, &b_op, &fby);
+        builder.set_loop_carried_variable(fby, acc);
         builder.close_dim(&acc_dim_k);
 
         let acc = VirtualTensor::new(acc, vec![acc_batch, acc_dim_m, acc_dim_n]);
-        let st_c = acc.store(&self.c, &mut builder);
+        let st_c = acc.store(&self.c, &[&acc_dim_k], &mut builder);
 
         // Order for correctness.
         builder.order(&st_c.inst(), &acc_dim_k, Order::AFTER);

--- a/kernels/src/linalg.rs
+++ b/kernels/src/linalg.rs
@@ -4,8 +4,8 @@ use kernel::Kernel;
 use ndarray::{Array1, Array2, Array3, ArrayD};
 use rand;
 use telamon::explorer::Candidate;
-use telamon::helper::*;
 use telamon::helper::tensor::*;
+use telamon::helper::*;
 use telamon::ir::DimMapScope::Global as GlobalScope;
 use telamon::search_space::*;
 use telamon::{device, ir};
@@ -598,8 +598,7 @@ impl<'a, S: Scalar> Kernel<'a> for BatchMM<'a, S> {
         let m_tiling = TilingPattern::infer_pattern(self.params.m as u32, &[64]);
         let n_tiling = TilingPattern::infer_pattern(self.params.n as u32, &[64]);
         let k_tiling = TilingPattern::infer_pattern(self.params.k as u32, &[64]);
-        let batch_tiling =
-            TilingPattern::infer_pattern(self.params.batch as u32, &[128]);
+        let batch_tiling = TilingPattern::infer_pattern(self.params.batch as u32, &[128]);
         let mut builder = Builder::new(signature, ctx.device());
         let a_tiling = vec![batch_tiling.clone(), m_tiling, k_tiling.clone()];
         let ld_a = self.a.load(a_tiling, &mut builder);

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -422,13 +422,6 @@ impl<'a> Instruction<'a> {
         &self.instantiation_dims
     }
 
-    /// Indicates if the instruction performs a reduction, in wich case it returns the
-    /// instruction that initializes the reduction, the `DimMap` to readh it and the
-    /// reduction dimensions.
-    pub fn as_reduction(&self) -> Option<(ir::InstId, &ir::DimMap)> {
-        self.instruction.as_reduction().map(|(x, y, _)| (x, y))
-    }
-
     /// Returns the memory flag of the intruction, if any.
     pub fn mem_flag(&self) -> Option<search_space::InstFlag> {
         self.mem_flag

--- a/src/device/cuda/characterize/gen.rs
+++ b/src/device/cuda/characterize/gen.rs
@@ -78,7 +78,13 @@ pub fn loop_chained_adds<'a>(
     builder.close_dim(&d0);
     builder.close_dim(&d1);
     let pattern = ir::AccessPattern::Unknown(None);
-    builder.st_ex(&out, &Last(acc, &[&d0, &d1]), true, pattern, InstFlag::CACHE_GLOBAL);
+    builder.st_ex(
+        &out,
+        &Last(acc, &[&d0, &d1]),
+        true,
+        pattern,
+        InstFlag::CACHE_GLOBAL,
+    );
     builder.get()
 }
 
@@ -119,7 +125,13 @@ where
     builder.close_dim(&d0);
     builder.close_dim(&d1);
     let pattern = ir::AccessPattern::Unknown(None);
-    builder.st_ex(&out, &Last(acc, &[&d0, &d1]), true, pattern, InstFlag::NO_CACHE);
+    builder.st_ex(
+        &out,
+        &Last(acc, &[&d0, &d1]),
+        true,
+        pattern,
+        InstFlag::NO_CACHE,
+    );
     builder.get()
 }
 
@@ -183,18 +195,19 @@ pub fn load_chain<'a>(
     let mut dims = vec![&d0, &d1];
     dims.extend(d2.as_ref());
     let fby = builder.create_fby_variable(init, &dims);
-    let ptr = builder.ld_ex(
-        ir::Type::I(64),
-        &fby,
-        pattern0,
-        InstFlag::CACHE_GLOBAL,
-    );
+    let ptr = builder.ld_ex(ir::Type::I(64), &fby, pattern0, InstFlag::CACHE_GLOBAL);
     builder.set_loop_carried_variable(fby, ptr);
     builder.order(&d0, &d1, Order::OUTER);
     builder.close_dim(&d1);
     builder.close_dim(&d0);
     let pattern1 = ir::AccessPattern::Unknown(None);
-    builder.st_ex(&out, &Last(ptr, &[&d0, &d1]), true, pattern1, InstFlag::NO_CACHE);
+    builder.st_ex(
+        &out,
+        &Last(ptr, &[&d0, &d1]),
+        true,
+        pattern1,
+        InstFlag::NO_CACHE,
+    );
     builder.get()
 }
 
@@ -230,7 +243,13 @@ pub fn shared_load_chain<'a>(
     builder.close_dim(&d0);
     builder.close_dim(&d1);
     let out_pattern = ir::AccessPattern::Unknown(None);
-    builder.st_ex(&out, &Last(addr, &[&d0, &d1]), true, out_pattern, InstFlag::CACHE_GLOBAL);
+    builder.st_ex(
+        &out,
+        &Last(addr, &[&d0, &d1]),
+        true,
+        out_pattern,
+        InstFlag::CACHE_GLOBAL,
+    );
 
     builder.order(&last_st, &addr_init, Order::BEFORE);
     builder.order(&d0, &d1, Order::OUTER);
@@ -304,7 +323,13 @@ pub fn parallel_load<'a>(
     let d1_2_b = builder.open_mapped_dim(&d1_1_b);
     builder.order(&d1_2_a, &d1_2_b, Order::OUTER);
     let out_pattern = ir::AccessPattern::Unknown(None);
-    builder.st_ex(&out, &Last(acc, &[&d0, &d3, &d4_1]), true, out_pattern, InstFlag::NO_CACHE);
+    builder.st_ex(
+        &out,
+        &Last(acc, &[&d0, &d3, &d4_1]),
+        true,
+        out_pattern,
+        InstFlag::NO_CACHE,
+    );
 
     builder.order(&d1_0_a, &d0, Order::BEFORE);
     builder.order(&d1_0_b, &d0, Order::BEFORE);
@@ -433,7 +458,13 @@ pub fn chain_in_syncthread<'a>(
 
     let d5 = builder.open_mapped_dim(&d0);
     let pattern = ir::AccessPattern::Unknown(None);
-    builder.st_ex(&out, &Last(acc, &[&d1, &d2, &d3, &d4, &d5]), true, pattern, InstFlag::CACHE_GLOBAL);
+    builder.st_ex(
+        &out,
+        &Last(acc, &[&d1, &d2, &d3, &d4, &d5]),
+        true,
+        pattern,
+        InstFlag::CACHE_GLOBAL,
+    );
 
     builder.order(&d1, &d2, Order::OUTER);
     builder.order(&d1, &d3, Order::OUTER);

--- a/src/helper/builder.rs
+++ b/src/helper/builder.rs
@@ -302,7 +302,7 @@ impl<'a> Builder<'a> {
     pub fn set_loop_carried_variable<V: ToVariable>(
         &mut self,
         fby: ir::VarId,
-        loop_carried: V
+        loop_carried: V,
     ) {
         let loop_carried = loop_carried.to_variable(self);
         unwrap!(self.function.set_loop_carried_variable(fby, loop_carried))

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -124,7 +124,10 @@ impl TilingPattern {
         } else {
             multiples
         };
-        TilingPattern { tiling_factors, tile_sizes, }
+        TilingPattern {
+            tiling_factors,
+            tile_sizes,
+        }
     }
 }
 

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -6,7 +6,7 @@ mod signature;
 pub mod tensor;
 
 pub use self::builder::Builder;
-pub use self::operand::{AutoOperand, Reduce, TmpArray};
+pub use self::operand::*;
 pub use self::signature::Builder as SignatureBuilder;
 
 use ir;
@@ -119,10 +119,12 @@ impl TilingPattern {
             .map(|max| {
                 VecSet::new(multiples.iter().cloned().take_while(|x| x <= max).collect())
             }).collect();
-        TilingPattern {
-            tiling_factors: multiples,
-            tile_sizes,
-        }
+        let tiling_factors = if multiples.is_empty() {
+            VecSet::new(vec![1])
+        } else {
+            multiples
+        };
+        TilingPattern { tiling_factors, tile_sizes, }
     }
 }
 

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -152,7 +152,9 @@ impl<'a, L> Function<'a, L> {
         def: ir::VarDef,
     ) -> Result<ir::Variable, ir::Error> {
         def.check(self)?;
-        Ok(ir::Variable::new(id, def, self))
+        let var = ir::Variable::new(id, def, self);
+        trace!("Created variable {:?}", var);
+        Ok(var)
     }
 
     /// Registers a layout dimension in the function.
@@ -668,7 +670,6 @@ impl<'a> Function<'a> {
                     );
                     return Err(());
                 }
-                Operand::Reduce(..) => return Err(()),
                 _ => panic!(),
             }
         };

--- a/src/ir/induction_var.rs
+++ b/src/ir/induction_var.rs
@@ -29,9 +29,6 @@ impl<'a, L> InductionVar<'a, L> {
         }
         // TODO(cleanup): return errors instead of panicing
         match base {
-            ir::Operand::Reduce(..) => {
-                panic!("induction variables cannot perform reductions")
-            }
             ir::Operand::Inst(.., ir::DimMapScope::Global(..)) =>
             // TODO(search_space): allow dim map lowering for induction variables
             {

--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -145,20 +145,6 @@ impl<'a, L> Instruction<'a, L> {
         }
     }
 
-    /// Indicates if the instruction performs a reduction.
-    pub fn as_reduction(&self) -> Option<(InstId, &ir::DimMap, &[ir::DimId])> {
-        at_most_one(self.operands().iter().flat_map(|x| x.as_reduction()))
-    }
-
-    /// Returns 'true' if `self` is a reduction initialized by init, and if 'dim' should
-    /// have the same nesting with 'init' that with 'self'.
-    pub fn is_reduction_common_dim(&self, init: InstId, dim: ir::DimId) -> bool {
-        self.as_reduction()
-            .map(|(i, map, rd)| {
-                i == init && !rd.contains(&dim) && map.iter().all(|&(_, rhs)| dim != rhs)
-            }).unwrap_or(false)
-    }
-
     /// Rename a dimension to another ID.
     pub fn merge_dims(&mut self, lhs: ir::DimId, rhs: ir::DimId) {
         self.operator.merge_dims(lhs, rhs);

--- a/src/ir/operand.rs
+++ b/src/ir/operand.rs
@@ -118,8 +118,6 @@ pub enum Operand<'a, L = LoweringMap> {
     Param(&'a Parameter),
     /// The address of a memory block.
     Addr(ir::MemId),
-    /// The value of the current instruction at a previous iteration.
-    Reduce(InstId, Type, DimMap, Vec<ir::DimId>),
     /// A variable increased by a fixed amount at every step of some loops.
     InductionVar(ir::IndVarId, Type),
     /// A variable, stored in register.
@@ -136,7 +134,7 @@ impl<'a, L> Operand<'a, L> {
             Index(..) => Type::I(32),
             Param(p) => p.t,
             Variable(_, t) => t,
-            Inst(_, t, ..) | Reduce(_, t, ..) | InductionVar(_, t) => t,
+            Inst(_, t, ..) | InductionVar(_, t) => t,
         }
     }
 
@@ -156,15 +154,6 @@ impl<'a, L> Operand<'a, L> {
         Inst(inst.id(), unwrap!(inst.t()), dim_map, scope)
     }
 
-    /// Creates a reduce operand from an instruction and a set of dimensions to reduce on.
-    pub fn new_reduce(
-        init: &Instruction<L>,
-        dim_map: DimMap,
-        dims: Vec<ir::DimId>,
-    ) -> Self {
-        Reduce(init.id(), unwrap!(init.t()), dim_map, dims)
-    }
-
     /// Creates a new Int operand and checks its number of bits.
     pub fn new_int(val: BigInt, len: u16) -> Self {
         assert!(num_bits(&val) <= len);
@@ -179,9 +168,9 @@ impl<'a, L> Operand<'a, L> {
     /// Renames a basic block id.
     pub fn merge_dims(&mut self, lhs: ir::DimId, rhs: ir::DimId) {
         match *self {
-            Inst(_, _, ref mut dim_map, _) | Reduce(_, _, ref mut dim_map, _) => {
+            Inst(_, _, ref mut dim_map, _) => {
                 dim_map.merge_dims(lhs, rhs);
-            }
+            },
             _ => (),
         }
     }
@@ -189,19 +178,10 @@ impl<'a, L> Operand<'a, L> {
     /// Indicates if a `DimMap` should be lowered if lhs and rhs are not mapped.
     pub fn should_lower_map(&self, lhs: ir::DimId, rhs: ir::DimId) -> bool {
         match *self {
-            Inst(_, _, ref dim_map, _) | Reduce(_, _, ref dim_map, _) => dim_map
+            Inst(_, _, ref dim_map, _) => dim_map
                 .iter()
                 .any(|&pair| pair == (lhs, rhs) || pair == (rhs, lhs)),
             _ => false,
-        }
-    }
-
-    /// If the operand is a reduction, returns the instruction initializing the reduction.
-    pub fn as_reduction(&self) -> Option<(InstId, &DimMap, &[ir::DimId])> {
-        if let Reduce(id, _, ref dim_map, ref dims) = *self {
-            Some((id, dim_map, dims))
-        } else {
-            None
         }
     }
 
@@ -209,14 +189,14 @@ impl<'a, L> Operand<'a, L> {
     pub fn is_constant(&self) -> bool {
         match self {
             Int(..) | Float(..) | Addr(..) | Param(..) => true,
-            Index(..) | Inst(..) | Reduce(..) | InductionVar(..) | Variable(..) => false,
+            Index(..) | Inst(..) | InductionVar(..) | Variable(..) => false,
         }
     }
 
     /// Returns the list of dimensions mapped together by the operand.
     pub fn mapped_dims(&self) -> Option<&DimMap> {
         match self {
-            Inst(_, _, dim_map, _) | Reduce(_, _, dim_map, _) => Some(dim_map),
+            Inst(_, _, dim_map, _) => Some(dim_map),
             _ => None,
         }
     }
@@ -241,7 +221,6 @@ impl<'a> Operand<'a, ()> {
             Index(id) => Index(id),
             Param(param) => Param(param),
             Addr(id) => Addr(id),
-            Reduce(id, t, dim_map, dims) => Reduce(id, t, dim_map, dims),
             InductionVar(id, t) => InductionVar(id, t),
         }
     }

--- a/src/ir/operand.rs
+++ b/src/ir/operand.rs
@@ -170,7 +170,7 @@ impl<'a, L> Operand<'a, L> {
         match *self {
             Inst(_, _, ref mut dim_map, _) => {
                 dim_map.merge_dims(lhs, rhs);
-            },
+            }
             _ => (),
         }
     }

--- a/src/ir/variable.rs
+++ b/src/ir/variable.rs
@@ -6,6 +6,8 @@ use utils::*;
 #[derive(
     Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
 )]
+#[repr(C)]
+/// cbindgen:field-names=[id]
 pub struct VarId(pub u16);
 
 impl From<VarId> for usize {

--- a/src/model/level.rs
+++ b/src/model/level.rs
@@ -383,8 +383,7 @@ fn list_dim_maps(space: &SearchSpace) -> Vec<DimMap> {
         .flat_map(|inst| {
             let dst = inst.id();
             inst.operands().into_iter().flat_map(move |op| match *op {
-                ir::Operand::Inst(src, _, ref dim_map, _)
-                | ir::Operand::Reduce(src, _, ref dim_map, _) => {
+                ir::Operand::Inst(src, _, ref dim_map, _) => {
                     list_dim_map(space, src, dst, dim_map)
                 }
                 _ => None,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -232,20 +232,6 @@ fn set_data_deps(
                     .bound(BottleneckLevel::Thread, thread_rates);
                 set_data_dep(space, pred, to, dim_map, &latency, level_dag);
             }
-            ir::Operand::Reduce(pred_id, _, ref dim_map, ref reduce_dims) => {
-                let pred = code_points.ids[&CodePoint::Inst(pred_id)];
-                let latency = local_info.hw_pressure[&pred_id.into()]
-                    .bound(BottleneckLevel::Thread, thread_rates);
-                set_data_dep(space, pred, to, dim_map, &latency, level_dag);
-                // Add the back-edge in the levels where it is possible.
-                let latency = local_info.hw_pressure[&inst_id.into()]
-                    .bound(BottleneckLevel::Thread, thread_rates);
-                for level in levels.iter_mut() {
-                    if level.dims.iter().all(|d| reduce_dims.contains(d)) {
-                        level.back_edges.push((to, to, latency.clone()));
-                    }
-                }
-            }
             _ => (),
         }
     }

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -248,12 +248,6 @@ require forall $dim in StaticDims:
     dim_kind($dim) is not VECTOR || order($dim, $inst) is not OUTER
       || "$fun.device().can_vectorize($dim, $inst.operator())"
 
-require forall $dim in Dimensions:
-  forall $init in Instructions:
-    forall $reduce in Instructions:
-      "!$reduce.is_reduction_common_dim($init.id(), $dim.id())"
-        || is_iteration_dim($reduce, $dim) is FALSE || order($dim, $init) is OUTER
-
 // dim_map lowering.
 trigger forall $lhs in Dimensions:
   forall $rhs in Dimensions:

--- a/src/search_space/operand.rs
+++ b/src/search_space/operand.rs
@@ -1,7 +1,7 @@
 //! Handle operands invariants.
 use ir::Operand::*;
 use ir::{self, DimMapScope, Statement};
-use search_space::choices::{Action, DimKind, DimMapping, Order};
+use search_space::choices::{Action, DimMapping, Order};
 
 /// Generates actions to enforce operands invariants.
 pub fn invariants(fun: &ir::Function, op: &ir::Operand, user: ir::StmtId) -> Vec<Action> {
@@ -26,21 +26,6 @@ pub fn invariants(fun: &ir::Function, op: &ir::Operand, user: ir::StmtId) -> Vec
             }
             // Order the with the source instruction.
             actions.push(Action::Order(src.into(), user, Order::BEFORE));
-            actions
-        }
-        Reduce(src, _, ref dim_map, ref reduce_dims) => {
-            let order = Order::BEFORE | Order::MERGED;
-            let mut actions = Vec::new();
-            // TODO(search_space): allow tmp mem to be generated for reduce dim maps.
-            for &(lhs, rhs) in dim_map.iter() {
-                actions.push(Action::Order(lhs.into(), rhs.into(), order));
-                actions.push(Action::DimMapping(lhs, rhs, DimMapping::MAPPED));
-            }
-            actions.push(Action::Order(src.into(), user, Order::BEFORE));
-            for &dim in reduce_dims {
-                actions.push(Action::Order(src.into(), dim.into(), Order::BEFORE));
-                actions.push(Action::DimKind(dim, DimKind::LOOP | DimKind::UNROLL));
-            }
             actions
         }
         Index(dim) => vec![Action::Order(dim.into(), user, Order::OUTER)],

--- a/src/search_space/variable.exh
+++ b/src/search_space/variable.exh
@@ -165,11 +165,24 @@ require forall $mapping in DimMappings:
 
 require forall $var in Variables:
   forall $mapping in DimMappings:
-    forall $lhs in MappedDims($mapping):
-      forall $rhs in MappedDims($mapping):
-        "$var.max_memory_level() <= ir::MemoryLevel::RegisterNoSync"
+    forall $lhs in StaticMappedDims($mapping):
+      forall $rhs in StaticMappedDims($mapping):
+        "$var.max_memory_level() > ir::MemoryLevel::RegisterNoSync"
           || order($lhs, $rhs) is MERGED
           || dim_kind($lhs) is UNROLL | VECTOR
+        // TODO(ulysse): allow lowering to memory
+        // Ensure we allow point-to-ponmt communication without memory
+        order($lhs, $rhs) is MERGED
+          || dim_kind($lhs) is UNROLL | VECTOR | THREAD
+        // .. using threads
+        order($lhs, $rhs) is MERGED
+          || dim_kind($lhs) is not THREAD
+          || thread_mapping($lhs, $rhs) is MAPPED
+        // .. or using registers.
+        order($lhs, $rhs) is MERGED
+          || dim_kind($lhs) is not UNROLL | VECTOR
+          || dim_kind($rhs) is UNROLL | VECTOR
+
 
 /// Lists the static dimensions in a dimension mapping.
 set StaticMappedDims($pair in DimMappings) subsetof StaticDims:


### PR DESCRIPTION
This PR uses the new variable system everywhere where it is possible. It
also removes the old `Reduce` operand as it is not needed anymore and
fixes minor bugs caught in the process.

Suggested review order:
- src/ir/operand.rs
- src/helper/operand.rs
- src/helper/builder.rs
- src/*
- all the rest