### PR TITLE
Make the MCTS explorer more generic

### DIFF
--- a/kernels/benches/cuda_variance.rs
+++ b/kernels/benches/cuda_variance.rs
@@ -58,8 +58,7 @@ where
     let candidates = std::iter::repeat(())
         .flat_map(|()| {
             let order = explorer::config::NewNodeOrder::WeightedRandom;
-            let bounds = candidates.iter().map(|c| c.bound.value()).enumerate();
-            let candidate_idx = local_selection::pick_index(order, bounds, CUT);
+            let candidate_idx = order.pick_candidate(&candidates, CUT);
             let candidate = candidates[unwrap!(candidate_idx)].clone();
             local_selection::descend(&Default::default(), order, &context, candidate, CUT)
         }).take(NUM_TESTS)

--- a/kernels/src/kernel.rs
+++ b/kernels/src/kernel.rs
@@ -75,8 +75,7 @@ pub trait Kernel<'a>: Sized {
         while num_runs < num_tests {
             let order = explorer::config::NewNodeOrder::WeightedRandom;
             let ordering = explorer::config::ChoiceOrdering::default();
-            let bounds = candidates.iter().map(|c| c.bound.value()).enumerate();
-            let candidate_idx = local_selection::pick_index(order, bounds, CUT);
+            let candidate_idx = order.pick_candidate(&candidates, CUT);
             let candidate = candidates[unwrap!(candidate_idx)].clone();
             let leaf =
                 local_selection::descend(&ordering, order, context, candidate, CUT);
@@ -226,8 +225,7 @@ pub trait Kernel<'a>: Sized {
                 let order = explorer::config::NewNodeOrder::WeightedRandom;
                 let ordering = explorer::config::ChoiceOrdering::default();
                 let inf = std::f64::INFINITY;
-                let bounds = candidates.iter().map(|c| c.bound.value()).enumerate();
-                let candidate_idx = local_selection::pick_index(order, bounds, inf);
+                let candidate_idx = order.pick_candidate(&candidates, inf);
                 let candidate = candidates[unwrap!(candidate_idx)].clone();
                 local_selection::descend(&ordering, order, context, candidate, inf)
                     .is_none()
@@ -245,10 +243,7 @@ fn descend_check_bounds<'a>(
     let mut candidates = std::borrow::Cow::Borrowed(candidates);
     let mut bounds = Vec::new();
     loop {
-        let idx = if let Some(idx) = {
-            let idx_bounds = candidates.iter().map(|c| c.bound.value()).enumerate();
-            local_selection::pick_index(order, idx_bounds, CUT)
-        } {
+        let idx = if let Some(idx) = order.pick_candidate(&candidates, CUT) {
             idx
         } else {
             return None;

--- a/src/explorer/bandit_arm.rs
+++ b/src/explorer/bandit_arm.rs
@@ -1,8 +1,7 @@
-//! Exploration of the search space.
-
+///! Exploration of the search space.
 use device::Context;
 use explorer::candidate::Candidate;
-use explorer::config::{self, BanditConfig, NewNodeOrder, OldNodeOrder};
+use explorer::config::{BanditConfig, NewNodeOrder, OldNodeOrder};
 use explorer::logger::LogMessage;
 use explorer::store::Store;
 use explorer::{choice, local_selection};
@@ -14,12 +13,68 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock, Weak};
 use utils::*;
 
+/// An environment in which candidates can be refined.
+pub struct Env<'a> {
+    config: &'a BanditConfig,
+    context: &'a dyn Context,
+    cut: f64,
+}
+
+impl<'a> Env<'a> {
+    /// List the available actions for a given candidate.
+    ///
+    /// If `list_actions` return `None`, the candidate is a fully-specified implementation.
+    pub fn list_actions(
+        &self,
+        candidate: &Candidate<'_>,
+    ) -> Option<Vec<choice::ActionEx>> {
+        choice::list(&self.config.choice_ordering, &candidate.space).next()
+    }
+
+    /// Apply a choice to a candidate.
+    ///
+    /// This returns a list of candidates, one for each potential decision.  Note that the
+    /// resulting vector of candidates may be shorter than the number of decisions in the choice in
+    /// two cases: some actions can be discarded through propagation or by applying a
+    /// branch-and-bound algorithm.
+    pub fn apply_choice<'c>(
+        &self,
+        candidate: &Candidate<'c>,
+        actions: Vec<choice::ActionEx>,
+    ) -> Vec<Candidate<'c>> {
+        candidate
+            .apply_choice(self.context, actions)
+            .into_iter()
+            .filter(|candidate| candidate.bound.value() < self.cut)
+            .collect::<Vec<_>>()
+    }
+}
+
+/// Policy to use when descending in the tree.
+pub trait TreePolicy: Sync + Sized {
+    /// Statistics stored on the nodes.
+    type NodeStats: Default + Send + Sync;
+
+    /// Statistics stored on the edges.
+    type EdgeStats: Default + Send + Sync;
+
+    /// Pick a child in the given environment.  Returns an index for the child, or `None` if the
+    /// node has no children.
+    fn pick_child(&self, env: &Env<'_>, node: &Node<'_, Self>) -> Option<usize>;
+
+    /// Record an evaluation across an edge.  This indicates that an evaluation of `eval` was found
+    /// in a path which contains edge `node.children[idx]`.
+    fn backpropagate(&self, node: &Node<Self>, idx: usize, eval: f64);
+}
+
+/// Global tree statistics
 struct TreeStats {
+    /// The number of deadends encountered during the descent.
     num_deadends: AtomicUsize,
 }
 
