### PR TITLE
Add object-safe trait for building candidates

### DIFF
--- a/kernels/benches/cuda_bound.rs
+++ b/kernels/benches/cuda_bound.rs
@@ -4,7 +4,7 @@ extern crate telamon;
 extern crate telamon_kernels;
 
 use telamon::device::cuda;
-use telamon_kernels::{analyze_bounds, linalg, Kernel};
+use telamon_kernels::{analyze_bounds, linalg, Kernel, MemInit};
 
 fn main() {
     env_logger::init();
@@ -29,7 +29,7 @@ where
     K: Kernel<'a>,
 {
     let mut context = cuda::Context::new(executor);
-    let bounds = K::test_bound(params, num_runs, true, &mut context);
+    let bounds = K::test_bound(params, num_runs, MemInit::RandomFill, &mut context);
     println!("bounds for kernel {}", K::name());
     analyze_bounds(bounds);
 }

--- a/kernels/benches/cuda_search.rs
+++ b/kernels/benches/cuda_search.rs
@@ -13,7 +13,7 @@ use cuda_sys::cuda::*;
 use telamon::device::cuda;
 use telamon::explorer::config::Config;
 use telamon_kernels::statistics::estimate_mean;
-use telamon_kernels::{linalg, Kernel};
+use telamon_kernels::{linalg, Kernel, MemInit};
 
 fn main() {
     env_logger::init();
@@ -104,8 +104,13 @@ fn benchmark<'a, K, REF>(
     //config.distance_to_best.get_or_insert(20.);
 
     let mut context = cuda::Context::new(executor);
-    let runtime =
-        K::benchmark(&config, params.clone(), NUM_CODE_RUNS, true, &mut context);
+    let runtime = K::benchmark(
+        &config,
+        params.clone(),
+        NUM_CODE_RUNS,
+        MemInit::RandomFill,
+        &mut context,
+    );
     for _ in 0..4 {
         reference(&params, &context);
     }

--- a/kernels/benches/cuda_variance.rs
+++ b/kernels/benches/cuda_variance.rs
@@ -61,7 +61,7 @@ where
             let bounds = candidates.iter().map(|c| c.bound.value()).enumerate();
             let candidate_idx = local_selection::pick_index(order, bounds, CUT);
             let candidate = candidates[unwrap!(candidate_idx)].clone();
-            local_selection::descend(order, &context, candidate, CUT)
+            local_selection::descend(&Default::default(), order, &context, candidate, CUT)
         }).take(NUM_TESTS)
         .collect_vec();
     info!("Evaluating candidates, simulating a GPU-bound exploration");

--- a/kernels/src/kernel.rs
+++ b/kernels/src/kernel.rs
@@ -4,6 +4,8 @@ use num_cpus;
 use rayon::prelude::*;
 use statistics;
 use std;
+use std::borrow::Cow;
+use std::marker::PhantomData;
 use std::sync::{atomic, Mutex};
 use telamon::explorer::{local_selection, Candidate};
 use telamon::helper::SignatureBuilder;
@@ -56,56 +58,66 @@ pub trait Kernel<'a>: Sized {
         context: &device::Context,
     ) -> Result<(), String>;
 
+    fn builder(params: Self::Parameters) -> KernelBuilder<Self, Self::Parameters> {
+        KernelBuilder::new(params)
+    }
+
     /// Generates, executes and tests the output of candidates for the kernel.
     fn test_correctness<AM>(params: Self::Parameters, num_tests: usize, context: &mut AM)
     where
         AM: device::ArgMap + device::Context + 'a,
     {
-        let kernel;
-        let signature = {
-            let mut builder = SignatureBuilder::new(Self::name(), context);
-            builder.set_random_fill(true);
-            kernel = Self::build_signature(params, &mut builder);
-            builder.get()
-        };
-        let expected_output = kernel.get_expected_output(context);
-        let candidates = kernel.build_body(&signature, context);
-        let mut num_deadends = 0;
-        let mut num_runs = 0;
-        while num_runs < num_tests {
-            let order = explorer::config::NewNodeOrder::WeightedRandom;
-            let ordering = explorer::config::ChoiceOrdering::default();
-            let bounds = candidates.iter().map(|c| c.bound.value()).enumerate();
-            let candidate_idx = local_selection::pick_index(order, bounds, CUT);
-            let candidate = candidates[unwrap!(candidate_idx)].clone();
-            let leaf =
-                local_selection::descend(&ordering, order, context, candidate, CUT);
-            if let Some(leaf) = leaf {
-                let device_fn = codegen::Function::build(&leaf.space);
-                unwrap!(
-                    context.evaluate(&device_fn, device::EvalMode::FindBest),
-                    "evaluation failed for kernel {}, with actions {:?}",
-                    Self::name(),
-                    leaf.actions
-                );
-                if let Err(err) = kernel.check_result(&expected_output, context) {
-                    panic!(
-                        "incorrect output for kernel {}, with actions {:?}: {}",
-                        Self::name(),
-                        leaf.actions,
-                        err
-                    )
+        Self::builder(params)
+            .mem_init(MemInit::RandomFill)
+            .scoped_kernel(context, |context, kernel, signature| {
+                let expected_output = kernel.get_expected_output(context);
+                let candidates = kernel.build_body(&signature, context);
+                let mut num_deadends = 0;
+                let mut num_runs = 0;
+                while num_runs < num_tests {
+                    let order = explorer::config::NewNodeOrder::WeightedRandom;
+                    let ordering = explorer::config::ChoiceOrdering::default();
+                    let bounds = candidates.iter().map(|c| c.bound.value()).enumerate();
+                    let candidate_idx = local_selection::pick_index(order, bounds, CUT);
+                    let candidate = candidates[unwrap!(candidate_idx)].clone();
+                    let leaf = local_selection::descend(
+                        &ordering, order, context, candidate, CUT,
+                    );
+                    if let Some(leaf) = leaf {
+                        let device_fn = codegen::Function::build(&leaf.space);
+                        unwrap!(
+                            context.evaluate(&device_fn, device::EvalMode::FindBest),
+                            "evaluation failed for kernel {}, with actions {:?}",
+                            Self::name(),
+                            leaf.actions
+                        );
+                        if let Err(err) = kernel.check_result(&expected_output, context) {
+                            panic!(
+                                "incorrect output for kernel {}, with actions {:?}: {}",
+                                Self::name(),
+                                leaf.actions,
+                                err
+                            )
+                        }
+                        num_runs += 1;
+                    } else {
+                        num_deadends += 1;
+                        if num_deadends as f32 / ((1 + num_deadends + num_runs) as f32)
+                            >= MAX_DEADEND_RATIO
+                        {
+                            panic!(
+                                concat!(
+                                    "too many dead-ends for kernel {}, ",
+                                    "{} deadends for {} successful runs"
+                                ),
+                                Self::name(),
+                                num_deadends,
+                                num_runs
+                            )
+                        }
+                    }
                 }
-                num_runs += 1;
-            } else {
-                num_deadends += 1;
-                if num_deadends as f32 / ((1 + num_deadends + num_runs) as f32)
-                    >= MAX_DEADEND_RATIO
-                {
-                    panic!("too many dead-ends for kernel {}, {} deadends for {} successful runs", Self::name(), num_deadends, num_runs)
-                }
-            }
-        }
+            })
     }
 
     /// Tests the correctness of the bound of kernels and returns the list of tested leafs
@@ -113,66 +125,73 @@ pub trait Kernel<'a>: Sized {
     fn test_bound<AM>(
         params: Self::Parameters,
         num_tests: usize,
-        random_fill: bool,
+        mem_init: MemInit,
         context: &mut AM,
     ) -> Vec<BoundSample>
     where
         AM: device::ArgMap + device::Context + 'a,
     {
-        let kernel;
-        let signature = {
-            let mut builder = SignatureBuilder::new(Self::name(), context);
-            builder.set_random_fill(random_fill);
-            kernel = Self::build_signature(params, &mut builder);
-            builder.get()
-        };
-        let candidates = kernel.build_body(&signature, context);
-        let leaves = Mutex::new(Vec::new());
-        let num_tested = atomic::AtomicUsize::new(0);
-        context.async_eval(
-            num_cpus::get(),
-            device::EvalMode::TestBound,
-            &|evaluator| loop {
-                if num_tested.fetch_add(1, atomic::Ordering::SeqCst) >= num_tests {
-                    if num_tested.fetch_sub(1, atomic::Ordering::SeqCst) > num_tests {
-                        break;
-                    }
-                }
-                if let Some((leaf, bounds)) = descend_check_bounds(&candidates, context) {
-                    let leaves = &leaves;
-                    evaluator.add_kernel(
-                        leaf,
-                        (move |leaf: Candidate, runtime: f64| {
-                            let bound = leaf.bound.clone();
-                            let mut leaves = unwrap!(leaves.lock());
-                            let mut actions = leaf.actions.iter().cloned().collect_vec();
-                            actions.reverse();
-                            for (idx, partial_bound) in bounds.iter().enumerate() {
-                                assert!(
-                                    partial_bound.value() <= bound.value() * 1.01,
-                                    "invalid inner bound: {} < {}, kernel {}, \
-                                     actions {:?} then {:?}",
-                                    partial_bound,
-                                    bound,
-                                    Self::name(),
-                                    &actions[..idx],
-                                    &actions[idx..]
-                                );
+        Self::builder(params).mem_init(mem_init).scoped_candidates(
+            context,
+            |context, candidates| {
+                let leaves = Mutex::new(Vec::new());
+                let num_tested = atomic::AtomicUsize::new(0);
+                context.async_eval(
+                    num_cpus::get(),
+                    device::EvalMode::TestBound,
+                    &|evaluator| loop {
+                        if num_tested.fetch_add(1, atomic::Ordering::SeqCst) >= num_tests
+                        {
+                            if num_tested.fetch_sub(1, atomic::Ordering::SeqCst)
+                                > num_tests
+                            {
+                                break;
                             }
-                            info!("new evaluation: {:.2e}ns, bound {}", runtime, bound);
-                            leaves.push(BoundSample {
-                                actions,
-                                bound,
-                                runtime,
-                            });
-                        }).into(),
-                    );
-                } else {
-                    num_tested.fetch_sub(1, atomic::Ordering::SeqCst);
-                }
+                        }
+                        if let Some((leaf, bounds)) =
+                            descend_check_bounds(&candidates, context)
+                        {
+                            let leaves = &leaves;
+                            evaluator.add_kernel(
+                                leaf,
+                                (move |leaf: Candidate, runtime: f64| {
+                                    let bound = leaf.bound.clone();
+                                    let mut leaves = unwrap!(leaves.lock());
+                                    let mut actions =
+                                        leaf.actions.iter().cloned().collect_vec();
+                                    actions.reverse();
+                                    for (idx, partial_bound) in bounds.iter().enumerate()
+                                    {
+                                        assert!(
+                                            partial_bound.value() <= bound.value() * 1.01,
+                                            "invalid inner bound: {} < {}, kernel {}, \
+                                             actions {:?} then {:?}",
+                                            partial_bound,
+                                            bound,
+                                            Self::name(),
+                                            &actions[..idx],
+                                            &actions[idx..]
+                                        );
+                                    }
+                                    info!(
+                                        "new evaluation: {:.2e}ns, bound {}",
+                                        runtime, bound
+                                    );
+                                    leaves.push(BoundSample {
+                                        actions,
+                                        bound,
+                                        runtime,
+                                    });
+                                }).into(),
+                            );
+                        } else {
+                            num_tested.fetch_sub(1, atomic::Ordering::SeqCst);
+                        }
+                    },
+                );
+                unwrap!(leaves.into_inner())
             },
-        );
-        unwrap!(leaves.into_inner())
+        )
     }
 
     /// Runs the search and benchmarks the resulting candidate.
@@ -180,27 +199,24 @@ pub trait Kernel<'a>: Sized {
         config: &explorer::Config,
         params: Self::Parameters,
         num_samples: usize,
-        random_fill: bool,
+        mem_init: MemInit,
         context: &mut AM,
     ) -> Vec<f64>
     where
         AM: device::ArgMap + device::Context + 'a,
     {
-        let kernel;
-        let signature = {
-            let mut builder = SignatureBuilder::new(Self::name(), context);
-            builder.set_random_fill(random_fill);
-            kernel = Self::build_signature(params, &mut builder);
-            builder.get()
-        };
-        let search_space = kernel.build_body(&signature, context);
-        let best = unwrap!(
-            explorer::find_best_ex(config, context, search_space),
-            "no candidates found for kernel {}",
-            Self::name()
-        );
-        let best_fn = codegen::Function::build(&best.space);
-        context.benchmark(&best_fn, num_samples)
+        Self::builder(params).mem_init(mem_init).scoped_candidates(
+            context,
+            |context, candidates| {
+                let best = unwrap!(
+                    explorer::find_best_ex(config, context, candidates),
+                    "no candidates found for kernel {}",
+                    Self::name()
+                );
+                let best_fn = codegen::Function::build(&best.space);
+                context.benchmark(&best_fn, num_samples)
+            },
+        )
     }
 
     /// Computes the probability of encountering a dead-end when descending in the search
@@ -213,26 +229,141 @@ pub trait Kernel<'a>: Sized {
     where
         AM: device::ArgMap + device::Context + 'a,
     {
-        let kernel;
-        let signature = {
-            let mut builder = SignatureBuilder::new(Self::name(), context);
-            kernel = Self::build_signature(params, &mut builder);
-            builder.get()
-        };
-        let candidates = kernel.build_body(&signature, context);
-        let num_deadends = (0..num_samples)
-            .into_par_iter()
-            .filter(|_| {
-                let order = explorer::config::NewNodeOrder::WeightedRandom;
-                let ordering = explorer::config::ChoiceOrdering::default();
-                let inf = std::f64::INFINITY;
-                let bounds = candidates.iter().map(|c| c.bound.value()).enumerate();
-                let candidate_idx = local_selection::pick_index(order, bounds, inf);
-                let candidate = candidates[unwrap!(candidate_idx)].clone();
-                local_selection::descend(&ordering, order, context, candidate, inf)
-                    .is_none()
-            }).count();
-        num_deadends as f64 / num_samples as f64
+        Self::builder(params)
+            .mem_init(MemInit::Uninit)
+            .scoped_candidates(context, |context, candidates| {
+                let num_deadends = (0..num_samples)
+                    .into_par_iter()
+                    .filter(|_| {
+                        let order = explorer::config::NewNodeOrder::WeightedRandom;
+                        let ordering = explorer::config::ChoiceOrdering::default();
+                        let inf = std::f64::INFINITY;
+                        let bounds =
+                            candidates.iter().map(|c| c.bound.value()).enumerate();
+                        let candidate_idx =
+                            local_selection::pick_index(order, bounds, inf);
+                        let candidate = candidates[unwrap!(candidate_idx)].clone();
+                        local_selection::descend(
+                            &ordering, order, context, candidate, inf,
+                        ).is_none()
+                    }).count();
+                num_deadends as f64 / num_samples as f64
+            })
+    }
+}
+
+/// Memory initialization strategies.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum MemInit {
+    /// Memory is left uninitialized
+    Uninit,
+    /// Memory is randomly filled with zeroes
+    RandomFill,
+}
+
+/// A kernel builder, providing control over the kernel parameters and execution hyper-parameters.
+pub struct KernelBuilder<K, P> {
+    kernel: PhantomData<fn() -> K>,
+    name: Cow<'static, str>,
+    mem_init: MemInit,
+    params: P,
+}
+
+// Manual Clone implementation because the generated one requires a `Clone` bound on `K`.
+impl<'a, K: Kernel<'a>> Clone for KernelBuilder<K, K::Parameters> {
+    fn clone(&self) -> Self {
+        KernelBuilder {
+            kernel: PhantomData,
+            params: self.params.clone(),
+            name: self.name.clone(),
+            mem_init: self.mem_init,
+        }
+    }
+}
+
+impl<'a, K: Kernel<'a>> KernelBuilder<K, K::Parameters> {
+    /// Constructs a new `KernelBuilder` for kernels of type `K` with parameters `params`, with the
+    /// following default configuration:
+    ///
+    ///  - Use the default kernel name from `K::name`
+    ///  - Memory is left unitialized
+    ///
+    /// Builder methods are provided to change these defaults and otherwise configure the kernel.
+    pub fn new(params: K::Parameters) -> Self {
+        KernelBuilder {
+            kernel: PhantomData,
+            params,
+            name: K::name().into(),
+            mem_init: MemInit::Uninit,
+        }
+    }
+
+    /// Sets the name of the generated kernel.  This will appear in log files.
+    pub fn name<T: Into<Cow<'static, str>>>(mut self, name: T) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Sets the memory initialization strategy.  See `MemInit` for details.
+    fn mem_init(mut self, mem_init: MemInit) -> Self {
+        self.mem_init = mem_init;
+        self
+    }
+
+    /// Creates the kernel in the given `context` and passes it to the `body` for handling.
+    fn scoped_kernel<AM, T>(
+        self,
+        context: &mut AM,
+        body: impl FnOnce(&AM, K, ir::Signature) -> T,
+    ) -> T
+    where
+        AM: device::ArgMap + device::Context + 'a,
+    {
+        let (kernel, signature);
+        {
+            let mut builder = SignatureBuilder::new(&self.name, context);
+            builder.set_random_fill(match self.mem_init {
+                MemInit::RandomFill => true,
+                MemInit::Uninit => false,
+            });
+            kernel = K::build_signature(self.params, &mut builder);
+            signature = builder.get();
+        }
+
+        body(context, kernel, signature)
+    }
+}
+
+/// An object-safe trait independent of the kernel to create type-erased candidates.
+pub trait ScopedCandidates<'a, F, AM, T>
+where
+    AM: device::ArgMap + device::Context + 'a,
+    F: for<'c> FnOnce(&AM, Vec<Candidate<'c>>) -> T,
+{
+    fn scoped_candidates(self, context: &mut AM, body: F) -> T
+    where
+        Self: Sized,
+    {
+        // This becomes `*Box::new(self)`; rust should be able to eliminate the allocation.
+        Box::new(self).scoped_candidates_box(context, body)
+    }
+
+    // TODO(bclement): Remove once unsized_locals stabilizes.
+    // https://github.com/rust-lang/rust/issues/48055
+    fn scoped_candidates_box(self: Box<Self>, context: &mut AM, body: F) -> T;
+}
+
+impl<'a, F, AM, K, T> ScopedCandidates<'a, F, AM, T> for KernelBuilder<K, K::Parameters>
+where
+    AM: device::ArgMap + device::Context + 'a,
+    K: Kernel<'a>,
+    F: for<'c> FnOnce(&AM, Vec<Candidate<'c>>) -> T,
+{
+    fn scoped_candidates_box(self: Box<Self>, context: &mut AM, body: F) -> T {
+        (*self).scoped_kernel(context, |context, kernel, signature| {
+            let candidates = kernel.build_body(&signature, context);
+            body(context, candidates)
+        })
     }
 }
 

