### PR TITLE
Add a CLI tool to extract data from event logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ required-features = ["cuda"]
 [[example]]
 name = "print_event_log"
 
+[[example]]
+name = "parse_event_log"
+
 [build-dependencies]
 cc = "1.0.12"
 failure = "0.1.1"
@@ -99,6 +102,8 @@ gcc = "0.3.54"
 tempdir = "0.3.7"
 criterion = "0.2.4"
 jemalloc-ctl = "0.1"
+dot = "0.1"
+csv = "1"
 
 [features]
 cuda = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ required-features = ["cuda"]
 [[bin]]
 name = "expandconfig"
 
+[[bin]]
+name = "parse_event_log"
+
 [[bench]]
 name = "descent"
 harness = false
@@ -36,9 +39,6 @@ required-features = ["cuda"]
 
 [[example]]
 name = "print_event_log"
-
-[[example]]
-name = "parse_event_log"
 
 [build-dependencies]
 cc = "1.0.12"
@@ -90,6 +90,8 @@ tempfile = "3.0.1"
 toml = "0.4"
 xdg = "^2.1"
 flate2 = "1.0.2"
+dot = "0.1"
+csv = "1"
 
 [dependencies.telamon-utils]
 path = "telamon-utils"
@@ -102,8 +104,6 @@ gcc = "0.3.54"
 tempdir = "0.3.7"
 criterion = "0.2.4"
 jemalloc-ctl = "0.1"
-dot = "0.1"
-csv = "1"
 
 [features]
 cuda = []

