### PR TITLE
Add CUDA_HOME paths to the linker search path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -20,8 +20,21 @@ fn add_dependency(dep: &Path) {
 fn compile_link_cuda() {
     let mut builder = cc::Build::new();
 
-    // If CUDA_HOME is defined, use the cuda headers from there.
+    // If CUDA_HOME is defined, use the cuda headers and libraries from there.
     if let Some(cuda_home) = env::var_os("CUDA_HOME").map(PathBuf::from) {
+        println!(
+            "cargo:rustc-link-search=native={}",
+            cuda_home.join("lib64").display()
+        );
+        println!(
+            "cargo:rustc-link-search=native={}",
+            cuda_home
+                .join("extras")
+                .join("CUPTI")
+                .join("lib64")
+                .display()
+        );
+
         builder
             .include(cuda_home.join("include"))
             .include(cuda_home.join("extras").join("CUPTI").join("include"));


### PR DESCRIPTION
@ulysseB just want to make sure you sign off on this.  This adds the `lib64` and `extras/CUPTI/lib64` paths from `CUDA_HOME` to the linker search space for compatibility with systems where the CUDA libraries are not available system-wide, without having to set LIBRARY_PATH.  This complements #169 which did the same thing for headers, and I am still puzzled as to why I thought that was working.

The NVIDIA driver libraries (libcuda) still need to be set up system-wide (or through `LIBRARY_PATH`), and `LD_LIBRARY_PATH` still needs to be set properly for actually *running* the built executables.