--- a/kernels/src/lib.rs
+++ b/kernels/src/lib.rs
@@ -19,7 +19,7 @@ mod kernel;
 pub mod linalg;
 pub mod statistics;
 
-pub use kernel::{analyze_bounds, Kernel};
+pub use kernel::{analyze_bounds, Kernel, KernelBuilder, MemInit, ScopedCandidates};
 
 use telamon::device::{self, ArgMap, Context};
 use telamon::helper::tensor::DimSize;

--- a/telamon-capi/src/lib.rs
+++ b/telamon-capi/src/lib.rs
@@ -27,7 +27,7 @@ use telamon::device;
 use telamon::device::x86;
 use telamon::explorer::config::Config;
 use telamon::helper::TilingPattern;
-pub use telamon_kernels::{linalg, Kernel};
+pub use telamon_kernels::{linalg, Kernel, MemInit};
 
 // Pointers to `device::Context` and `device::Device` are not C-like pointers.
 // Instead, they are fat pointers containing both a regular pointer to the
@@ -75,7 +75,7 @@ impl KernelParameters {
                     config,
                     params.clone(),
                     0,
-                    true,
+                    MemInit::RandomFill,
                     context,
                 );
             }


### PR DESCRIPTION
This patch introduces a `KernelBuilder` structure which wraps a kernel's
parameters.  The `KernelBuilder` provides a `scoped_kernel` helper
function which takes care of building the kernel itself and its
signature, and passes them on to a scoped closure[1].  Moreover, it
introduces a `ScopedCandidates` trait (and implements it for the
`KernelBuilder`) that allows building candidates from a type which
doesn't depend on the actual kernel used:

```rust
let builder: Box<dyn ScopedCandidates<'_, _, _, _>> = match KernelType {
	Axpy(params) => Box::new(linalg::Axpy<'_, f32>::builder(params)),
	MatMul(params) => Box::new(
		linalg::MatMul<'_, f32>::builder(params),
	)
}
```

This makes it easier to write kernel-independent tools around the core
Telamon library; in particular, this will allow more direct integration with the `Candidates` on the Python side of things (we want to reach the candidates from Python).

I am not 100% sure this is the right approach; ideally I'd like a way to create the Context (from Python), then interact with it by creating various candidates, contexts, etc. but as far as I can tell this is going to be a pain due to all the lifetime-bound references lying around.  Using a callback in that case seems like the less painful path to me; unless @ulysseB has a better suggestion.

1: The closure is required to ensure lifetime invariants relative to the
   mutable reference on the execution context.

telamon-kernels/
 * src/kernel.rs:
	Introduce the `KernelBuilder` and `ScopedCandidates`, and rewrite
	the `Kernel` helper functions (`benchmark`, etc.) to use them.
	Also introduce and use a more explicit `MemInit` enum for specifying
	memory initialization procedure instead of relying on a
	`random_fill` boolean.
 * src/lib.rs:
 * benches/cuda_bound.rs:
 * benches/cuda_search.rs:
 * benches/cuda_variance.rs:

telamon-capi/
 * telamon-capi/src/lib.rs