### PR TITLE
Add DMA instructions

### DIFF
--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -2,7 +2,7 @@
 use codegen::{self, cfg, dimension, Cfg, Dimension, InductionLevel, InductionVar};
 use ir;
 use itertools::Itertools;
-use search_space::{self, DimKind, Domain, MemSpace, SearchSpace};
+use search_space::*;
 use std;
 use utils::*;
 
@@ -360,7 +360,8 @@ impl<'a> MemoryRegion<'a> {
 pub struct Instruction<'a> {
     instruction: &'a ir::Instruction<'a>,
     instantiation_dims: Vec<(ir::DimId, u32)>,
-    mem_flag: Option<search_space::InstFlag>,
+    mem_access: Option<MemAccess<'a>>,
+    dma_wait: Option<MemAccess<'a>>,
     t: Option<ir::Type>,
 }
 
@@ -377,16 +378,29 @@ impl<'a> Instruction<'a> {
                 let size = space.ir_instance().dim(dim).size();
                 (dim, unwrap!(codegen::Size::from_ir(size, space).as_int()))
             }).collect();
-        let mem_flag = instruction
-            .as_mem_inst()
-            .map(|inst| space.domain().get_inst_flag(inst.id()));
+        let mem_access = instruction
+            .operator()
+            .mem_access_pattern()
+            .map(|pattern| MemAccess::new(instruction, &pattern, space));
+        let op = instruction.operator();
+        let dma_wait = if let ir::op::DmaStart { dma_wait, .. } = op {
+            let inst = space.ir_instance().inst(unwrap!(*dma_wait));
+            if let ir::op::DmaWait { dst_pattern, .. } = inst.operator() {
+                Some(MemAccess::new(inst, dst_pattern, space))
+            } else {
+                panic!("expected a DmaWait operator")
+            }
+        } else {
+            None
+        };
         let t = instruction
             .t()
             .map(|t| unwrap!(space.ir_instance().device().lower_type(t, space)));
         Instruction {
             instruction,
             instantiation_dims,
-            mem_flag,
+            mem_access,
+            dma_wait,
             t,
         }
     }
@@ -402,9 +416,14 @@ impl<'a> Instruction<'a> {
         space: &'a SearchSpace<'a>,
     ) -> impl Iterator<Item = ParamVal<'a>> {
         let operands = self.instruction.operator().operands();
+        let mem_access_stride = self
+            .mem_access()
+            .and_then(|x| x.stride.as_ref())
+            .and_then(ParamVal::from_size);
         operands
             .into_iter()
             .flat_map(move |op| ParamVal::from_operand(op, space))
+            .chain(mem_access_stride)
     }
 
     /// Returns the type of the instruction.
@@ -422,9 +441,14 @@ impl<'a> Instruction<'a> {
         &self.instantiation_dims
     }
 
-    /// Returns the memory flag of the intruction, if any.
-    pub fn mem_flag(&self) -> Option<search_space::InstFlag> {
-        self.mem_flag
+    /// Returns a description of how the instruction accesses the memory.
+    pub fn mem_access(&self) -> Option<&MemAccess<'a>> {
+        self.mem_access.as_ref()
+    }
+
+    /// Indicates how the DMA wait link to this instruction, if any, accesses the memory.
+    pub fn dma_wait_access(&self) -> Option<&MemAccess<'a>> {
+        self.dma_wait.as_ref()
     }
 
     /// Indicates if the instruction has observable side effects.
@@ -435,5 +459,49 @@ impl<'a> Instruction<'a> {
     /// Indicates where to store the result of the instruction.
     pub fn result_variable(&self) -> Option<ir::VarId> {
         self.instruction.result_variable()
+    }
+}
+
+/// Describes a memory access.
+#[derive(Debug)]
+pub struct MemAccess<'a> {
+    pub stride: Option<codegen::Size<'a>>,
+    pub space: MemSpace,
+    pub flag: InstFlag,
+}
+
+impl<'a> MemAccess<'a> {
+    pub fn new(
+        inst: &ir::Instruction,
+        access_pattern: &ir::AccessPattern,
+        space: &SearchSpace,
+    ) -> Self {
+        let layout_dims = inst
+            .mem_access_layout()
+            .iter()
+            .map(|&id| {
+                let dim = space.ir_instance().layout_dimension(id);
+                let rank_universe = unwrap!(dim.possible_ranks());
+                let rank = space.domain().get_rank(id).as_constrained(rank_universe);
+                (dim, unwrap!(rank))
+            }).sorted_by(|(_, lhs), (_, rhs)| std::cmp::Ord::cmp(lhs, rhs));
+        let first_outer_vec = layout_dims.iter().find(|(dim, _)| {
+            space.domain().get_dim_kind(dim.dim()) == DimKind::OUTER_VECTOR
+        });
+        let last_inner_vec = layout_dims
+            .iter()
+            .rev()
+            .find(|(dim, _)| {
+                space.domain().get_dim_kind(dim.dim()) == DimKind::OUTER_VECTOR
+            }).map_or(0, |&(_, rank)| rank);
+        if let Some(&(dim, rank)) = first_outer_vec {
+            let is_strided = rank > last_inner_vec + 1 || dim.is_strided();
+            assert!(!is_strided, "strided access are not supported yet");
+        }
+        MemAccess {
+            stride: None,
+            space: access_pattern_space(access_pattern, space),
+            flag: space.domain().get_inst_flag(inst.id()),
+        }
     }
 }