-impl TreeStats {
-    fn new() -> Self {
+impl Default for TreeStats {
+    fn default() -> Self {
         TreeStats {
             num_deadends: AtomicUsize::new(0),
         }
@@ -35,49 +90,51 @@ pub enum TreeEvent {
 }
 
 /// A search tree to perform a multi-armed bandit search.
-pub struct Tree<'a, 'b> {
-    shared_tree: Arc<RwLock<SubTree<'a>>>,
+pub struct Tree<'a, 'b, P: TreePolicy> {
+    root: Edge<'a, P>,
     stop: AtomicBool,
     cut: RwLock<f64>,
     config: &'b BanditConfig,
+    policy: P,
     stats: TreeStats,
     log: std::sync::mpsc::SyncSender<LogMessage<TreeEvent>>,
 }
 
-impl<'a, 'b> Tree<'a, 'b> {
+impl<'a, 'b, P: TreePolicy> Tree<'a, 'b, P> {
     /// Creates a new search tree containing the given candidates.
     pub fn new(
         candidates: Vec<Candidate<'a>>,
         config: &'b BanditConfig,
+        policy: P,
         log_sender: std::sync::mpsc::SyncSender<LogMessage<TreeEvent>>,
     ) -> Self {
-        let root = SubTree::from_candidates(candidates, std::f64::INFINITY);
         Tree {
-            shared_tree: Arc::new(RwLock::new(root)),
+            root: SubTree::from(Node::from_candidates(candidates)).into(),
             stop: AtomicBool::new(false),
             cut: RwLock::new(std::f64::INFINITY),
             config,
-            stats: TreeStats::new(),
+            policy,
+            stats: TreeStats::default(),
             log: log_sender,
         }
     }
 
     /// Removes the dead ends along the given path. Assumes the path points to a dead-end.
     /// Updates bounds along the way.
-    fn clean_deadends(&self, mut path: Path<'a>, cut: f64) {
+    fn clean_deadends(&self, mut path: Path<'a, P>, cut: f64) {
         // A `None` bound indicates the path points to a dead-end.
         let mut bound = None;
         while let Some((node, pos)) = path.0.pop() {
             if let Some(node) = node.upgrade() {
-                let mut lock = unwrap!(node.write());
                 if let Some(bound) = bound {
-                    lock.children[pos].update_bound(bound);
+                    node.children[pos].update_bound(bound);
                     // If the bound was set, then we finished removing deadends.
                     return;
                 } else {
-                    lock.children[pos] = SubTree::Empty;
-                    bound = lock.bound();
-                    // Children with a bound above the cut are considered as dead-ends.
+                    node.children[pos].kill();
+
+                    bound = node.bound();
+                    // Node with a bound above the cut are considered as dead-ends.
                     if bound.map(|b| b >= cut).unwrap_or(false) {
                         bound = None;
                     }
@@ -86,87 +143,29 @@ impl<'a, 'b> Tree<'a, 'b> {
                 return;
             }
         }
-        // If we did not returned before, we have reached the root of the tree.
-        let mut lock = unwrap!(self.shared_tree.write());
-        if let Some(bound) = bound {
-            lock.update_bound(bound);
-        } else {
-            *lock = SubTree::Empty
-        }
-    }
 
-    /// Descend in the tree and tries to reach a leaf from the given `DescendState`.
-    fn descend(
-        &self,
-        context: &Context,
-        mut state: DescendState<'a>,
-        cut: f64,
-    ) -> Option<(Candidate<'a>, Path<'a>)> {
-        let mut path = Path::default();
-        loop {
-            match std::mem::replace(&mut state, DescendState::DeadEnd) {
-                DescendState::DeadEnd => {
-                    self.clean_deadends(path, cut);
-                    return None;
-                }
-                DescendState::Leaf(leaf) => {
-                    self.clean_deadends(path.clone(), cut);
-                    return Some((leaf, path));
-                }
-                DescendState::InternalNode(node, is_new) => {
-                    if is_new && self.config.monte_carlo {
-                        let res = unwrap!(node.write()).descend_noexpand(
-                            &self.config,
-                            context,
-                            cut,
-                        );
-                        // We manually process the first two levels of the search as they
-                        // are still in the tree and thus must be updated if needed.
-                        if let Some((idx, maybe_candidate)) = res {
-                            path.0.push((Arc::downgrade(&node), idx));
-                            match maybe_candidate {
-                                Ok(candidate) => {
-                                    let res = local_selection::descend(
-                                        &self.config.choice_ordering,
-                                        self.config.new_nodes_order,
-                                        context,
-                                        candidate,
-                                        cut,
-                                    );
-                                    return res.map(|c| (c, path));
-                                }
-                                Err(new_state) => state = new_state,
-                            }
-                        } else {
-                            continue;
-                        }
-                    } else {
-                        let next =
-                            unwrap!(node.write()).descend(&self.config, context, cut);
-                        if let Some((idx, new_state)) = next {
-                            path.0.push((Arc::downgrade(&node), idx));
-                            state = new_state;
-                        }
-                    }
-                }
-            }
+        // If we did not returned before, we have reached the root of the tree.
+        if let Some(bound) = bound {
+            self.root.update_bound(bound);
+        } else {
+            self.root.kill();
         }
     }
 }
 
-impl<'a, 'b> Store<'a> for Tree<'a, 'b> {
-    type PayLoad = Path<'a>;
+impl<'a, 'b, P: TreePolicy> Store<'a> for Tree<'a, 'b, P> {
+    type PayLoad = Path<'a, P>;
 
     type Event = TreeEvent;
 
     fn update_cut(&self, new_cut: f64) {
         *unwrap!(self.cut.write()) = new_cut;
-        let root = unwrap!(self.shared_tree.write()).trim(new_cut);
-        let mut stack = root.into_iter().collect_vec();
-        while let Some(node) = stack.pop() {
-            let mut lock = unwrap!(node.write());
-            for subtree in &mut lock.children {
-                stack.extend(subtree.trim(new_cut));
+        let mut stack = self.root.trim(new_cut).into_iter().collect::<Vec<_>>();
+        while let Some(subtree) = stack.pop() {
+            if let SubTree::InternalNode(node) = &*unwrap!(subtree.read()) {
+                for edge in &node.children {
+                    stack.extend(edge.trim(new_cut))
+                }
             }
         }
         info!("trimming finished");
@@ -185,32 +184,58 @@ impl<'a, 'b> Store<'a> for Tree<'a, 'b> {
 
         while let Some((node, idx)) = path.0.pop() {
             if let Some(node) = node.upgrade() {
-                if !unwrap!(node.write()).update_rewards(&self.config, idx, eval) {
-                    return;
-                }
+                self.policy.backpropagate(&node, idx, eval);
             }
         }
     }
 
     fn explore(&self, context: &Context) -> Option<(Candidate<'a>, Self::PayLoad)> {
+        // Retry loop (in case of deadends)
         loop {
             if self.stop.load(Ordering::Relaxed) {
                 return None;
             }
+
             let cut: f64 = { *unwrap!(self.cut.read()) };
-            let state = unwrap!(self.shared_tree.write()).descend(
-                &self.config.choice_ordering,
+            let env = Env {
+                config: &self.config,
                 context,
                 cut,
-            );
-            if let DescendState::DeadEnd = state {
+            };
+
+            // Bail out early if the root is a deadend
+            let mut state = self.root.descend(&env);
+            if let SubTree::Empty = state {
                 return None;
             }
-            let res = self.descend(context, state, cut);
-            if res.is_some() {
-                return res;
-            } else {
-                self.stats.num_deadends.fetch_add(1, Ordering::Relaxed);
+
+            // Descent loop
+            let mut path = Path::default();
+            loop {
+                match state {
+                    SubTree::Empty => {
+                        self.clean_deadends(path, env.cut);
+                        self.stats.num_deadends.fetch_add(1, Ordering::Relaxed);
+                        break;
+                    }
+                    SubTree::Leaf(leaf) => {
+                        return local_selection::descend(
+                            &env.config.choice_ordering,
+                            env.config.new_nodes_order,
+                            env.context,
+                            *leaf,
+                            env.cut,
+                        ).map(|c| (c, path));
+                    }
+                    SubTree::InternalNode(node) => {
+                        if let Some((idx, next)) = node.descend(&env, &self.policy) {
+                            path.0.push((Arc::downgrade(&node), idx));
+                            state = next;
+                        } else {
+                            state = SubTree::Empty;
+                        }
+                    }
+                }
             }
         }
     }
@@ -229,289 +254,292 @@ impl<'a, 'b> Store<'a> for Tree<'a, 'b> {
 }
 
 /// Path to follow to reach a leaf in the tree.
-#[derive(Clone, Default)]
-pub struct Path<'a>(Vec<(Weak<RwLock<Children<'a>>>, usize)>);
+#[derive(Clone)]
+pub struct Path<'a, P: TreePolicy>(Vec<(Weak<Node<'a, P>>, usize)>);
+
+impl<'a, P: TreePolicy> Default for Path<'a, P> {
+    fn default() -> Self {
+        Path(vec![])
+    }
+}
 
 /// The search tree that will be traversed
-enum SubTree<'a> {
+enum SubTree<'a, P: TreePolicy> {
     /// The subtree has been expanded and has children.
-    InternalNode(Arc<RwLock<Children<'a>>>, f64),
-    /// The subtree has not been expanded yet.
-    UnexpandedNode(Candidate<'a>),
+    InternalNode(Arc<Node<'a, P>>),
+    /// The subtree has not been expanded yet.  This is a leaf in the MCTS tree.
+    Leaf(Box<Candidate<'a>>),
     /// The subtree is empty.
     Empty,
 }
 
-impl<'a> SubTree<'a> {
-    /// Creates a `SubTree` containing the given list of candidates.
-    fn from_candidates(candidates: Vec<Candidate<'a>>, cut: f64) -> SubTree<'a> {
-        let children = Children::from_candidates(candidates, cut);
-        if let Some(bound) = children.bound() {
-            SubTree::InternalNode(Arc::new(RwLock::new(children)), bound)
+impl<'a, P: TreePolicy> From<Node<'a, P>> for SubTree<'a, P> {
+    fn from(node: Node<'a, P>) -> Self {
+        if node.bound().is_some() {
+            SubTree::InternalNode(Arc::new(node))
         } else {
             SubTree::Empty
         }
     }
+}
+
+impl<'a, P: TreePolicy> SubTree<'a, P> {
+    fn bound(&self) -> Option<f64> {
+        match self {
+            SubTree::InternalNode(node) => node.bound(),
+            SubTree::Leaf(candidate) => Some(candidate.bound.value()),
+            SubTree::Empty => None,
+        }
+    }
+}
+
+/// An edge in the tree
+struct Edge<'a, P: TreePolicy> {
+    /// The destination of the edge.  This may not be expanded yet.
+    dst: Arc<RwLock<SubTree<'a, P>>>,
+
+    /// Edge statistics
+    stats: P::EdgeStats,
+
+    /// The current bound for the pointed-to node.
+    bound: RwLock<f64>,
+}
+
+impl<'a, P: TreePolicy> From<SubTree<'a, P>> for Edge<'a, P> {
+    fn from(subtree: SubTree<'a, P>) -> Self {
+        Edge {
+            stats: P::EdgeStats::default(),
+            bound: RwLock::new(subtree.bound().unwrap_or(std::f64::INFINITY)),
+            dst: Arc::new(RwLock::new(subtree)),
+        }
+    }
+}
+
+impl<'a, P: TreePolicy> From<Candidate<'a>> for Edge<'a, P> {
+    fn from(candidate: Candidate<'a>) -> Self {
+        SubTree::Leaf(Box::new(candidate)).into()
+    }
+}
+
+impl<'a, P: TreePolicy> Edge<'a, P> {
+    /// Kill the edge, replacing it with a dead end.  The bound is erased.
+    fn kill(&self) {
+        *unwrap!(self.dst.write()) = SubTree::Empty;
+        self.update_bound(std::f64::INFINITY);
+    }
+
+    // TODO(bclement):  Does this actually help at all?
+    /// Update the bound.  This is typically called after a cut made more information available in
+    /// the subtree.
+    fn update_bound(&self, bound: f64) {
+        *unwrap!(self.bound.write()) = bound;
+    }
+
+    /// Return the bound on execution time for the node this edge points to.
+    fn bound(&self) -> f64 {
+        *unwrap!(self.bound.read())
+    }
 
     /// Trims the branch if it has with an evaluation time guaranteed to be worse than
     /// `cut`. Returns the childrens to trim if any,
-    fn trim(&mut self, cut: f64) -> Option<Arc<RwLock<Children<'a>>>> {
+    fn trim(&self, cut: f64) -> Option<Arc<RwLock<SubTree<'a, P>>>> {
         if self.bound() >= cut {
-            *self = SubTree::Empty;
+            self.kill();
             None
-        } else if let SubTree::InternalNode(ref inner, _) = *self {
-            Some(inner.clone())
+        } else if let SubTree::InternalNode(_) = *unwrap!(self.dst.read()) {
+            Some(Arc::clone(&self.dst))
         } else {
             None
-        }
-    }
-
-    /// Returns the lower bound on the execution time on the `SubTree`.
-    fn bound(&self) -> f64 {
-        match *self {
-            SubTree::InternalNode(_, bound) => bound,
-            SubTree::UnexpandedNode(ref cand) => cand.bound.value(),
-            SubTree::Empty => std::f64::INFINITY,
-        }
-    }
-
-    /// Indicates if the `SubTree` is empty.
-    fn is_empty(&self) -> bool {
-        if let SubTree::Empty = *self {
-            true
-        } else {
-            false
         }
     }
 
     /// Descend one level in the tree, expanding it if necessary.
-    fn descend(
-        &mut self,
-        choice_ordering: &config::ChoiceOrdering,
-        context: &Context,
-        cut: f64,
-    ) -> DescendState<'a> {
-        match std::mem::replace(self, SubTree::Empty) {
-            SubTree::InternalNode(node, bound) => {
-                *self = SubTree::InternalNode(node.clone(), bound);
-                DescendState::InternalNode(node, false)
-            }
-            SubTree::UnexpandedNode(candidate) => {
-                let choice = choice::list(choice_ordering, &candidate.space).next();
-                if let Some(choice) = choice {
-                    let candidates = candidate.apply_choice(context, choice);
-                    let children = Children::from_candidates(candidates, cut);
-                    if let Some(bound) = children.bound() {
-                        let children = Arc::new(RwLock::new(children));
-                        *self = SubTree::InternalNode(children.clone(), bound);
-                        DescendState::InternalNode(children, true)
-                    } else {
-                        DescendState::DeadEnd
+    fn descend(&self, env: &Env<'_>) -> SubTree<'a, P> {
+        loop {
+            // Most of the time we only need read access
+            {
+                match &*unwrap!(self.dst.read()) {
+                    SubTree::Empty => return SubTree::Empty,
+                    SubTree::InternalNode(node) => {
+                        return SubTree::InternalNode(Arc::clone(node))
                     }
-                } else {
-                    DescendState::Leaf(candidate)
+                    SubTree::Leaf(_) => {
+                        // Need write access
+                    }
                 }
             }
-            SubTree::Empty => DescendState::DeadEnd,
+
+            // Some times we do need write access to expand a leaf candidate... but some other
+            // thread could beat us to the punch and expand it before, so we loop.
+            {
+                let dst = &mut *unwrap!(self.dst.write());
+                if let SubTree::Leaf(_) = dst {
+                    if let SubTree::Leaf(candidate) =
+                        std::mem::replace(dst, SubTree::Empty)
+                    {
+                        let choice = env.list_actions(&candidate);
+                        if let Some(choice) = choice {
+                            let node = Node::from_candidates(
+                                env.apply_choice(&candidate, choice),
+                            );
+                            if node.bound().is_some() {
+                                // Newly expanded node, with no stats yet.
+                                *dst = SubTree::InternalNode(Arc::new(node));
+                                return SubTree::Leaf(candidate);
+                            } else {
+                                // Actual dead-end; leave the SubTree::Empty there.
+                                return SubTree::Empty;
+                            }
+                        } else {
+                            // Fully specified implementation; we leave the SubTree::Empty here because if
+                            // we come back, this becomes a dead-end.  It may not be the smartest thing to
+                            // do because it could throw off the search, but that is probably pretty rate
+                            // anyways.
+                            return SubTree::Leaf(candidate);
+                        }
+                    } else {
+                        // We checked we were in the Leaf case before the mem::replace
+                        unreachable!()
+                    }
+                }
+            }
         }
     }
-
-    /// Update the bound registered in the node, if possible.
-    fn update_bound(&mut self, bound: f64) {
-        if let SubTree::InternalNode(_, ref mut old_bound) = *self {
-            *old_bound = bound
-        }
-    }
-}
-
-/// Indicates the current state of a descent in the search tree.
-enum DescendState<'a> {
-    /// The descent reached an internal node with multiple children. Indicates if the
-    /// children were created during the descent.
-    InternalNode(Arc<RwLock<Children<'a>>>, bool),
-    /// The descent reached a leaf of the tree.
-    Leaf(Candidate<'a>),
-    /// The descent reached a dead-end.
-    DeadEnd,
 }
 
 /// Holds the children of a `SubTree::InternalNode`.
-pub struct Children<'a> {
-    children: Vec<SubTree<'a>>,
-    rewards: Vec<(Vec<f64>, usize)>,
+pub struct Node<'a, P: TreePolicy> {
+    children: Vec<Edge<'a, P>>,
+
+    /// Node statistics
+    _stats: P::NodeStats,
 }
 
-impl<'a> Children<'a> {
-    /// Creates a new children containing the given candidates, if any. Only keeps
-    /// candidates above the cut.
-    fn from_candidates(candidates: Vec<Candidate<'a>>, cut: f64) -> Self {
-        let children = candidates
-            .into_iter()
-            .filter(|c| c.bound.value() < cut)
-            .map(SubTree::UnexpandedNode)
-            .collect_vec();
-        let rewards = children.iter().map(|_| (vec![], 0)).collect();
-        Children { children, rewards }
+impl<'a, P: TreePolicy> Node<'a, P> {
+    /// Creates a new children containing the given candidates, if any.
+    fn from_candidates(candidates: Vec<Candidate<'a>>) -> Self {
+        let children = candidates.into_iter().map(Edge::from).collect_vec();
+        Node {
+            children,
+            _stats: Default::default(),
+        }
     }
 
     /// Returns the lowest bound of the children, if any.
     fn bound(&self) -> Option<f64> {
         self.children
             .iter()
-            .map(|c| c.bound())
+            .map(|edge| edge.bound())
             .min_by(|&lhs, &rhs| cmp_f64(lhs, rhs))
     }
 
     /// Trim children (that is, replace with an empty `SubTree`) children whose bounds are
-    /// higher than the cut. Also clean-up rewards.
-    fn trim(&mut self, cut: f64) {
-        for (child, reward) in self.children.iter_mut().zip_eq(&mut self.rewards) {
-            if child.bound() >= cut {
-                *child = SubTree::Empty;
-                *reward = (vec![], 0);
-            }
+    /// higher than the cut. Also clean-up evaluations.
+    fn trim(&self, cut: f64) {
+        for edge in &self.children {
+            edge.trim(cut);
         }
     }
 
     /// Descend one level in the tree, expanding it if necessary.
-    fn descend(
-        &mut self,
-        config: &BanditConfig,
-        context: &Context,
-        cut: f64,
-    ) -> Option<(usize, DescendState<'a>)> {
-        self.trim(cut);
-        self.pick_child(config, cut).map(|idx| {
-            self.rewards[idx].1 += 1;
-            (
-                idx,
-                self.children[idx].descend(&config.choice_ordering, context, cut),
-            )
-        })
-    }
+    fn descend(&self, env: &Env<'_>, policy: &P) -> Option<(usize, SubTree<'a, P>)> {
+        self.trim(env.cut);
 
-    /// Descends one level in the tree and apply an action on the candidate reached to
-    /// generate a candidate that is not owned by the tree. Assumes all the `Children` are
-    /// either dead-ends or unexpanded nodes. Returns the index of the selected child,
-    /// the generated `Candidate` or the current state of the exploration if the candidate
-    /// could not be generated. Returns `None` if a dead-end is reached before we could
-    /// descend.
-    fn descend_noexpand(
-        &mut self,
-        config: &BanditConfig,
-        context: &Context,
-        cut: f64,
-    ) -> Option<(usize, Result<Candidate<'a>, DescendState<'a>>)> {
-        self.trim(cut);
-        self.pick_child(config, cut).map(|idx| {
-            self.rewards[idx].1 += 1;
-            let node = std::mem::replace(&mut self.children[idx], SubTree::Empty);
-            let cand = match node {
-                SubTree::UnexpandedNode(c) => c,
-                SubTree::Empty => return (idx, Err(DescendState::DeadEnd)),
-                SubTree::InternalNode(ref node, _) => {
-                    return (idx, Err(DescendState::InternalNode(node.clone(), true)))
-                }
-            };
-            let choice = choice::list(&config.choice_ordering, &cand.space).next();
-            let out = if let Some(choice) = choice {
-                let cands = cand.apply_choice(context, choice);
-                self.children[idx] = SubTree::UnexpandedNode(cand);
-                let order = config.new_nodes_order;
-                if let Some(cand) = local_selection::pick_candidate(order, cands, cut) {
-                    Ok(cand)
-                } else {
-                    Err(DescendState::DeadEnd)
-                }
-            } else {
-                Err(DescendState::Leaf(cand))
-            };
-            (idx, out)
-        })
-    }
-
-    /// Picks a child to descend in. Returns `None` if all children are cut.
-    fn pick_child(&self, config: &BanditConfig, cut: f64) -> Option<usize> {
-        let new_nodes = self
-            .children
-            .iter()
-            .map(|c| c.bound())
-            .enumerate()
-            .filter(|&(idx, _)| self.rewards[idx].1 == 0);
-        local_selection::pick_index(config.new_nodes_order, new_nodes, cut).or_else(
-            || match config.old_nodes_order {
-                OldNodeOrder::Bound => {
-                    let children = self.children.iter().map(|c| c.bound()).enumerate();
-                    local_selection::pick_index(NewNodeOrder::Bound, children, cut)
-                }
-                OldNodeOrder::WeightedRandom => {
-                    let children = self.children.iter().map(|c| c.bound()).enumerate();
-                    let order = NewNodeOrder::WeightedRandom;
-                    local_selection::pick_index(order, children, cut)
-                }
-                OldNodeOrder::Bandit => {
-                    pick_bandit_arm(config, &self.children, &self.rewards, cut)
-                }
-            },
-        )
-    }
-
-    /// Update a rewards list given a new value and the position where it was found
-    /// returns true if the value was inserted in the node.
-    fn update_rewards(&mut self, config: &BanditConfig, pos: usize, val: f64) -> bool {
-        if self.children[pos].is_empty() {
-            return false;
-        }
-        let total_trials = self.rewards.iter().map(|x| x.0.len()).sum::<usize>();
-        // If total trials is less than THRESHOLD, then we simply push our new value
-        // in the node where it was found.
-        if total_trials < config.threshold {
-            self.rewards[pos].0.push(val);
-            true
-        } else {
-            let (child, idx, max) = unwrap!(self.find_max_rewards());
-            if val < max {
-                self.rewards[child].0[idx] = val;
-                true
-            } else {
-                false
-            }
-        }
-    }
-
-    /// Returns the tuple `(child_index, eval_index, value)` containing the position and
-    /// the value of the biggest reward registered.
-    fn find_max_rewards(&self) -> Option<(usize, usize, f64)> {
-        self.rewards
-            .iter()
-            .enumerate()
-            .flat_map(|(child_idx, rewards)| {
-                let max = rewards
-                    .0
-                    .iter()
-                    .cloned()
-                    .enumerate()
-                    .max_by(|lhs, rhs| cmp_f64(lhs.1, rhs.1));
-                max.map(|(idx, value)| (child_idx, idx, value))
-            }).max_by(|x1, x2| cmp_f64(x1.2, x2.2))
+        policy
+            .pick_child(env, self)
+            .map(|idx| (idx, self.children[idx].descend(env)))
     }
 }
 
-/// Picks a candidate below the bound following a multi-armed bandit approach.
-fn pick_bandit_arm(
-    config: &BanditConfig,
-    children: &[SubTree],
-    rewards: &[(Vec<f64>, usize)],
+impl<'a> TreePolicy for &'a BanditConfig {
+    type NodeStats = ();
+    type EdgeStats = TAGStats;
+
+    fn pick_child(&self, env: &Env<'_>, node: &Node<'_, Self>) -> Option<usize> {
+        // Pick a new node if there are any remaining.
+        let new_nodes = node
+            .children
+            .iter()
+            .enumerate()
+            .filter(|(_, edge)| edge.stats.num_visits() == 0)
+            .map(|(idx, edge)| (idx, edge.bound()));
+
+        self.new_nodes_order
+            .pick_index(new_nodes, env.cut)
+            .or_else(|| match self.old_nodes_order {
+                OldNodeOrder::Bound => NewNodeOrder::Bound.pick_index(
+                    node.children.iter().map(|edge| edge.bound()).enumerate(),
+                    env.cut,
+                ),
+                OldNodeOrder::WeightedRandom => NewNodeOrder::WeightedRandom.pick_index(
+                    node.children.iter().map(|edge| edge.bound()).enumerate(),
+                    env.cut,
+                ),
+                OldNodeOrder::Bandit => {
+                    pick_tag_arm(self.delta, self.threshold, node, env.cut)
+                }
+            }).map(|idx| {
+                node.children[idx].stats.down();
+                idx
+            })
+    }
+
+    fn backpropagate(&self, node: &Node<Self>, idx: usize, eval: f64) {
+        node.children[idx].stats.up(self, eval);
+    }
+}
+
+/// Picks a candidate below the bound using TAG formula.
+fn pick_tag_arm<'a>(
+    delta: f64,
+    threshold: usize,
+    node: &Node<'a, &'_ BanditConfig>,
     cut: f64,
 ) -> Option<usize> {
-    let nb_tested = rewards.iter().fold(0, |acc, ref x| acc + x.1);
-    rewards
+    // Ignore cut children
+    let children = node
+        .children
         .iter()
         .enumerate()
-        .filter(|&(i, _)| children[i].bound() < cut)
-        .map(|(ind, x)| (ind, heval(config, x.0.len(), x.1, nb_tested, rewards.len())))
-        .max_by(|x1, x2| cmp_f64(x1.1, x2.1))
-        .map(|(ind, _)| ind)
+        .filter(|(_, edge)| edge.bound() < cut);
+
+    // Compute the threshold to use so that we only have `config.threshold` children
+    let threshold = {
+        let mut evalns = Evaluations::with_capacity(threshold);
+        for (_, edge) in children.clone() {
+            // Evaluations are sorted; we can bail out early.
+            for &eval in &*unwrap!(edge.stats.evaluations.read()) {
+                if !evalns.record(eval, threshold) {
+                    break;
+                }
+            }
+        }
+        evalns.max()?
+    };
+
+    // Total number of visits on this node, excluding ones which were cut
+    let num_visits = children
+        .clone()
+        .map(|(_, edge)| edge.stats.num_visits())
+        .sum::<usize>();
+
+    // Total number of children, excluding ones which were cut
+    let num_children = children.clone().count();
+
+    children
+        .map(|(ix, edge)| {
+            let num_successes =
+                unwrap!(edge.stats.evaluations.read()).count_lte(threshold);
+            let score = heval(
+                delta,
+                num_successes,
+                edge.stats.num_visits(),
+                num_visits,
+                num_children,
+            );
+            (ix, score)
+        }).max_by(|x1, x2| cmp_f64(x1.1, x2.1))
+        .map(|(ix, _)| ix)
 }
 
 /// gives a "score" to a branch of the tree at a given node n_successes is the number of
@@ -521,7 +549,7 @@ fn pick_bandit_arm(
 /// * `n_trials` is  the number of trials of the node and k the number of branches in the
 ///   node.
 fn heval(
-    config: &BanditConfig,
+    delta: f64,
     n_successes: usize,
     n_branch_trials: usize,
     n_trials: usize,
@@ -532,10 +560,106 @@ fn heval(
     if n_branch_trials == 0 {
         std::f64::INFINITY
     } else {
-        let alpha = (2. * (n_trials * n_branches) as f64 / config.delta)
-            .ln()
-            .max(0.);
+        let alpha = (2. * (n_trials * n_branches) as f64 / delta).ln().max(0.);
         let sqrt_body = alpha * (2. * n_successes as f64 + alpha);
         (n_successes as f64 + alpha + sqrt_body.sqrt()) / n_branch_trials as f64
+    }
+}
+
+/// Holds the TAG statistics for a given edge.
+pub struct TAGStats {
+    /// All evaluations seen for the pointed-to node.
+    evaluations: RwLock<Evaluations>,
+
+    /// Number of visits across this edge.  Note that this is the number of descents; there may
+    /// have been less backpropagations due to dead-ends.
+    num_visits: AtomicUsize,
+}
+
+impl Default for TAGStats {
+    fn default() -> Self {
+        TAGStats {
+            evaluations: RwLock::new(Evaluations::new()),
+            num_visits: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl TAGStats {
+    /// Called when the edge is selected during a descent
+    fn down(&self) {
+        self.num_visits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Called when backpropagating across this edge after an evaluation
+    fn up(&self, config: &BanditConfig, eval: f64) {
+        unwrap!(self.evaluations.write()).record(eval, config.threshold);
+    }
+
+    /// The number of visits through this edge.
+    fn num_visits(&self) -> usize {
+        self.num_visits.load(Ordering::Relaxed)
+    }
+}
+
+/// Holds the evaluations seen for a given node or edge.
+struct Evaluations(Vec<f64>);
+
+impl Evaluations {
+    /// Create an new evaluation vector
+    fn new() -> Evaluations {
+        Evaluations(vec![])
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        Evaluations(Vec::with_capacity(capacity))
+    }
+
+    /// Returns the number of evaluations below the given threshold.
+    fn count_lte(&self, threshold: f64) -> usize {
+        match self.0.binary_search_by(|&probe| cmp_f64(probe, threshold)) {
+            Ok(mut pos) => {
+                // Get the highest value matching the threshold
+                while pos < self.0.len()
+                    && cmp_f64(self.0[pos], threshold) == std::cmp::Ordering::Equal
+                {
+                    pos += 1;
+                }
+                pos
+            }
+            Err(pos) => pos,
+        }
+    }
+
+    /// Record a new evaluation.  Returns `true` if the evaluation is among the top `threshold`.
+    fn record(&mut self, eval: f64, threshold: usize) -> bool {
+        let pos = self
+            .0
+            .binary_search_by(|&probe| cmp_f64(probe, eval))
+            .unwrap_or_else(|e| e);
+        if pos < threshold {
+            if self.0.len() >= threshold {
+                self.0.pop();
+            }
+            self.0.insert(pos, eval);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns the maximum recorded reward.  Note that some higher evaluations may have been seen, but
+    /// were discarded due to being too large according to the configured threshold.
+    fn max(&self) -> Option<f64> {
+        self.0.last().cloned()
+    }
+}
+
+impl<'a> IntoIterator for &'a Evaluations {
+    type Item = &'a f64;
+    type IntoIter = std::slice::Iter<'a, f64>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
     }
 }

--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -188,7 +188,7 @@ pub struct BanditConfig {
     /// Indicates how to choose between nodes with at least one children evaluated.
     pub old_nodes_order: OldNodeOrder,
     /// The number of best execution times to remember.
-    pub threshold: usize,
+    pub topk: usize,
     /// The biggest delta is, the more focused on the previous best candidates the
     /// exploration is.
     pub delta: f64,
@@ -221,7 +221,7 @@ impl Default for BanditConfig {
         BanditConfig {
             new_nodes_order: NewNodeOrder::default(),
             old_nodes_order: OldNodeOrder::default(),
-            threshold: 10,
+            topk: 10,
             delta: 1.,
             choice_ordering: ChoiceOrdering::default(),
         }

--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -192,9 +192,6 @@ pub struct BanditConfig {
     /// The biggest delta is, the more focused on the previous best candidates the
     /// exploration is.
     pub delta: f64,
-    /// If true, does not expand tree until end - instead, starts a montecarlo descend after each
-    /// expansion of a node
-    pub monte_carlo: bool,
     /// Order in which the different choices are going to be determined
     pub choice_ordering: ChoiceOrdering,
 }
@@ -227,7 +224,6 @@ impl Default for BanditConfig {
             threshold: 10,
             delta: 1.,
             choice_ordering: ChoiceOrdering::default(),
-            monte_carlo: true,
         }
     }
 }

--- a/src/explorer/mod.rs
+++ b/src/explorer/mod.rs
@@ -72,8 +72,12 @@ pub fn find_best_ex<'a>(
                         .spawn(|| (unwrap!(logger::log(config, log_receiver))))
                 );
 
-                let tree =
-                    bandit_arm::Tree::new(candidates, band_config, log_sender.clone());
+                let tree = bandit_arm::Tree::new(
+                    candidates,
+                    band_config,
+                    band_config,
+                    log_sender.clone(),
+                );
                 unwrap!(
                     scope
                         .builder()


### PR DESCRIPTION
This patch tries to address various issues with the MCTS explorer, which
is outgrowing its initially planned feature set.  In particular, it
makes it more generic w.r.t. additional tree policies and
environment configurations which can be defined separately.

This patch shouldn't change functionality of the explorer, except for
two points which you need to be aware of:

 - The `monte_carlo` option in the config is removed, and the only
   behavior is now that of `monte_carlo = True`.

 - Before, in TAG, we were keeping at most `threshold` evaluations
   across all children of a node; now, we are keeping at most
   `threshold` evaluations per node and collecting the global
   `threshold` highest before selecting a child.  This more faithfully
   implements the original algorithm in the presence of cuts, although
   it shouldn't matter much in practice (branches which are cut are not
   likely to contain good evaluations anyways).

 - Before, in TAG, we were using the number of children before applying
   the cut in the formula.  Instead, they are now ignored, and only the
   number of children after cut is used.  This shouldn't matter since
   this is only a multiplicative factor in the formula, but more closely
   matches the actual tree structure.

The main architectural changes in this patch are as follow:

 - `Children` is renamed to `Node`, as it represents an internal node of
   the tree (arguably, `InternalNode` would be more appropriate).

 - A new `Edge` structure is created for each child of a `Node`.  The
   evaluation statistics are stored on the edge, instead of being in a
   separate vector.

 - `SubTree` and `DescendState` are merged.  This is made easy by the
   removal of the `monte_carlo` option.  This also has the nice effect to
   remove the confusing `descend_noexpand` method.

 - A new `Env` structure is introduced to hold information about the
   environment we are exploring.  This is a wrapper around the context
   and provide a clear hook point to modify the way we explore the
   environment, such as changing the order in which actions are taken, or
   selecting a flat order.

 - A `TreePolicy` trait is introduced.  This contains information about
   how to pick children in the tree (where we have statistics), and how to
   backpropagate evaluation information.  Currently only the existing
   algorithms (random-based and TAG) are implemented, but this can
   easily be extended to handle more classic UCT policies and hybrid
   policies with transversal models.

telamon/
 * src/explorer/bandit_arm.rs:  Refactored to be more generic.
 * src/explorer/local_selection.rs: Make `pick_index` and
`pick_candidate` methods of `NewNodeOrder` instead of free functions.
 * src/explorer/mod.rs:  Give a policy to the tree
 * src/explorer/config.rs:  Remove monte_carlo option

telamon-kernels/
 * benches/cuda_variance.rs:  Use `NewNodeOrder.pick_index`
 * src/kernel.rs:  Use `NewNodeOrder.pick_index`