--- a/examples/parse_event_log.rs
+++ b/examples/parse_event_log.rs
@@ -1,0 +1,278 @@
+extern crate bincode;
+extern crate csv;
+extern crate dot;
+extern crate flate2;
+extern crate structopt;
+
+extern crate telamon;
+extern crate telamon_utils as utils;
+
+use std::collections::HashMap;
+
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::PathBuf;
+use telamon::explorer::{choice::ActionEx, TreeEvent};
+use utils::tfrecord::{ReadError, RecordReader};
+
+use flate2::read::{GzDecoder, ZlibDecoder};
+use structopt::StructOpt;
+
+struct Edge {
+    action: ActionEx,
+    node: Box<Node>,
+}
+
+struct Node {
+    children: HashMap<ActionEx, Edge>,
+    evaluations: Vec<f64>,
+    id: usize,
+    tag: Option<f64>,
+}
+
+impl Node {
+    fn compute_top(&mut self, k: usize) {
+        let mut buf = Vec::with_capacity(k);
+
+        for (_action, edge) in self.children.iter() {
+            for eval in &edge.node.evaluations {
+                let pos = buf
+                    .binary_search_by(|&probe| utils::cmp_f64(probe, *eval))
+                    .unwrap_or_else(|e| e);
+                if pos < k {
+                    if buf.len() >= k {
+                        buf.pop();
+                    }
+                    buf.insert(pos, *eval);
+                }
+            }
+        }
+
+        if let Some(threshold) = buf.pop() {
+            for (_action, edge) in self.children.iter_mut() {
+                edge.node.tag = Some(
+                    edge.node
+                        .evaluations
+                        .iter()
+                        .filter(|eval| **eval <= threshold)
+                        .count() as f64
+                        / k as f64,
+                );
+
+                edge.node.compute_top(k);
+            }
+        }
+    }
+}
+
+struct TreeInfo<'a> {
+    nodes: Vec<&'a Node>,
+    edges: Vec<(usize, usize, &'a Edge)>,
+}
+
+type Nd<'a> = (usize, &'a &'a Node);
+
+type Ed<'a> = &'a (usize, usize, &'a Edge);
+
+impl<'a> dot::GraphWalk<'a, Nd<'a>, Ed<'a>> for TreeInfo<'a> {
+    fn nodes(&'a self) -> dot::Nodes<'a, Nd<'a>> {
+        self.nodes.iter().enumerate().collect()
+    }
+
+    fn edges(&'a self) -> dot::Edges<'a, Ed<'a>> {
+        self.edges.iter().collect()
+    }
+
+    fn source(&'a self, edge: &Ed<'a>) -> Nd<'a> {
+        (edge.0, &self.nodes[edge.0])
+    }
+
+    fn target(&'a self, edge: &Ed<'a>) -> Nd<'a> {
+        (edge.1, &self.nodes[edge.1])
+    }
+}
+
+impl<'a> dot::Labeller<'a, Nd<'a>, Ed<'a>> for TreeInfo<'a> {
+    fn graph_id(&'a self) -> dot::Id<'a> {
+        dot::Id::new("telamon").unwrap()
+    }
+
+    fn node_id(&'a self, n: &Nd<'a>) -> dot::Id<'a> {
+        dot::Id::new(format!("N{}", n.0)).unwrap()
+    }
+
+    fn node_label(&self, n: &Nd<'a>) -> dot::LabelText<'_> {
+        dot::LabelText::label(format!(
+            "#{}: {} (best: {:7.03e}, avg: {:7.03e}, avglog: {:7.03e}{})",
+            n.1.id,
+            n.1.evaluations.len(),
+            n.1.evaluations
+                .iter()
+                .cloned()
+                .min_by(|lhs, rhs| utils::cmp_f64(*lhs, *rhs))
+                .unwrap_or(std::f64::INFINITY),
+            n.1.evaluations.iter().sum::<f64>() / n.1.evaluations.len() as f64,
+            n.1.evaluations.iter().map(|x| x.ln()).sum::<f64>()
+                / n.1.evaluations.len() as f64,
+            if let Some(tag) = n.1.tag {
+                format!(", top10: {}%", tag * 100.)
+            } else {
+                "".into()
+            },
+        ))
+    }
+
+    fn edge_label(&self, e: &Ed<'a>) -> dot::LabelText<'_> {
+        dot::LabelText::label(format!("{:?}", e.2.action))
+    }
+}
+
+impl Node {
+    fn info(&self) -> TreeInfo<'_> {
+        let mut worklist = vec![(self, 0)];
+        let mut nodes = vec![];
+        let mut edges = vec![];
+
+        let max_depth = None;
+        let min_evals = Some(1000);
+
+        while let Some((node, depth)) = worklist.pop() {
+            nodes.push((node as *const Node, node));
+
+            if max_depth.map(|max_depth| depth < max_depth).unwrap_or(true)
+                && min_evals
+                    .map(|min_evals| node.evaluations.len() > min_evals)
+                    .unwrap_or(true)
+            {
+                for (action, edge) in node.children.iter() {
+                    edges.push((node as *const Node, &*edge.node as *const Node, edge));
+
+                    worklist.push((&edge.node, depth + 1));
+                }
+            }
+        }
+
+        let mut nodeindex: HashMap<*const Node, usize> = HashMap::new();
+        for (index, (nid, _)) in nodes.iter().enumerate() {
+            nodeindex.insert(*nid, index);
+        }
+
+        TreeInfo {
+            nodes: nodes.into_iter().map(|(_nid, info)| info).collect(),
+            edges: edges
+                .into_iter()
+                .map(|(from, to, info)| (nodeindex[&from], nodeindex[&to], info))
+                .collect(),
+        }
+    }
+}
+
+fn dig<II>(children: &mut HashMap<ActionEx, Edge>, actions: II, eval: f64, id: usize)
+where
+    II: IntoIterator<Item = ActionEx>,
+{
+    let mut it = actions.into_iter();
+
+    if let Some(action) = it.next() {
+        let edge = children.entry(action.clone()).or_insert_with(|| Edge {
+            action: action.clone(),
+            node: Box::new(Node {
+                children: Default::default(),
+                evaluations: vec![],
+                id: id,
+                tag: None,
+            }),
+        });
+
+        edge.node.evaluations.push(eval);
+        dig(&mut edge.node.children, it, eval, id)
+    }
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "print_event_log")]
+struct Opt {
+    #[structopt(
+        parse(from_os_str),
+        short = "i",
+        long = "input",
+        default_value = "eventlog.tfrecord.gz"
+    )]
+    eventlog: PathBuf,
+
+    #[structopt(long = "topk", default_value = "10")]
+    topk: usize,
+}
+
+impl Opt {
+    fn open_eventlog(&self) -> io::Result<Box<dyn Read>> {
+        let raw_file = File::open(&self.eventlog)?;
+        Ok(match self.eventlog.extension().and_then(OsStr::to_str) {
+            Some("gz") => Box::new(GzDecoder::new(raw_file)),
+            Some("zz") => Box::new(ZlibDecoder::new(raw_file)),
+            _ => Box::new(raw_file),
+        })
+    }
+}
+
+fn main() -> Result<(), ReadError> {
+    let opt = Opt::from_args();
+
+    let mut f = opt.open_eventlog()?;
+    let mut root = Node {
+        children: Default::default(),
+        evaluations: vec![],
+        id: 0,
+        tag: None,
+    };
+
+    let mut evals = Vec::new();
+
+    for (id, record_bytes) in f.records().enumerate() {
+        match bincode::deserialize(&record_bytes?).unwrap() {
+            TreeEvent::Evaluation { actions, score } => {
+                root.evaluations.push(score);
+
+                let actions = {
+                    let mut actions = actions.iter().cloned().collect::<Vec<_>>();
+                    actions.reverse();
+                    actions
+                };
+
+                dig(&mut root.children, actions, score, id);
+
+                evals.push(score);
+            }
+        }
+    }
+
+    println!("Computing top{} for all nodes...", opt.topk);
+    root.compute_top(opt.topk);
+
+    // Print the graph
+    println!(
+        "Writing graph to {}...",
+        format!("graph-top{}.dot", opt.topk)
+    );
+    {
+        let mut f = std::fs::File::create(format!("graph-top{}.dot", opt.topk)).unwrap();
+        dot::render(&root.info(), &mut f).unwrap();
+    }
+
+    // Print the csv
+    println!("Writing out.csv...");
+    {
+        let mut f = std::fs::File::create("out.csv")?;
+        let mut writer = csv::Writer::from_writer(&mut f);
+        writer.write_record(&["Id", "Time"]).unwrap();
+        for (id, eval) in evals.iter().enumerate() {
+            writer
+                .write_record(&[id.to_string(), eval.to_string()])
+                .unwrap();
+        }
+        writer.flush()?;
+    }
+
+    Ok(())
+}