--- a/src/helper/builder.rs
+++ b/src/helper/builder.rs
@@ -226,7 +226,10 @@ impl<'a> Builder<'a> {
         let sync_flag = dma_start.to_operand(self);
         let has_side_effects = {
             let start_op = self.function.inst(dma_start).operator();
-            if let ir::op::DmaStart { has_side_effects, .. } = start_op {
+            if let ir::op::DmaStart {
+                has_side_effects, ..
+            } = start_op
+            {
                 *has_side_effects
             } else {
                 panic!("expected a DmaStart operator")

--- a/src/ir/operator.rs
+++ b/src/ir/operator.rs
@@ -336,10 +336,14 @@ impl<'a, L> Operator<'a, L> {
         match self {
             Ld(_, _, pattern)
             | St(_, _, _, pattern)
-            | DmaStart { src_pattern: pattern, .. }
-            | DmaWait { dst_pattern: pattern, .. } => {
-                Some(Cow::Borrowed(pattern))
+            | DmaStart {
+                src_pattern: pattern,
+                ..
             }
+            | DmaWait {
+                dst_pattern: pattern,
+                ..
+            } => Some(Cow::Borrowed(pattern)),
             TmpLd(_, mem_id) | TmpSt(_, mem_id) => {
                 Some(Cow::Owned(AccessPattern::Unknown(Some(*mem_id))))
             }

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -12,22 +12,25 @@ pub enum Type {
     F(u16),
     /// Pointer type of the given memory space.
     PtrTo(ir::MemId),
+    /// A synchronisation event.
+    SyncFlag,
 }
 
 impl Type {
     /// Returns true if the type is an integer.
     pub fn is_integer(&self) -> bool {
-        match *self {
-            Type::I(_) | Type::PtrTo(_) => true,
-            Type::F(_) => false,
+        match self {
+            Type::I(..) | Type::PtrTo(..) => true,
+            _ => false,
         }
     }
 
     /// Returns true if the type is a float.
     pub fn is_float(&self) -> bool {
-        match *self {
-            Type::F(_) => true,
-            Type::I(_) | Type::PtrTo(..) => false,
+        if let Type::F(..) = self {
+            true
+        } else {
+            false
         }
     }
 
@@ -35,7 +38,7 @@ impl Type {
     pub fn len_byte(&self) -> Option<u32> {
         match *self {
             Type::I(i) | Type::F(i) => Some(u32::from(div_ceil(i, 8))),
-            Type::PtrTo(_) => None,
+            Type::PtrTo(_) | Type::SyncFlag => None,
         }
     }
 }
@@ -46,6 +49,7 @@ impl fmt::Display for Type {
             Type::I(s) => write!(f, "i{}", s),
             Type::F(s) => write!(f, "f{}", s),
             Type::PtrTo(mem) => write!(f, "ptr to {:?}", mem),
+            Type::SyncFlag => write!(f, "syncflag"),
         }
     }
 }

--- a/src/search_space/layout.exh
+++ b/src/search_space/layout.exh
@@ -84,7 +84,7 @@ require forall $inst in MemInsts:
           forall $mid_dim in ActualDimension($mid):
             forall $inner_dim in ActualDimension($inner):
               dim_kind($outer_dim) is not VECTOR
-              || dim_kind($inner_dim) is not VECTOR
+              || dim_kind($inner_dim) != dim_kind($outer_dim)
               || rank($outer) < rank($mid)
               || rank($mid) < rank($inner)
-              || dim_kind($mid_dim) is VECTOR
+              || dim_kind($mid_dim) == dim_kind($outer_dim)

--- a/src/search_space/mod.rs
+++ b/src/search_space/mod.rs
@@ -6,8 +6,8 @@ mod operand;
 generated_file!(choices);
 
 pub use self::choices::{
-    Action, Bool, Choice, DimKind, Domain, DomainStore, InstFlag, MemorySpace, MemSpace, NumSet,
-    Order, ThreadMapping,
+    Action, Bool, Choice, DimKind, Domain, DomainStore, InstFlag, MemSpace, MemorySpace,
+    NumSet, Order, ThreadMapping,
 };
 
 use self::choices::{apply_action, init_domain, DomainDiff};

--- a/src/search_space/mod.rs
+++ b/src/search_space/mod.rs
@@ -6,7 +6,7 @@ mod operand;
 generated_file!(choices);
 
 pub use self::choices::{
-    Action, Bool, Choice, DimKind, Domain, DomainStore, InstFlag, MemSpace, NumSet,
+    Action, Bool, Choice, DimKind, Domain, DomainStore, InstFlag, MemorySpace, MemSpace, NumSet,
     Order, ThreadMapping,
 };
 

--- a/src/search_space/variable.exh
+++ b/src/search_space/variable.exh
@@ -12,7 +12,7 @@ set DefStatements($var in Variables) subsetof Statements:
   item_type = "ir::Statement"
   id_type = "ir::StmtId"
   item_getter = "$fun.statement($id)"
-  id_getter = "$item.id()"
+  id_getter = "$item.stmt_id()"
   iterator = "$var.def_points().map(|id| $fun.statement(id))"
   from_superset = "if $item.defined_vars().contains(&$var.id()) { Some($item) } else { None }"
   reverse forall $stmt in Statements = "$stmt.defined_vars().iter().map(|&id| $fun.variable(id))"
@@ -24,7 +24,7 @@ set UseStatements($var in Variables) subsetof Statements:
   item_type = "ir::Statement"
   id_type = "ir::StmtId"
   item_getter = "$fun.statement($id)"
-  id_getter = "$item.id()"
+  id_getter = "$item.stmt_id()"
   iterator = "$var.use_points().map(|id| $fun.statement(id))"
   from_superset = "if $item.used_vars().contains(&$var.id()) { Some($item) } else { None }"
   reverse forall $stmt in Statements = "$stmt.used_vars().iter().map(|&id| $fun.variable(id))"
@@ -83,7 +83,7 @@ set VarDims($var in Variables) subsetof Dimensions:
   item_type = "ir::Dimension"
   id_type = "ir::DimId"
   item_getter = "$fun.dim($id)"
-  id_getter = "$item.id()"
+  id_getter = "$item.stmt_id()"
   iterator = "$var.dimensions().iter().map(|&dim| $fun.dim(dim))"
   from_superset = "if $var.dimensions().contains(&$item.id()) { Some($item) } else { None }"
   reverse forall $dim in Dimensions = "$dim.inner_vars().iter().map(|&id| $fun.variable(id))"
@@ -114,6 +114,27 @@ define enum memory_space($var in Variables):
                 || order($outer_lhs, $inner_lhs) is not OUTER
                 || order($outer_rhs, $inner_rhs) is OUTER
 end
+
+// We model synchronisation flags as vector registers to ensure the vectorization pattern
+// is the same on the `DmaStart` and `DmaWait`.
+require forall $var in Variables:
+  "$var.t() != ir::Type::SyncFlag" || memory_space($var) is VECTOR_REGISTER
+
+// Force `DmaStart` and `DmaWait` to have the same nesting. This supposes the
+// synchronisation flag is transmitted through a DimMap(Inst(dma_start), ..) variable.
+require forall $var in Variables:
+  forall $pred in PredecessorVars($var):
+    forall $use in UseStatements($var):
+      forall $def in DefStatements($pred):
+        forall $dim in Dimensions:
+          "$var.t() != ir::Type::SyncFlag"
+          || "$var.dimensions().contains(&$dim.id())"
+          || order($use, $dim) is not INNER
+          || order($def, $dim) is INNER
+          "$var.t() != ir::Type::SyncFlag"
+          || "$pred.dimensions().contains(&$dim.id())"
+          || order($def, $dim) is not INNER
+          || order($use, $dim) is INNER
 
 /// List pairs of dimensions that must have the same size and can be use for
 /// point-to-point communication.

--- a/telamon-gen/src/flat_filter.rs
+++ b/telamon-gen/src/flat_filter.rs
@@ -88,11 +88,13 @@ impl FlatFilter {
             let mut adaptator = ir::Adaptator::default();
             // Ensure variables are compatible.
             for (old_id, &new_id) in var_map.iter().enumerate() {
-                if other.vars[old_id] != self.vars[new_id] {
-                    continue 'var_maps;
-                }
                 let old_var = ir::Variable::Forall(old_id);
                 adaptator.set_variable(old_var, ir::Variable::Forall(new_id));
+            }
+            for (old_id, &new_id) in var_map.iter().enumerate() {
+                if other.vars[old_id].adapt(&adaptator) != self.vars[new_id] {
+                    continue 'var_maps;
+                }
             }
             // Find the input mapping.
             for (old_id, input) in other.inputs.iter().enumerate() {

--- a/tests/common/fake.rs
+++ b/tests/common/fake.rs
@@ -48,20 +48,23 @@ impl device::Device for Device {
             Operator::TmpLd(..)
             | Operator::TmpSt(..)
             | Operator::BinOp(ir::BinOp::Add, ..) => true,
-            Operator::Ld(.., pattern) |
-            Operator::St(.., pattern) |
-            Operator::DmaStart { src_pattern: pattern, .. } |
-            Operator::DmaWait { dst_pattern: pattern, .. } => {
-                pattern.is_layout_dimension(dim.id())
+            Operator::Ld(.., pattern)
+            | Operator::St(.., pattern)
+            | Operator::DmaStart {
+                src_pattern: pattern,
+                ..
             }
+            | Operator::DmaWait {
+                dst_pattern: pattern,
+                ..
+            } => pattern.is_layout_dimension(dim.id()),
             _ => false,
         }
     }
 
     fn max_vectorization(&self, op: &ir::Operator) -> [u32; 2] {
         match op {
-            Operator::DmaStart { .. } |
-            Operator::DmaWait { .. } => [std::u32::MAX; 2],
+            Operator::DmaStart { .. } | Operator::DmaWait { .. } => [std::u32::MAX; 2],
             _ => [8, 4],
         }
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -767,3 +767,97 @@ fn non_contiguous_vector_dims() {
         DimKind::OUTER_VECTOR
     );
 }
+
+/// Ensures constraints are respected for DMA instructions.
+#[test]
+fn simple_dma() {
+    const DATA_TYPE: ir::Type = ir::Type::F(32);
+
+    let _ = env_logger::try_init();
+    let context = fake::Context::default();
+    let signature = empty_signature();
+    let mut builder = helper::Builder::new(&signature, context.device());
+
+    let buffer = builder.allocate_shared(DATA_TYPE, 256);
+    let start_dim = builder.open_dim_ex(ir::Size::new_const(256), DimKind::VECTOR);
+    let (src_ptr, src_pattern) = builder
+        .tensor_access(&0i32, None, DATA_TYPE, &[&start_dim]);
+    let (dst_ptr, _) = builder
+        .tensor_access(&buffer, Some(buffer), DATA_TYPE, &[&start_dim]);
+    let start = builder.dma_start(&src_ptr, src_pattern, &dst_ptr, false);
+    let wait_dim = builder.open_mapped_dim(&start_dim);
+    let (_, dst_pattern) = builder
+        .tensor_access(&buffer, Some(buffer), DATA_TYPE, &[&wait_dim]);
+    builder.dma_wait(start, dst_pattern);
+
+    let sync_var = builder.get_inst_variable(start);
+    let space = builder.get();
+    // Ensures start and wait have the same vectorization pattern.
+    assert_eq!(space.domain().get_dim_kind(wait_dim[0]), DimKind::VECTOR);
+    // Ensure the synchronisation flag has the correct type.
+    assert_eq!(space.ir_instance().variable(sync_var).t(), ir::Type::SyncFlag);
+    // Ensure the synchronisation flag is handled as a vector register.
+    assert_eq!(space.domain().get_memory_space(sync_var), MemorySpace::VECTOR_REGISTER);
+    // Try to generate a fully specified candidate.
+    gen_best(&context, space);
+}
+
+/// Ensures DMA start and stop instructions have the same nesting.
+#[test]
+fn dma_start_wait_nesting() {
+    const DATA_TYPE: ir::Type = ir::Type::F(32);
+
+    let _ = env_logger::try_init();
+    let context = fake::Context::default();
+    let signature = empty_signature();
+    let mut builder = helper::Builder::new(&signature, context.device());
+
+    let buffer = builder.allocate_shared(DATA_TYPE, 256);
+    let start_dim = builder.open_dim_ex(ir::Size::new_const(256), DimKind::VECTOR);
+    let (src_ptr, src_pattern) = builder
+        .tensor_access(&0i32, None, DATA_TYPE, &[&start_dim]);
+    let (dst_ptr, _) = builder
+        .tensor_access(&buffer, Some(buffer), DATA_TYPE, &[&start_dim]);
+    let start = builder.dma_start(&src_ptr, src_pattern, &dst_ptr, false);
+    let wait_dim = builder.open_mapped_dim(&start_dim);
+    let (_, dst_pattern) = builder
+        .tensor_access(&buffer, Some(buffer), DATA_TYPE, &[&wait_dim]);
+    let wait = builder.dma_wait(start, dst_pattern);
+
+    let extra_dim = builder.open_dim(ir::Size::new_const(42));
+    builder.order(&start, &extra_dim, Order::INNER);
+    let space = builder.get();
+    assert_eq!(space.domain().get_order(wait.into(), extra_dim[0].into()), Order::INNER);
+}
+
+/// Ensure we can generate DMA with strided accesses and multiple requests in-flight.
+#[test]
+fn complex_dma() {
+    const DATA_TYPE: ir::Type = ir::Type::F(32);
+
+    let _ = env_logger::try_init();
+    let context = fake::Context::default();
+    let signature = empty_signature();
+    let mut builder = helper::Builder::new(&signature, context.device());
+
+    let buffer = builder.allocate_shared(DATA_TYPE, 256);
+    let start_dim_0 = builder.open_dim_ex(ir::Size::new_const(4), DimKind::OUTER_VECTOR);
+    let start_dim_1 = builder.open_dim_ex(ir::Size::new_const(4), DimKind::UNROLL);
+    let start_dim_2 = builder.open_dim_ex(ir::Size::new_const(4), DimKind::INNER_VECTOR);
+    let (src_ptr, src_pattern) = builder.tensor_access(
+        &0i32, None, DATA_TYPE, &[&start_dim_0, &start_dim_1, &start_dim_2]);
+    let (dst_ptr, _) = builder.tensor_access(
+        &buffer, Some(buffer), DATA_TYPE, &[&start_dim_0, &start_dim_1, &start_dim_2]);
+    let start = builder.dma_start(&src_ptr, src_pattern, &dst_ptr, false);
+
+    let wait_dim_0 = builder.open_mapped_dim(&start_dim_0);
+    let wait_dim_1 = builder.open_mapped_dim(&start_dim_1);
+    let wait_dim_2 = builder.open_mapped_dim(&start_dim_2);
+    let (_, dst_pattern) = builder.tensor_access(
+        &buffer, Some(buffer), DATA_TYPE, &[&wait_dim_0, &wait_dim_1, &wait_dim_2]);
+    builder.dma_wait(start, dst_pattern);
+    builder.order(&start_dim_1, &wait_dim_1, Order::BEFORE);
+    let space = builder.get();
+    // Try to generate a fully specified candidate.
+    gen_best(&context, space);
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -786,14 +786,14 @@ fn simple_dma() {
 
     let buffer = builder.allocate_shared(DATA_TYPE, 256);
     let start_dim = builder.open_dim_ex(ir::Size::new_const(256), DimKind::VECTOR);
-    let (src_ptr, src_pattern) = builder
-        .tensor_access(&0i32, None, DATA_TYPE, &[&start_dim]);
-    let (dst_ptr, _) = builder
-        .tensor_access(&buffer, Some(buffer), DATA_TYPE, &[&start_dim]);
+    let (src_ptr, src_pattern) =
+        builder.tensor_access(&0i32, None, DATA_TYPE, &[&start_dim]);
+    let (dst_ptr, _) =
+        builder.tensor_access(&buffer, Some(buffer), DATA_TYPE, &[&start_dim]);
     let start = builder.dma_start(&src_ptr, src_pattern, &dst_ptr, false);
     let wait_dim = builder.open_mapped_dim(&start_dim);
-    let (_, dst_pattern) = builder
-        .tensor_access(&buffer, Some(buffer), DATA_TYPE, &[&wait_dim]);
+    let (_, dst_pattern) =
+        builder.tensor_access(&buffer, Some(buffer), DATA_TYPE, &[&wait_dim]);
     builder.dma_wait(start, dst_pattern);
 
     let sync_var = builder.get_inst_variable(start);
@@ -801,9 +801,15 @@ fn simple_dma() {
     // Ensures start and wait have the same vectorization pattern.
     assert_eq!(space.domain().get_dim_kind(wait_dim[0]), DimKind::VECTOR);
     // Ensure the synchronisation flag has the correct type.
-    assert_eq!(space.ir_instance().variable(sync_var).t(), ir::Type::SyncFlag);
+    assert_eq!(
+        space.ir_instance().variable(sync_var).t(),
+        ir::Type::SyncFlag
+    );
     // Ensure the synchronisation flag is handled as a vector register.
-    assert_eq!(space.domain().get_memory_space(sync_var), MemorySpace::VECTOR_REGISTER);
+    assert_eq!(
+        space.domain().get_memory_space(sync_var),
+        MemorySpace::VECTOR_REGISTER
+    );
     // Try to generate a fully specified candidate.
     gen_best(&context, space);
 }
@@ -820,20 +826,23 @@ fn dma_start_wait_nesting() {
 
     let buffer = builder.allocate_shared(DATA_TYPE, 256);
     let start_dim = builder.open_dim_ex(ir::Size::new_const(256), DimKind::VECTOR);
-    let (src_ptr, src_pattern) = builder
-        .tensor_access(&0i32, None, DATA_TYPE, &[&start_dim]);
-    let (dst_ptr, _) = builder
-        .tensor_access(&buffer, Some(buffer), DATA_TYPE, &[&start_dim]);
+    let (src_ptr, src_pattern) =
+        builder.tensor_access(&0i32, None, DATA_TYPE, &[&start_dim]);
+    let (dst_ptr, _) =
+        builder.tensor_access(&buffer, Some(buffer), DATA_TYPE, &[&start_dim]);
     let start = builder.dma_start(&src_ptr, src_pattern, &dst_ptr, false);
     let wait_dim = builder.open_mapped_dim(&start_dim);
-    let (_, dst_pattern) = builder
-        .tensor_access(&buffer, Some(buffer), DATA_TYPE, &[&wait_dim]);
+    let (_, dst_pattern) =
+        builder.tensor_access(&buffer, Some(buffer), DATA_TYPE, &[&wait_dim]);
     let wait = builder.dma_wait(start, dst_pattern);
 
     let extra_dim = builder.open_dim(ir::Size::new_const(42));
     builder.order(&start, &extra_dim, Order::INNER);
     let space = builder.get();
-    assert_eq!(space.domain().get_order(wait.into(), extra_dim[0].into()), Order::INNER);
+    assert_eq!(
+        space.domain().get_order(wait.into(), extra_dim[0].into()),
+        Order::INNER
+    );
 }
 
 /// Ensure we can generate DMA with strided accesses and multiple requests in-flight.
@@ -851,16 +860,28 @@ fn complex_dma() {
     let start_dim_1 = builder.open_dim_ex(ir::Size::new_const(4), DimKind::UNROLL);
     let start_dim_2 = builder.open_dim_ex(ir::Size::new_const(4), DimKind::INNER_VECTOR);
     let (src_ptr, src_pattern) = builder.tensor_access(
-        &0i32, None, DATA_TYPE, &[&start_dim_0, &start_dim_1, &start_dim_2]);
+        &0i32,
+        None,
+        DATA_TYPE,
+        &[&start_dim_0, &start_dim_1, &start_dim_2],
+    );
     let (dst_ptr, _) = builder.tensor_access(
-        &buffer, Some(buffer), DATA_TYPE, &[&start_dim_0, &start_dim_1, &start_dim_2]);
+        &buffer,
+        Some(buffer),
+        DATA_TYPE,
+        &[&start_dim_0, &start_dim_1, &start_dim_2],
+    );
     let start = builder.dma_start(&src_ptr, src_pattern, &dst_ptr, false);
 
     let wait_dim_0 = builder.open_mapped_dim(&start_dim_0);
     let wait_dim_1 = builder.open_mapped_dim(&start_dim_1);
     let wait_dim_2 = builder.open_mapped_dim(&start_dim_2);
     let (_, dst_pattern) = builder.tensor_access(
-        &buffer, Some(buffer), DATA_TYPE, &[&wait_dim_0, &wait_dim_1, &wait_dim_2]);
+        &buffer,
+        Some(buffer),
+        DATA_TYPE,
+        &[&wait_dim_0, &wait_dim_1, &wait_dim_2],
+    );
     builder.dma_wait(start, dst_pattern);
     builder.order(&start_dim_1, &wait_dim_1, Order::BEFORE);
     let space = builder.get();


### PR DESCRIPTION
This changes adds support for DMA instructions in Telamon. For that it
adds two instructions (DmaStart and DmaWait) and a new type of
variables (SyncFlag). DmaStart produces a SyncFlag variables consumed by
DmaWait. Constraints on the SyncFlag variable ensure the start and wait
instruction have the same vectorization pattern.

Suggested review order:
- src/ir/operator.rs
- src/ir/instruction.rs
- src/ir/types.rs
- src/search_space/variable.exh
- src/codegen/function.rs
- src/codegen/printer.rs
- src/helper/builder.rs
