### PR TITLE
[C API] Use repr(transparent) for newtype wrappers

### DIFF
--- a/src/ir/dimension.rs
+++ b/src/ir/dimension.rs
@@ -7,8 +7,7 @@ use utils::*;
 #[derive(
     Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
 )]
-#[repr(C)]
-/// cbindgen:field-names=[id]
+#[repr(transparent)]
 pub struct DimId(pub u32);
 
 impl Into<usize> for DimId {
@@ -232,7 +231,7 @@ impl<'a, L> Statement<'a, L> for Dimension<'a, L> {
 
 /// Provides a unique identifier for logic dimensions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[repr(C)]
+#[repr(transparent)]
 pub struct LogicalDimId(pub u32);
 
 /// A logic dimension composed of multiple `Dimension`s.

--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -7,8 +7,7 @@ use utils::*;
 #[derive(
     Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
 )]
-#[repr(C)]
-/// cbindgen:field-names=[id]
+#[repr(transparent)]
 pub struct InstId(pub u32);
 
 impl Into<usize> for InstId {

--- a/src/ir/mem.rs
+++ b/src/ir/mem.rs
@@ -6,8 +6,7 @@ use utils::*;
 
 /// Uniquely identifies a block.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
-#[repr(C)]
-/// cbindgen:field-names=[id]
+#[repr(transparent)]
 pub struct MemId(pub u32);
 
 impl From<MemId> for usize {

--- a/src/ir/variable.rs
+++ b/src/ir/variable.rs
@@ -6,6 +6,7 @@ use utils::*;
 #[derive(
     Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
 )]
+#[repr(transparent)]
 pub struct VarId(pub u16);
 
 impl From<VarId> for usize {

--- a/telamon-capi/cbindgen.toml
+++ b/telamon-capi/cbindgen.toml
@@ -2,7 +2,7 @@ autogen_warning = """/* DO NOT MODIFY THIS MANUALLY!
  * This file has been generated usin cbindgen.
  *
  * To generate this file:
- *  1. Get the latest cbindgen using `cargo install --force cbindgen --git https://github.com/Elarnon/cbindgen`
+ *  1. Get the latest cbindgen using `cargo install --force cbindgen`
  *  2. Run `rustup run nightly cbindgen telamon-capi -o telamon-capi/include/telamon.h`
  */"""
 include_guard = "TELAMON_CAPI_H"

--- a/telamon-capi/include/telamon.h
+++ b/telamon-capi/include/telamon.h
@@ -5,7 +5,7 @@
  * This file has been generated usin cbindgen.
  *
  * To generate this file:
- *  1. Get the latest cbindgen using `cargo install --force cbindgen --git https://github.com/Elarnon/cbindgen`
+ *  1. Get the latest cbindgen using `cargo install --force cbindgen`
  *  2. Run `rustup run nightly cbindgen telamon-capi -o telamon-capi/include/telamon.h`
  */
 
@@ -172,37 +172,24 @@ typedef struct String String;
 typedef struct Type Type;
 
 /*
- * Uniquely identifies variables.
- */
-typedef struct VarId VarId;
-
-/*
  * Provides a unique identifier for iteration dimensions.
  */
-typedef struct {
-    uint32_t id;
-} DimId;
+typedef uint32_t DimId;
 
 /*
  * Provides a unique identifier for logic dimensions.
  */
-typedef struct {
-    uint32_t _0;
-} LogicalDimId;
+typedef uint32_t LogicalDimId;
 
 /*
  * Uniquely identifies an instruction.
  */
-typedef struct {
-    uint32_t id;
-} InstId;
+typedef uint32_t InstId;
 
 /*
  * Uniquely identifies a block.
  */
-typedef struct {
-    uint32_t id;
-} MemId;
+typedef uint32_t MemId;
 
 /*
  * Specifies the version of an instruction to use.
@@ -225,6 +212,11 @@ typedef struct {
 typedef struct {
     uint8_t bits;
 } ThreadMapping;
+
+/*
+ * Uniquely identifies variables.
+ */
+typedef uint16_t VarId;
 
 /*
  * Specifies where to store a variable.


### PR DESCRIPTION
This patch uses `#[repr(transparent)]` instead of `#[repr(C)]` for
newtype wrappers.   This allows `cbindgen` to generate `typedefs`
instead of single-field structs, which are very non idiomatic in C.

In addition, this adds `#[repr(transparent)]` to `VarId` to make the C
and Python APIs work again.