### PR TITLE
 Support CUDA_HOME environment variable 

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,13 +21,10 @@ fn compile_link_cuda() {
     let mut builder = cc::Build::new();
 
     // If CUDA_HOME is defined, use the cuda headers from there.
-    match env::var_os("CUDA_HOME").map(PathBuf::from) {
-        Some(cuda_home) => {
-            builder
-                .include(cuda_home.join("include"))
-                .include(cuda_home.join("extras").join("CUPTI").join("include"));
-        }
-        None => (),
+    if let Some(cuda_home) = env::var_os("CUDA_HOME").map(PathBuf::from) {
+        builder
+            .include(cuda_home.join("include"))
+            .include(cuda_home.join("extras").join("CUPTI").join("include"));
     }
 
     builder

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,8 @@ extern crate failure;
 extern crate glob;
 extern crate telamon_gen;
 
-use std::path::Path;
+use std::env;
+use std::path::{Path, PathBuf};
 
 /// Orders to Cargo to link a library.
 fn add_lib(lib: &str) {
@@ -17,7 +18,19 @@ fn add_dependency(dep: &Path) {
 
 /// Compiles and links the cuda wrapper and libraries.
 fn compile_link_cuda() {
-    cc::Build::new()
+    let mut builder = cc::Build::new();
+
+    // If CUDA_HOME is defined, use the cuda headers from there.
+    match env::var_os("CUDA_HOME").map(PathBuf::from) {
+        Some(cuda_home) => {
+            builder
+                .include(cuda_home.join("include"))
+                .include(cuda_home.join("extras").join("CUPTI").join("include"));
+        }
+        None => (),
+    }
+
+    builder
         .flag("-Werror")
         .file("src/device/cuda/api/wrapper.c")
         .compile("libdevice_cuda_wrapper.a");

--- a/src/explorer/parallel_list.rs
+++ b/src/explorer/parallel_list.rs
@@ -58,6 +58,7 @@ impl<'a> ParallelCandidateList<'a> {
     }
 
     /// Insert a candidate to process.
+    #[allow(dead_code)]
     pub fn insert(&self, candidate: Candidate<'a>) {
         self.lock().0.insert(candidate);
         self.wakeup.notify_all();

--- a/src/explorer/parallel_list.rs
+++ b/src/explorer/parallel_list.rs
@@ -57,13 +57,6 @@ impl<'a> ParallelCandidateList<'a> {
         }
     }
 
-    /// Insert a candidate to process.
-    #[allow(dead_code)]
-    pub fn insert(&self, candidate: Candidate<'a>) {
-        self.lock().0.insert(candidate);
-        self.wakeup.notify_all();
-    }
-
     /// Insert multiple candidates to process.
     pub fn insert_many(&self, candidates: Vec<Candidate<'a>>) {
         let mut lock = self.lock();


### PR DESCRIPTION
This patch makes it so that Telamon's build.rs uses the CUDA headers
from the user's CUDA_HOME environment variable if defined.  This matches
the behavior of most CUDA-based toolkits, including nVidia's own
examples.

The CUDA_HOME environment variable should point to the directory where
the CUDA toolkit is installed, which is /usr/local/cuda by default when
running nVidia's installer.