### PR TITLE
Fixed choose_cand_weighted when list is empty

### DIFF
--- a/src/explorer/local_selection.rs
+++ b/src/explorer/local_selection.rs
@@ -109,5 +109,9 @@ where
             weighted_items.push(Weighted { weight, item: ind });
         }
     }
+    if weighted_items.is_empty() {
+        None 
+    } else {
     Some(WeightedChoice::new(&mut weighted_items).sample(&mut rng))
+    }
 }

--- a/src/explorer/local_selection.rs
+++ b/src/explorer/local_selection.rs
@@ -110,8 +110,8 @@ where
         }
     }
     if weighted_items.is_empty() {
-        None 
+        None
     } else {
-    Some(WeightedChoice::new(&mut weighted_items).sample(&mut rng))
+        Some(WeightedChoice::new(&mut weighted_items).sample(&mut rng))
     }
 }


### PR DESCRIPTION
Fixed choose_cand_weighted behaviour when node list is empty