### PR TITLE
Make ArgMap object-safe

### DIFF
--- a/kernels/benches/cuda_variance.rs
+++ b/kernels/benches/cuda_variance.rs
@@ -61,7 +61,7 @@ where
             let bounds = candidates.iter().map(|c| c.bound.value()).enumerate();
             let candidate_idx = local_selection::pick_index(order, bounds, CUT);
             let candidate = candidates[unwrap!(candidate_idx)].clone();
-            local_selection::descend(order, &context, candidate, CUT)
+            local_selection::descend(&Default::default(), order, &context, candidate, CUT)
         }).take(NUM_TESTS)
         .collect_vec();
     info!("Evaluating candidates, simulating a GPU-bound exploration");

--- a/kernels/src/kernel.rs
+++ b/kernels/src/kernel.rs
@@ -36,7 +36,7 @@ pub trait Kernel<'a>: Sized {
         builder: &mut SignatureBuilder<AM>,
     ) -> Self
     where
-        AM: device::ArgMap + device::Context + 'a;
+        AM: device::ArgMap<'a> + device::Context;
 
     /// Builder the kernel body in the given builder. This builder should be based on the
     /// signature created by `build_signature`.
@@ -59,7 +59,7 @@ pub trait Kernel<'a>: Sized {
     /// Generates, executes and tests the output of candidates for the kernel.
     fn test_correctness<AM>(params: Self::Parameters, num_tests: usize, context: &mut AM)
     where