--- a/examples/print_event_log.rs
+++ b/examples/print_event_log.rs
@@ -1,3 +1,4 @@
+/// This example shows how to iterate over the events stored in an eventlog.
 extern crate bincode;
 extern crate telamon;
 extern crate telamon_utils as utils;
@@ -9,30 +10,15 @@ use utils::tfrecord::{ReadError, RecordReader};
 
 fn main() -> Result<(), ReadError> {
     let mut f = std::fs::File::open("eventlog.tfrecord")?;
-    let mut offset;
-    loop {
-        offset = f.seek(io::SeekFrom::Current(0))?;
 
-        match f.read_record() {
-            Ok(record) => match bincode::deserialize(&record).unwrap() {
-                TreeEvent::Evaluation {
-                    actions,
-                    score: _score,
-                } => println!("{:?}", actions.into_iter().collect::<Vec<_>>()),
-            },
-            Err(err) => {
-                // If we reached eof and no bytes were read, we were
-                // at the end of a well-formed file and we can safely
-                // exit. Otherwise, we propagate the error.
-                if let ReadError::IOError(ref error) = err {
-                    if error.kind() == io::ErrorKind::UnexpectedEof
-                        && offset == f.seek(io::SeekFrom::Current(0))?
-                    {
-                        return Ok(());
-                    }
-                }
-                return Err(err);
-            }
+    for record_bytes in (&mut f).records() {
+        match bincode::deserialize(&record_bytes?).unwrap() {
+            TreeEvent::Evaluation {
+                actions,
+                score: _score,
+            } => println!("{:?}", actions.into_iter().collect::<Vec<_>>()),
         }
     }
+
+    Ok(())
 }

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -12,7 +12,8 @@
 
 # Find all staged rust files, and exit early if there aren't any.
 RUST_FILES=($(git diff --name-only --cached --diff-filter=AM | \
-    grep --color=never '.rs$'))
+    grep --color=never '.rs$' | \
+    grep --color=never -v '/template/'))
 if [ ! "$RUST_FILES" ]; then
     exit 0
 fi

--- a/src/bin/parse_event_log.rs
+++ b/src/bin/parse_event_log.rs
@@ -144,7 +144,7 @@ impl Node {
                     .map(|min_evals| node.evaluations.len() as u32 > min_evals)
                     .unwrap_or(true)
             {
-                for (action, edge) in node.children.iter() {
+                for (_action, edge) in node.children.iter() {
                     edges.push((node as *const Node, &*edge.node as *const Node, edge));
 
                     worklist.push((&edge.node, depth + 1));
@@ -230,7 +230,7 @@ impl Opt {
 fn main() -> Result<(), ReadError> {
     let opt = Opt::from_args();
 
-    let mut f = opt.open_eventlog()?;
+    let f = opt.open_eventlog()?;
     let mut root = Node {
         children: Default::default(),
         evaluations: vec![],

--- a/src/explorer/choice.rs
+++ b/src/explorer/choice.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use search_space::{Action, Domain, NumSet, Order, SearchSpace};
 
 /// Either a regular action or a manually applied action.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ActionEx {
     Action(Action),
     LowerLayout {

--- a/telamon-gen/src/print/runtime/integer_set.rs
+++ b/telamon-gen/src/print/runtime/integer_set.rs
@@ -6,7 +6,7 @@ use proc_macro2::TokenStream;
 /// Defines the `NumericSet` type.
 pub fn get() -> TokenStream {
     quote! {
-        #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+        #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
         #[repr(C)]
         pub struct NumericSet {
             enabled_values: u16

--- a/telamon-gen/src/print/runtime/range.rs
+++ b/telamon-gen/src/print/runtime/range.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream;
 pub fn get() -> TokenStream {
     quote! {
         /// Abstracts integer choices by a range.
-        #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+        #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
         #[repr(C)]
         pub struct Range {
             pub min: u32,
@@ -125,7 +125,7 @@ pub fn get() -> TokenStream {
         }
 
         /// Abstracts integer choices by a range, but only store `min`.
-        #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+        #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
         #[repr(C)]
         pub struct HalfRange { pub min: u32 }
 

--- a/telamon-gen/src/print/template/actions.rs
+++ b/telamon-gen/src/print/template/actions.rs
@@ -1,5 +1,5 @@
 /// A decision to apply to the domain.
-#[derive(PartialEq, Eq, Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy, Serialize, Deserialize)]
 #[repr(C)]
 pub enum Action {
     {{~#each choices}}

--- a/telamon-utils/src/tfrecord.rs
+++ b/telamon-utils/src/tfrecord.rs
@@ -84,6 +84,25 @@ fn masked_crc32(bytes: &[u8]) -> u32 {
     ((crc >> 15) | (crc << 17)).wrapping_add(0xa282_ead8u32)
 }
 
+// Wrapper around Read::read which retries when receiving an Interrupted error
+fn retry_read<R: Read + ?Sized>(read: &mut R, mut buf: &mut [u8]) -> io::Result<usize> {
+    let mut nread = 0;
+    while !buf.is_empty() {
+        match read.read(buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                let tmp = buf;
+                buf = &mut tmp[n..];
+                nread += n;
+            }
+            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(nread)
+}
+
 /// A trait extension for reading records.
 ///
 /// Inspired from the C++ implementation at: *
@@ -91,32 +110,86 @@ fn masked_crc32(bytes: &[u8]) -> u32 {
 ///  *
 ///  https://github.com/tensorflow/tensorflow/blob/f318765ad5a50b2fbd7cc08dd4ebc249b3924270/tensorflow/core/lib/io/record_reader.cc
 pub trait RecordReader: Read {
-    /// Read a single record.
-    fn read_record(&mut self) -> Result<Vec<u8>, ReadError> {
+    /// Read a single record, placing the bytes into `buf`.
+    ///
+    /// All bytes read from this source will be appended to the specified buffer `buf`.
+    ///
+    /// If successful, this function returns the total number of bytes read, including the tfrecord
+    /// header and footer sizes.  If the total number of bytes read is `0`, then the reader has
+    /// reached end of file.
+    ///
+    /// # Errors
+    ///
+    /// If this function encounters an error of the kind `ErrorKind::Interrupted` then the error is
+    /// ignored and the operation will continue.
+    ///
+    /// If any other read error is encountered then this function immediately returns.  Any bytes
+    /// which have already been read will be appended to `buf`.  If an error occurs while reading
+    /// the initial tfrecord header, buf is unchanged.
+    fn read_record(&mut self, buf: &mut Vec<u8>) -> Result<usize, ReadError> {
         let len = {
             let mut len_bytes = [0u8; 8];
-            self.read_exact(&mut len_bytes)?;
+            if retry_read(self, &mut len_bytes)? == 0 {
+                return Ok(0);
+            }
+
             if self.read_u32::<LittleEndian>()? != masked_crc32(&len_bytes) {
                 return Err(ReadError::CorruptedRecord);
             }
+
             // We `unwrap` here because reading from the on-stack
             // buffer cannnot fail.
-            len_bytes.as_ref().read_u64::<LittleEndian>().unwrap()
+            (&len_bytes[..]).read_u64::<LittleEndian>().unwrap()
         };
 
-        let mut record_bytes = Vec::with_capacity(len as usize);
-        let nread = self.take(len).read_to_end(&mut record_bytes)? as u64;
-        if nread != len {
+        // TODO(bclement): Consider adding a safety check that we are not allocating too large a
+        // buffer here.
+        let buf_start = buf.len();
+        buf.reserve_exact(len as usize);
+        let nread = self.take(len).read_to_end(buf)?;
+        if nread as u64 != len {
             return Err(ReadError::TruncatedRecord);
         }
-        if self.read_u32::<LittleEndian>()? != masked_crc32(&record_bytes) {
+        if self.read_u32::<LittleEndian>()? != masked_crc32(&buf[buf_start..]) {
             return Err(ReadError::CorruptedRecord);
         }
-        Ok(record_bytes)
+
+        Ok(8 + 4 + 4 + nread)
+    }
+
+    /// Transforms this `Read` instance to an `Iterator` over the contained records.
+    ///
+    /// The returned type implements `Iterator` where the `Item` is `Result<u8, ReadError>`.  The
+    /// yielded item is `Ok` if a record was successfuly read and `Err` otherwise.  EOF is mapped
+    /// to returning `None` from this iterator.
+    fn records(self) -> Records<Self>
+    where
+        Self: Sized,
+    {
+        Records { read: self }
     }
 }
 
 impl<R: Read + ?Sized> RecordReader for R {}
+
+/// A simple iterator over the records stored in a file.
+#[derive(Debug)]
+pub struct Records<R> {
+    read: R,
+}
+
+impl<R: Read> Iterator for Records<R> {
+    type Item = Result<Vec<u8>, ReadError>;
+
+    fn next(&mut self) -> Option<Result<Vec<u8>, ReadError>> {
+        let mut buf = Vec::new();
+        match self.read.read_record(&mut buf) {
+            Ok(0) => None,
+            Ok(..) => Some(Ok(buf)),
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
 
 /// A trait extension for writing records.
 ///


### PR DESCRIPTION
The new tool, in `examples/parse_event_log`, allows dumping a CSV of all
the evaluations that were performed during a run, as well as a graphviz
(.dot) graph recapitulating the run.

telamon-utils/
 - src/tfrecord.rs:  Add `.records()` iterator method.

telamon/
 - Cargo.toml:  Add crates for graphviz and csv writing.
 - examples/print_event_log.rs:  Upgrade to the `.records()` API
 - examples/parse_event_log.rs:  Added.