### PR TITLE
Fix some MPPA compilation issues

### DIFF
--- a/src/device/mppa/device.rs
+++ b/src/device/mppa/device.rs
@@ -12,14 +12,6 @@ impl device::Device for MPPA {
         device::mppa::printer::print(fun, false, out).unwrap();
     }
 
-    fn is_valid_type(&self, t: &ir::Type) -> bool {
-        match *t {
-            ir::Type::Void | ir::Type::PtrTo(..) => true,
-            ir::Type::F(x) => x == 16 || x == 32 || x == 64,
-            ir::Type::I(x) => x == 8 || x == 16 || x == 32 || x == 64,
-        }
-    }
-
     fn lower_type(&self, t: ir::Type, _: &SearchSpace) -> Option<ir::Type> {
         Some(t)
     }
@@ -42,18 +34,6 @@ impl device::Device for MPPA {
     // TODO(mppa): allow SMEM use and allow L1 as scratchpad
     fn shared_mem(&self) -> u32 {
         0
-    }
-
-    fn supports_nc_access(&self) -> bool {
-        false
-    }
-
-    fn supports_l1_access(&self) -> bool {
-        false
-    }
-
-    fn supports_l2_access(&self) -> bool {
-        false
     }
 
     fn name(&self) -> &str {

--- a/src/device/mppa/printer.rs
+++ b/src/device/mppa/printer.rs
@@ -168,7 +168,7 @@ pub fn print(fun: &Function, time: bool, out: &mut io::Write) -> io::Result<()> 
 /// Prints a multiplicative induction var level.
 fn parallel_induction_level(
     dim: ir::DimId,
-    level: &InductionVarLevel,
+    level: &InductionLevel,
     name_map: &NameMap,
     out: &mut fmt::Write,
 ) -> fmt::Result {
@@ -309,11 +309,11 @@ fn instruction(
         write!(out, "  {} = ", name_map.name_inst(inst))?;
     }
     match *inst.operator() {
-        ir::op::Add(ref lhs, ref rhs, rounding) => {
+        ir::op::BinOp(ir::BinOp::Add, ref lhs, ref rhs, rounding) => {
             assert!(check_rounding(rounding));
             write!(out, "{} + {}", name_map.name(lhs), name_map.name(rhs))
         }
-        ir::op::Sub(ref lhs, ref rhs, rounding) => {
+        ir::op::BinOp(ir::BinOp::Sub, ref lhs, ref rhs, rounding) => {
             assert!(check_rounding(rounding));
             write!(out, "{} - {}", name_map.name(lhs), name_map.name(rhs))
         }
@@ -338,11 +338,11 @@ fn instruction(
             let add_rhs = name_map.name(add_rhs);
             write!(out, "({}){} * ({}){} + {}", t, mul_lhs, t, mul_rhs, add_rhs)
         }
-        ir::op::Div(ref lhs, ref rhs, rounding) => {
+        ir::op::BinOp(ir::BinOp::Div, ref lhs, ref rhs, rounding) => {
             assert!(check_rounding(rounding));
             write!(out, "{}/{}", name_map.name(lhs), name_map.name(rhs))
         }
-        ir::op::Mov(ref op) => write!(out, "{}", name_map.name(op)),
+        ir::op::UnaryOp(ir::UnaryOp::Mov, ref op) => write!(out, "{}", name_map.name(op)),
         ir::op::Ld(ref t, ref addr, _) => {
             write!(out, "*({}*){}", type_name(t), name_map.name(addr))
         }
@@ -351,10 +351,10 @@ fn instruction(
             let addr = name_map.name(addr);
             write!(out, "*(({}*){}) = {}", val_type, addr, name_map.name(val))
         }
-        ir::op::Cast(ref op, ir::Type::PtrTo(_)) => {
+        ir::op::UnaryOp(ir::UnaryOp::Cast(ir::Type::PtrTo(_)), ref op) => {
             write!(out, "(void*)(intptr_t) {}", name_map.name(op))
         }
-        ir::op::Cast(ref op, ref t) => {
+        ir::op::UnaryOp(ir::UnaryOp::Cast(ref t), ref op) => {
             write!(out, "({}) {}", type_name(t), name_map.name(op))
         }
         ir::op::TmpLd(..) | ir::op::TmpSt(..) => panic!("non-printable instruction"),


### PR DESCRIPTION
This upgrades the MPPA device to use:

 - The new printer structure (with BinOp / UnaryOp)
 - The new Context API (some functions have been moved out of the trait)
 - The new Device API (some functions are no longer used)

There are still remaining issues that I don't know how to fix, namely:

 - `induction_level_base` no longer exists (in the printer)
 - device::Argument has been replaced with device::ScalarArgument which
   is no longer object safe

telamon:
 * src/device/mppa/context.rs:
 * src/device/mppa/device.rs:
 * src/device/mppa/printer.rs: