### PR TITLE
Make ChoiceOrdering more idiomatic

### DIFF
--- a/src/explorer/bandit_arm.rs
+++ b/src/explorer/bandit_arm.rs
@@ -297,8 +297,7 @@ impl<'a> SubTree<'a> {
                 DescendState::InternalNode(node, false)
             }
             SubTree::UnexpandedNode(candidate) => {
-                let choice =
-                    choice::list_with_conf(choice_ordering, &candidate.space).next();
+                let choice = choice::list(choice_ordering, &candidate.space).next();
                 if let Some(choice) = choice {
                     let candidates = candidate.apply_choice(context, choice);
                     let children = Children::from_candidates(candidates, cut);
@@ -414,8 +413,7 @@ impl<'a> Children<'a> {
                     return (idx, Err(DescendState::InternalNode(node.clone(), true)))
                 }
             };
-            let choice =
-                choice::list_with_conf(&config.choice_ordering, &cand.space).next();
+            let choice = choice::list(&config.choice_ordering, &cand.space).next();
             let out = if let Some(choice) = choice {
                 let cands = cand.apply_choice(context, choice);
                 self.children[idx] = SubTree::UnexpandedNode(cand);

--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -304,7 +304,7 @@ impl fmt::Display for ChoiceGroup {
     }
 }
 
-/// An error which can
+/// An error which can be returned when parsing a group of choices.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ParseChoiceGroupError(String);
 

--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -8,8 +8,7 @@ use config;
 use getopts;
 use itertools::Itertools;
 use num_cpus;
-use std;
-use std::fmt;
+use std::{self, error, fmt, str::FromStr};
 
 /// Stores the configuration of the exploration.
 #[derive(Clone, Serialize, Deserialize)]
@@ -278,7 +277,6 @@ impl Default for OldNodeOrder {
 /// An enum listing the Group of choices we can make
 /// For example, we can make first all DimKind decisions, then all Order decisions, etc.
 #[derive(Clone, Serialize, Deserialize, Debug)]
-//#[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]
 pub enum ChoiceGroup {
     LowerLayout,
@@ -290,30 +288,104 @@ pub enum ChoiceGroup {
     InstFlag,
 }
 
-/// A list of ChoiceGroup representing the order in which we want to determine choices
-#[derive(Clone, Serialize, Deserialize)]
-pub struct ChoiceOrdering(Vec<ChoiceGroup>);
+impl fmt::Display for ChoiceGroup {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::ChoiceGroup::*;
 
-impl Default for ChoiceOrdering {
-    fn default() -> Self {
-        ChoiceOrdering(vec![
-            ChoiceGroup::LowerLayout,
-            ChoiceGroup::Size,
-            ChoiceGroup::DimKind,
-            ChoiceGroup::DimMap,
-            ChoiceGroup::MemSpace,
-            ChoiceGroup::Order,
-            ChoiceGroup::InstFlag,
-        ])
+        f.write_str(match self {
+            LowerLayout => "lower_layout",
+            Size => "size",
+            DimKind => "dim_kind",
+            DimMap => "dim_map",
+            Order => "order",
+            MemSpace => "mem_space",
+            InstFlag => "inst_flag",
+        })
     }
 }
 
-impl ChoiceOrdering {
-    pub fn print_serialize(&self) {
-        println!("{}", unwrap!(toml::to_string(self)));
-    }
+/// An error which can
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ParseChoiceGroupError(String);
 
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = &'a ChoiceGroup> + Clone {
+impl error::Error for ParseChoiceGroupError {}
+
+impl fmt::Display for ParseChoiceGroupError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invalid choice group value `{}`", self.0)
+    }
+}
+
+impl FromStr for ChoiceGroup {
+    type Err = ParseChoiceGroupError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use self::ChoiceGroup::*;
+
+        Ok(match s {
+            "lower_layout" => LowerLayout,
+            "size" => Size,
+            "dim_kind" => DimKind,
+            "dim_map" => DimMap,
+            "order" => Order,
+            "mem_space" => MemSpace,
+            "inst_flag" => InstFlag,
+            _ => return Err(ParseChoiceGroupError(s.to_string())),
+        })
+    }
+}
+
+/// A list of ChoiceGroup representing the order in which we want to determine choices
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ChoiceOrdering(Vec<ChoiceGroup>);
+
+impl<'a> IntoIterator for &'a ChoiceOrdering {
+    type Item = &'a ChoiceGroup;
+    type IntoIter = std::slice::Iter<'a, ChoiceGroup>;
+
+    fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
+    }
+}
+
+pub(super) const DEFAULT_ORDERING: [ChoiceGroup; 7] = [
+    ChoiceGroup::LowerLayout,
+    ChoiceGroup::Size,
+    ChoiceGroup::DimKind,
+    ChoiceGroup::DimMap,
+    ChoiceGroup::MemSpace,
+    ChoiceGroup::Order,
+    ChoiceGroup::InstFlag,
+];
+
+impl Default for ChoiceOrdering {
+    fn default() -> Self {
+        ChoiceOrdering(DEFAULT_ORDERING.to_vec())
+    }
+}
+
+impl fmt::Display for ChoiceOrdering {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some((first, rest)) = self.0.split_first() {
+            write!(f, "{:?}", first)?;
+
+            for elem in rest {
+                write!(f, ",{:?}", elem)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl FromStr for ChoiceOrdering {
+    type Err = ParseChoiceGroupError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(ChoiceOrdering(
+            s.split(",")
+                .map(str::parse)
+                .collect::<Result<Vec<_>, _>>()?,
+        ))
     }
 }

--- a/src/explorer/local_selection.rs
+++ b/src/explorer/local_selection.rs
@@ -18,7 +18,7 @@ pub fn descend<'a>(
     cut: f64,
 ) -> Option<Candidate<'a>> {
     //let choice_opt = choice::list(&candidate.space).next();
-    let choice_opt = choice::list_with_conf(choice_order, &candidate.space).next();
+    let choice_opt = choice::list(choice_order, &candidate.space).next();
     if let Some(choice) = choice_opt {
         let new_nodes = candidate.apply_choice(context, choice);
         pick_candidate(node_order, new_nodes, cut)


### PR DESCRIPTION
This patch allows displaying and parsing ChoiceOrdering values, which
paves the way for using them as command line parameters.  The patch also
removes the ChoiceGroup definition in choice.rs to keep only the ones in
config.rs, greatly diminishing the bookkeeping required.  The
distinction was meant to allow more generic selection of groups at the
config level which would require extra computation to be lowered (e.g.
mapping of loop variables to internal dimension IDs), but we ended up
not doing this for the foreseeable future.

I also finally understood the proper way of using IntoIterator to write
a generic `list` version, so the patch folds `choice::list_with_conf`
into the generi `choice::list`.

telamon:
 * src/explorer/config.rs:
	Add FromStr, Display and IntoIterator implementations.
 * src/explorer/choice.rs:
	Use config::ChoiceGroup and the new IntoIterator directly.
 * src/explorer/local_selection.rs:
	Use `choice::list` instead of `choice::list_with_conf`.
 * src/explorer/bandit_arm.rs:
	Use `choice::list` instead of `choice::list_with_conf`.