-        AM: device::ArgMap + device::Context + 'a,
+        AM: device::ArgMap<'a> + device::Context,
     {
         let kernel;
         let signature = {
@@ -117,7 +117,7 @@ pub trait Kernel<'a>: Sized {
         context: &mut AM,
     ) -> Vec<BoundSample>
     where
-        AM: device::ArgMap + device::Context + 'a,
+        AM: device::ArgMap<'a> + device::Context,
     {
         let kernel;
         let signature = {
@@ -184,7 +184,7 @@ pub trait Kernel<'a>: Sized {
         context: &mut AM,
     ) -> Vec<f64>
     where
-        AM: device::ArgMap + device::Context + 'a,
+        AM: device::ArgMap<'a> + device::Context,
     {
         let kernel;
         let signature = {
@@ -211,7 +211,7 @@ pub trait Kernel<'a>: Sized {
         context: &mut AM,
     ) -> f64
     where
-        AM: device::ArgMap + device::Context + 'a,
+        AM: device::ArgMap<'a> + device::Context,
     {
         let kernel;
         let signature = {

--- a/kernels/src/lib.rs
+++ b/kernels/src/lib.rs
@@ -44,7 +44,7 @@ fn create_size<'a, AM>(
     builder: &mut SignatureBuilder<AM>,
 ) -> DimSize<'a>
 where
-    AM: ArgMap + Context,
+    AM: ArgMap<'a> + Context,
 {
     if is_generic {
         builder.max_size(name, value as u32)

--- a/kernels/src/linalg.rs
+++ b/kernels/src/linalg.rs
@@ -39,7 +39,7 @@ where
         builder: &mut SignatureBuilder<AM>,
     ) -> Self
     where
-        AM: device::ArgMap + device::Context + 'a,
+        AM: device::ArgMap<'a> + device::Context,
     {
         let n_size = create_size(n, "n", generic, builder);
         builder.scalar("alpha", S::one());
@@ -121,7 +121,7 @@ where
         builder: &mut SignatureBuilder<AM>,
     ) -> Self
     where
-        AM: device::ArgMap + device::Context + 'a,
+        AM: device::ArgMap<'a> + device::Context,
     {
         let m_size = create_size(m, "m", generic, builder);
         let n_size = create_size(n, "n", generic, builder);
@@ -214,7 +214,7 @@ impl<'a, S: Scalar> Kernel<'a> for Gesummv<'a, S> {
         builder: &mut SignatureBuilder<AM>,
     ) -> Self
     where
-        AM: device::ArgMap + device::Context + 'a,
+        AM: device::ArgMap<'a> + device::Context,
     {
         let m_size = create_size(m, "m", generic, builder);
         let n_size = create_size(n, "n", generic, builder);
@@ -371,7 +371,7 @@ impl<'a, S: Scalar> Kernel<'a> for MatMul<'a, S> {
 
     fn build_signature<AM>(params: MatMulP, builder: &mut SignatureBuilder<AM>) -> Self
     where
-        AM: device::ArgMap + device::Context + 'a,
+        AM: device::ArgMap<'a> + device::Context,
     {
         let m_size = create_size(params.m, "m", params.generic, builder);
         let n_size = create_size(params.n, "n", params.generic, builder);
@@ -564,7 +564,7 @@ impl<'a, S: Scalar> Kernel<'a> for BatchMM<'a, S> {
 
     fn build_signature<AM>(params: BatchMMP, builder: &mut SignatureBuilder<AM>) -> Self
     where
-        AM: device::ArgMap + device::Context + 'a,
+        AM: device::ArgMap<'a> + device::Context,
     {
         let m_size = create_size(params.m, "m", params.generic, builder);
         let n_size = create_size(params.n, "n", params.generic, builder);

--- a/src/device/argument.rs
+++ b/src/device/argument.rs
@@ -81,7 +81,6 @@ float_scalar_argument!(unsafe impl ScalarArgument for f64 [(0.) .. (1.)]);
 // `ScalarArgument` implementation for integer types.  Requires that the type is an integer scalar
 // type (see safety requirements for `ScalarArgument`).
 macro_rules! int_scalar_argument {
-
     (unsafe impl ScalarArgument for $ty:ident [ ($start:expr) .. ($stop:expr) ]) => {
         unsafe impl ScalarArgument for $ty {
             fn as_size(&self) -> Option<u32> {

--- a/src/device/argument.rs
+++ b/src/device/argument.rs
@@ -1,156 +1,115 @@
 //! Maps rust types to telamon data types.
 use ir;
 use libc;
-use num::bigint::BigInt;
 use num::integer::div_rem;
 use num::rational::Ratio;
-use num::traits::FromPrimitive;
 use rand::Rng;
 use std;
-use std::fmt::Display;
 
-/// Represents a value that can be used as a `Function` argument. Must ensures the type
-/// is a scalar and does not contains any reference.
+/// Represents a value that can be used as a `Function` argument. Must ensures the type is a scalar
+/// and does not contains any reference.  Also must ensure that no two implementers should have the
+/// same `::t()` value, because that is used for downcasting.
 pub unsafe trait ScalarArgument:
-    Sync + Send + Copy + PartialEq + Display + 'static
+    std::fmt::Display + Send + Sync + 'static
 {
     /// Returns the argument interpreted as an iteration dimension size, if applicable.
     fn as_size(&self) -> Option<u32> {
         None
     }
+
     /// Returns the type of the argument.
-    fn t() -> ir::Type;
+    fn t() -> ir::Type
+    where
+        Self: Sized;
+
+    /// Returns the type of the argument.  This is a version of `::t()` that can be called on a
+    /// trait object.
+    fn get_type(&self) -> ir::Type;
+
     /// Returns a raw pointer to the object.
     fn raw_ptr(&self) -> *const libc::c_void;
+
     /// Returns an operand holding the argument value as a constant.
-    fn as_operand<L>(&self) -> ir::Operand<'static, L>;
+    fn as_operand<L>(&self) -> ir::Operand<'static, L>
+    where
+        Self: Sized;
+
     /// Generates a random instance of the argument type.
-    fn gen_random<R: Rng>(&mut R) -> Self;
+    fn gen_random<R: Rng>(&mut R) -> Self
+    where
+        Self: Sized;
 }
 
-unsafe impl ScalarArgument for f32 {
-    fn t() -> ir::Type {
-        ir::Type::F(32)
-    }
-
-    fn raw_ptr(&self) -> *const libc::c_void {
-        self as *const f32 as *const libc::c_void
-    }
-
-    fn as_operand<L>(&self) -> ir::Operand<'static, L> {
-        ir::Operand::new_float(unwrap!(Ratio::from_float(*self)), 32)
-    }
-
-    fn gen_random<R: Rng>(rng: &mut R) -> Self {
-        rng.gen_range(0., 1.)
-    }
+macro_rules! size_bits {
+    ($ty:ty) => {
+        8 * std::mem::size_of::<$ty>() as u16
+    };
 }
 
-unsafe impl ScalarArgument for f64 {
-    fn t() -> ir::Type {
-        ir::Type::F(64)
-    }
+macro_rules! scalar_argument {
+    ($ty:ident float [ ($start:expr) .. ($stop:expr) ]) => {
+        unsafe impl ScalarArgument for $ty {
+            fn t() -> ir::Type {
+                ir::Type::F(size_bits!($ty))
+            }
 
-    fn raw_ptr(&self) -> *const libc::c_void {
-        self as *const f64 as *const libc::c_void
-    }
+            fn get_type(&self) -> ir::Type {
+                Self::t()
+            }
 
-    fn as_operand<L>(&self) -> ir::Operand<'static, L> {
-        ir::Operand::new_float(unwrap!(Ratio::from_float(*self)), 64)
-    }
+            fn raw_ptr(&self) -> *const libc::c_void {
+                self as *const $ty as *const libc::c_void
+            }
 
-    fn gen_random<R: Rng>(rng: &mut R) -> Self {
-        rng.gen_range(0., 1.)
-    }
+            fn as_operand<L>(&self) -> ir::Operand<'static, L> {
+                ir::Operand::new_float(unwrap!(Ratio::from_float(*self)), size_bits!($ty))
+            }
+
+            fn gen_random<R: Rng>(rng: &mut R) -> Self {
+                rng.gen_range($start, $stop)
+            }
+        }
+    };
+
+    ($ty:ident int [ ($start:expr) .. ($stop:expr) ]) => {
+        unsafe impl ScalarArgument for $ty {
+            fn as_size(&self) -> Option<u32> {
+                if std::mem::size_of::<$ty>() <= std::mem::size_of::<u32>() {
+                    Some(*self as u32)
+                } else {
+                    None
+                }
+            }
+
+            fn t() -> ir::Type {
+                ir::Type::I(size_bits!($ty))
+            }
+
+            fn get_type(&self) -> ir::Type {
+                Self::t()
+            }
+
+            fn raw_ptr(&self) -> *const libc::c_void {
+                self as *const $ty as *const libc::c_void
+            }
+
+            fn as_operand<L>(&self) -> ir::Operand<'static, L> {
+                ir::Operand::new_int((*self).into(), size_bits!($ty))
+            }
+
+            fn gen_random<R: Rng>(rng: &mut R) -> Self {
+                rng.gen_range($start, $stop)
+            }
+        }
+    };
 }
 
-unsafe impl ScalarArgument for i8 {
-    fn as_size(&self) -> Option<u32> {
-        Some(*self as u32)
-    }
-
-    fn t() -> ir::Type {
-        ir::Type::I(8)
-    }
-
-    fn raw_ptr(&self) -> *const libc::c_void {
-        self as *const i8 as *const libc::c_void
-    }
-
-    fn as_operand<L>(&self) -> ir::Operand<'static, L> {
-        ir::Operand::new_int(unwrap!(BigInt::from_i8(*self)), 8)
-    }
-
-    fn gen_random<R: Rng>(rng: &mut R) -> Self {
-        rng.gen_range(0, 10)
-    }
-}
-
-unsafe impl ScalarArgument for i16 {
-    fn as_size(&self) -> Option<u32> {
-        Some(*self as u32)
-    }
-
-    fn t() -> ir::Type {
-        ir::Type::I(16)
-    }
-
-    fn raw_ptr(&self) -> *const libc::c_void {
-        self as *const i16 as *const libc::c_void
-    }
-
-    fn as_operand<L>(&self) -> ir::Operand<'static, L> {
-        ir::Operand::new_int(unwrap!(BigInt::from_i16(*self)), 16)
-    }
-
-    fn gen_random<R: Rng>(rng: &mut R) -> Self {
-        rng.gen_range(0, 100)
-    }
-}
-
-unsafe impl ScalarArgument for i32 {
-    fn as_size(&self) -> Option<u32> {
-        Some(*self as u32)
-    }
-
-    fn t() -> ir::Type {
-        ir::Type::I(32)
-    }
-
-    fn raw_ptr(&self) -> *const libc::c_void {
-        self as *const i32 as *const libc::c_void
-    }
-
-    fn as_operand<L>(&self) -> ir::Operand<'static, L> {
-        ir::Operand::new_int(unwrap!(BigInt::from_i32(*self)), 32)
-    }
-
-    fn gen_random<R: Rng>(rng: &mut R) -> Self {
-        rng.gen_range(0, 100)
-    }
-}
-
-unsafe impl ScalarArgument for i64 {
-    fn as_size(&self) -> Option<u32> {
-        None
-    }
-
-    fn t() -> ir::Type {
-        ir::Type::I(64)
-    }
-
-    fn raw_ptr(&self) -> *const libc::c_void {
-        self as *const i64 as *const libc::c_void
-    }
-
-    fn as_operand<L>(&self) -> ir::Operand<'static, L> {
-        ir::Operand::new_int(unwrap!(BigInt::from_i64(*self)), 64)
-    }
-
-    fn gen_random<R: Rng>(rng: &mut R) -> Self {
-        rng.gen_range(0, 100)
-    }
-}
+scalar_argument!(f32 float [(0.) .. (  1.)]);
+scalar_argument!(f64 float [(0.) .. (  1.)]);
+scalar_argument!(i8  int   [(0 ) .. ( 10)]);
+scalar_argument!(i16 int   [(0 ) .. (100)]);
+scalar_argument!(i32 int   [(0 ) .. (100)]);
+scalar_argument!(i64 int   [(0 ) .. (100)]);
 
 /// Represents an array on the device.
 pub trait ArrayArgument: Send + Sync {
@@ -166,23 +125,27 @@ pub trait ArrayArgument: Send + Sync {
     fn write_i8(&self, bytes: &[i8]);
 }
 
-/// Copies the array to the host, interpreting it as an array of `T`.
-pub fn read_array<T: ScalarArgument>(array: &ArrayArgument) -> Vec<T> {
-    let mut bytes_vec = array.read_i8();
-    bytes_vec.shrink_to_fit();
-    let (len, rem) = div_rem(bytes_vec.len(), std::mem::size_of::<T>());
-    assert_eq!(rem, 0);
-    unsafe {
-        let bytes = bytes_vec.as_mut_ptr() as *mut T;
-        std::mem::forget(bytes_vec);
-        Vec::from_raw_parts(bytes, len, len)
+pub trait ArrayArgumentExt: ArrayArgument {
+    /// Copies the array to the host, interpreting it as an array of `T`.
+    fn read<T: ScalarArgument>(&self) -> Vec<T> {
+        let mut bytes_vec = self.read_i8();
+        bytes_vec.shrink_to_fit();
+        let (len, rem) = div_rem(bytes_vec.len(), std::mem::size_of::<T>());
+        assert_eq!(rem, 0);
+        unsafe {
+            let bytes = bytes_vec.as_mut_ptr() as *mut T;
+            std::mem::forget(bytes_vec);
+            Vec::from_raw_parts(bytes, len, len)
+        }
+    }
+
+    /// Copies an values to the device array from the host array given as argument.
+    fn write<T: ScalarArgument>(&self, from: &[T]) {
+        let bytes_len = from.len() * std::mem::size_of::<T>();
+        let bytes_ptr = from.as_ptr() as *const i8;
+        let bytes = unsafe { std::slice::from_raw_parts(bytes_ptr, bytes_len) };
+        self.write_i8(bytes)
     }
 }
 
-/// Copies an values to the device array from the host array given as argument.
-pub fn write_array<T: ScalarArgument>(array: &ArrayArgument, from: &[T]) {
-    let bytes_len = from.len() * std::mem::size_of::<T>();
-    let bytes_ptr = from.as_ptr() as *const i8;
-    let bytes = unsafe { std::slice::from_raw_parts(bytes_ptr, bytes_len) };
-    array.write_i8(bytes)
-}
+impl<A: ?Sized> ArrayArgumentExt for A where A: ArrayArgument {}

--- a/src/device/cuda/api/fake.rs
+++ b/src/device/cuda/api/fake.rs
@@ -23,6 +23,12 @@ where
     }
 }
 
+impl Argument for Box<dyn device::ScalarArgument> {
+    fn as_size(&self) -> Option<u32> {
+        device::ScalarArgument::as_size(self.as_ref())
+    }
+}
+
 /// An array on the CUDA device.
 #[derive(Clone)]
 pub struct Array<'a, T> {

--- a/src/device/cuda/api/module.rs
+++ b/src/device/cuda/api/module.rs
@@ -160,3 +160,13 @@ where
         device::ScalarArgument::as_size(self)
     }
 }
+
+impl Argument for Box<dyn device::ScalarArgument> {
+    fn raw_ptr(&self) -> *const libc::c_void {
+        device::ScalarArgument::raw_ptr(self.as_ref())
+    }
+
+    fn as_size(&self) -> Option<u32> {
+        device::ScalarArgument::as_size(self.as_ref())
+    }
+}

--- a/src/device/cuda/characterize/gen.rs
+++ b/src/device/cuda/characterize/gen.rs
@@ -2,7 +2,7 @@
 use codegen;
 use device::cuda::characterize::Table;
 use device::cuda::{Context, Gpu, Kernel, PerfCounterSet};
-use device::{ArgMap, Device, ScalarArgument};
+use device::{ArgMapExt, Device, ScalarArgument};
 use explorer;
 use helper::tensor::DimSize;
 use helper::{AutoOperand, Builder, Reduce};

--- a/src/device/fake.rs
+++ b/src/device/fake.rs
@@ -77,20 +77,23 @@ impl<D: Device> Context for FakeContext<D> {
     }
 }
 
-impl<D: Device> ArgMap for FakeContext<D> {
-    type Array = FakeArray;
-
-    fn bind_scalar<S: ScalarArgument>(&mut self, param: &ir::Parameter, value: S) {
-        assert_eq!(param.t, S::t());
+impl<'a, D: Device + 'a> ArgMap<'a> for FakeContext<D> {
+    fn bind_erased_scalar(
+        &mut self,
+        param: &ir::Parameter,
+        value: Box<dyn ScalarArgument>,
+    ) {
+        assert_eq!(param.t, value.get_type());
 
         self.parameters.insert(param.name.clone(), value.as_size());
     }
 
-    fn bind_array<S: ScalarArgument>(
+    fn bind_erased_array(
         &mut self,
         _: &ir::Parameter,
+        _: ir::Type,
         _: usize,
-    ) -> Arc<Self::Array> {
+    ) -> Arc<dyn ArrayArgument + 'a> {
         Arc::new(FakeArray)
     }
 }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -8,8 +8,10 @@ pub mod x86;
 mod argument;
 mod context;
 
-pub use self::argument::{read_array, write_array, ArrayArgument, ScalarArgument};
-pub use self::context::{ArgMap, AsyncCallback, AsyncEvaluator, Context, EvalMode};
+pub use self::argument::{ArrayArgument, ArrayArgumentExt, ScalarArgument};
+pub use self::context::{
+    ArgMap, ArgMapExt, AsyncCallback, AsyncEvaluator, Context, EvalMode,
+};
 
 use codegen::Function;
 use ir;

--- a/src/device/x86/cpu_argument.rs
+++ b/src/device/x86/cpu_argument.rs
@@ -51,30 +51,12 @@ impl device::ArrayArgument for CpuArray {
     }
 }
 
-pub trait CpuScalarArg: Sync + Send {
-    fn as_size(&self) -> Option<u32>;
-    fn scal_raw_ptr(&self) -> *mut libc::c_void;
-}
-
-impl<T> CpuScalarArg for T
-where
-    T: ScalarArgument,
-{
-    fn as_size(&self) -> Option<u32> {
-        self.as_size()
-    }
-
-    fn scal_raw_ptr(&self) -> *mut libc::c_void {
-        ScalarArgument::raw_ptr(self) as *mut libc::c_void
-    }
-}
-
-impl Argument for Box<CpuScalarArg> {
+impl Argument for Box<dyn ScalarArgument> {
     fn size(&self) -> Option<u32> {
         self.as_size()
     }
 
     fn arg_lock(&self) -> ArgLock {
-        ArgLock::Scalar(self.scal_raw_ptr())
+        ArgLock::Scalar(self.as_ref().raw_ptr() as *mut libc::c_void)
     }
 }

--- a/src/helper/tensor.rs
+++ b/src/helper/tensor.rs
@@ -1,5 +1,5 @@
 //! Utilities to allocate and operate on tensors.
-use device::{read_array, ArgMap, ArrayArgument, Context, ScalarArgument};
+use device::{ArgMap, ArrayArgument, ArrayArgumentExt, Context, ScalarArgument};
 use helper::{Builder, LogicalDim, SignatureBuilder, TilingPattern};
 use ir;
 use itertools::Itertools;
@@ -99,7 +99,7 @@ impl<'a> TensorBuilder<'a> {
     pub fn finish<S, AM>(&self, builder: &mut SignatureBuilder<AM>) -> Tensor<'a, S>
     where
         S: ScalarArgument,
-        AM: ArgMap + Context + 'a,
+        AM: ArgMap<'a> + Context + 'a,
     {
         let size = self
             .storage_dims
@@ -213,7 +213,7 @@ where
     /// Reads the tensor value in the context and copies it on the host.
     pub fn read_to_host(&self, context: &Context) -> ArrayD<S> {
         use ndarray::ShapeBuilder;
-        let mut raw = read_array::<S>(self.array.as_ref());
+        let mut raw = self.array.as_ref().read::<S>();
         let (sizes, strides): (Vec<_>, _) = self
             .iter_dims
             .iter()

--- a/telamon-capi/src/cuda.rs
+++ b/telamon-capi/src/cuda.rs
@@ -2,7 +2,7 @@
 use env_logger;
 use libc;
 use std;
-use telamon::device::{cuda, ArgMap};
+use telamon::device::{cuda, ArgMapExt};
 use telamon::ir;
 use Context;
 use Device;

--- a/telamon-capi/src/lib.rs
+++ b/telamon-capi/src/lib.rs
@@ -64,7 +64,7 @@ pub enum KernelParameters {
 
 impl KernelParameters {
     /// Runs the search for a best candidate.
-    fn optimize_kernel<C: device::ArgMap + device::Context>(
+    fn optimize_kernel<'a, C: device::ArgMap<'a> + device::Context>(
         &self,
         config: &Config,
         context: &mut C,

--- a/tools/bench_perf_model/latency.rs
+++ b/tools/bench_perf_model/latency.rs
@@ -17,7 +17,7 @@ impl PerfModelTest for EmptyLoop {
         "latency_empty_loop"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("n", Self::N as i32);
     }
 
@@ -44,7 +44,7 @@ impl PerfModelTest for TwoEmptyLoop {
         "latency_two_empty_loop"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("n", Self::N as i32);
     }
 
@@ -78,7 +78,7 @@ impl PerfModelTest for InstChain {
         "inst_chain"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("n", Self::N as i32);
         builder.scalar("x", 1i32);
         builder.array::<i64>("out", 1);
@@ -109,7 +109,7 @@ impl PerfModelTest for LongInstChain {
         "long_inst_chain"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("n", Self::N as i32);
         builder.scalar("x", 1i64);
         builder.array::<i64>("out", 1);
@@ -144,7 +144,7 @@ impl PerfModelTest for UnrollReduction {
         "unroll_reduction"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("n", Self::N as i32);
         builder.scalar("x", 1i32);
         builder.array::<i32>("out", 1);
@@ -186,7 +186,7 @@ impl PerfModelTest for OrderedLoops {
         "ordered_loops"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("n", Self::SIZE as i32);
         builder.scalar("k", Self::SIZE as i32);
         builder.scalar("m", Self::SIZE as i32);
@@ -221,7 +221,7 @@ impl PerfModelTest for OrderedThreadDims {
         "ordered_thread_dims"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("n", Self::N as i32);
         builder.scalar("k", Self::K as i32);
         builder.scalar("x", 1i32);
@@ -272,7 +272,7 @@ impl PerfModelTest for DimMap {
         "dim_map"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("n", Self::N as i32);
         builder.scalar("x", 1i64);
         builder.array::<i64>("out", 1);
@@ -312,7 +312,7 @@ impl PerfModelTest for OperandPositionSlow {
         "operand_position_slow"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("n", Self::N as i32);
         builder.scalar("x", 1i64);
         builder.array::<i64>("out", 1);
@@ -346,7 +346,7 @@ impl PerfModelTest for OperandPositionFast {
         "operand_position_fast"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("n", Self::N as i32);
         builder.scalar("x", 1i64);
         builder.array::<i64>("out", 1);

--- a/tools/bench_perf_model/main.rs
+++ b/tools/bench_perf_model/main.rs
@@ -29,7 +29,9 @@ trait PerfModelTest {
     fn name() -> &'static str;
 
     /// Generates the base of the function to evaluate.
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut helper::SignatureBuilder<AM>);
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(
+        builder: &mut helper::SignatureBuilder<AM>,
+    );
 
     /// Generates the function to evaluate.
     fn gen_function(builder: &mut helper::Builder) -> Self;

--- a/tools/bench_perf_model/memory.rs
+++ b/tools/bench_perf_model/memory.rs
@@ -17,7 +17,7 @@ impl PerfModelTest for L1LinesPressure {
         "l1_lines_pressure"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("n", Self::N as i32);
         builder.array::<f32>("array", 128 * 32 * 32 * 32);
         builder.array::<f32>("out", 1);
@@ -78,7 +78,7 @@ impl PerfModelTest for L2LinesPressure {
         "l2_lines_pressure"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("n", Self::N as i32);
         builder.array::<f32>("array", 128 * 32 * 32 * 8);
         builder.array::<f32>("out", 1);
@@ -143,7 +143,7 @@ impl PerfModelTest for SharedLoad {
         "shared_load"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("n", Self::N as i32);
         builder.scalar("arg_zero", 0i32);
         builder.array::<f32>("out", 1);
@@ -205,7 +205,7 @@ impl PerfModelTest for VectorSharedLoad {
         "vector_shared_load"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("n", Self::N as i32);
         builder.scalar("arg_zero", 0i32);
         builder.array::<f32>("out", 1);
@@ -261,7 +261,7 @@ impl PerfModelTest for SharedReplay {
         "shared_replay"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("n", Self::N as i32);
         builder.scalar("arg_zero", 0i32);
         builder.array::<f32>("out", 1);
@@ -313,7 +313,7 @@ impl PerfModelTest for VectorSharedReplay {
         "vector_shared_replay"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("n", Self::N as i32);
         builder.scalar("arg_zero", 0i32);
         builder.array::<f32>("out", 1);

--- a/tools/bench_perf_model/tests.rs
+++ b/tools/bench_perf_model/tests.rs
@@ -23,7 +23,7 @@ impl PerfModelTest for Test0 {
         "test_0"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("m", Self::M / (Self::TILE_1 * Self::TILE_2));
         builder.scalar("n", Self::N / (Self::TILE_1 * Self::TILE_2));
         builder.scalar("k", Self::K / Self::TILE_1);
@@ -115,7 +115,7 @@ impl PerfModelTest for Test1 {
         "test_1"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("k", Self::K);
         builder.array::<f32>("out", 4 * 32 * 32 * 4 as usize);
     }
@@ -187,7 +187,7 @@ impl PerfModelTest for Test2 {
         "test_2"
     }
 
-    fn gen_signature<AM: ArgMap + Context>(builder: &mut SignatureBuilder<AM>) {
+    fn gen_signature<'a, AM: ArgMap<'a> + Context>(builder: &mut SignatureBuilder<AM>) {
         builder.scalar("m", Self::M / (Self::TILE_1 * Self::TILE_2));
         builder.scalar("n", Self::N / (Self::TILE_1 * Self::TILE_2));
         builder.scalar("k", Self::K);


### PR DESCRIPTION
This patch makes it so that `ArgMap` can be implemented for
`Box<dyn ArgMap>`, easing the compatibility with the C API.  This is
achieved by requiring devices to implement type-erased versions of
`bind_scalar` and `bind_array` (all existing implementations of `ArgMap`
were already type-erasing their arguments).

The pre-existing typed APIs are implemented as wrappers on their
type-erased version, allowing users (such as the `kernels` library) to
work with minor lifetime-related modifications.

telamon/
 * src/device/argument.rs:
       The `ScalarArgument` trait is revamped to:

        - Remove the `Copy` and `PartialEq` bounds, which were not used
          and prevented object safety by using `Self` in their methods

        - Guard the non-object-safe `t`, `gen_random` and `as_operand`
          methods with `Self: Sized` since we only use them when we know
          the exact type

        - Add `get_type` as an object-safe version of `t`

       All the old methods are still provided as before.

       In addition, the `write_array<S>` and `read_array<S>` functions
       are replaced with `write` and `read` methods on a new
       `ArrayArgumentExt` extension trait.

 * src/device/context.rs:
       The `ArgMap` trait is revamped:

        - `ArgMap` now takes a lifetime parameter bounding the lifetime
          of the generated arrays.  Most previous bounds were of the
          form `ArgMap + 'a`; they are now `ArgMap<'a>` instead.

        - The `bind_scalar` method is replaced with `bind_erased_scalar`
          which takes as argument a `ScalarArgument` trait object

        - The `bind_array` method is replaced with a `bind_erased_array`
          which takes as argument an `ir::Type` and returns an
          `ArrayArgument` trait object instead of the `Array` type
          parameter, which is removed.

       All the typed functionality of `ArgMap` (`bind_scalar` and
       `bind_array`) are automatically implemented through an
       `ArgMapExt` extension trait.

 * src/device/cuda/context.rs: Upgrade `ArgMap` implementation.
 * src/device/x86/context.rs: Upgrade `ArgMap` implementation.
 * src/device/fake.rs: Upgrade `ArgMap` implementation.
 * src/device/x86/cpu_argument.rs:
    Use `ScalarArgument` instead of the equivalent ` CpuScalarArg`
 * src/device/cuda/api/module.rs:
 * src/device/cuda/api/fake.rs:
 * src/device/cuda/characterize/gen.rs:
 * src/device/mod.rs:
 * src/helper/signature.rs:
 * src/helper/tensor.rs:
 * tests/cuda.rs:
 * tools/bench_perf_model/latency.rs:
 * tools/bench_perf_model/main.rs:
 * tools/bench_perf_model/memory.rs:
 * tools/bench_perf_model/tests.rs:

telamon-kernels/
 * benches/cuda_variance.rs:
 * src/kernel.rs:
 * src/lib.rs:
 * src/linalg.rs:

telamon-capi/
 * src/cuda.rs:
 * src/lib.rs: