### PR TITLE
[bandit] Use RwLock<Arc<T>> instead of Arc<RwLock<T>>

### DIFF
--- a/src/explorer/bandit_arm.rs
+++ b/src/explorer/bandit_arm.rs
@@ -91,7 +91,8 @@ pub enum TreeEvent {
 
 /// A search tree to perform a multi-armed bandit search.
 pub struct Tree<'a, 'b, P: TreePolicy> {
-    root: Edge<'a, P::EdgeStats>,
+    root: RwLock<Option<Arc<Node<'a, P::EdgeStats>>>>,
+    bound: RwLock<f64>,
     stop: AtomicBool,
     cut: RwLock<f64>,
     config: &'b BanditConfig,
@@ -108,10 +109,14 @@ impl<'a, 'b, P: TreePolicy> Tree<'a, 'b, P> {
         policy: P,
         log_sender: std::sync::mpsc::SyncSender<LogMessage<TreeEvent>>,
     ) -> Self {
+        let root = Node::try_from_candidates(candidates);
+        let bound = root.as_ref().and_then(|root| root.bound());
+
         Tree {
-            root: SubTree::from(Node::from_candidates(candidates)).into(),
+            root: RwLock::new(root),
             stop: AtomicBool::new(false),
             cut: RwLock::new(config.initial_cut.unwrap_or(std::f64::INFINITY)),
+            bound: RwLock::new(bound.unwrap_or(std::f64::INFINITY)),
             config,
             policy,
             stats: TreeStats::default(),
@@ -147,10 +152,10 @@ impl<'a, 'b, P: TreePolicy> Tree<'a, 'b, P> {
         // If we did not returned before, we have reached the root of the tree.
         if let Some(bound) = bound {
             trace!("upgrading root bound to {}", bound);
-            self.root.update_bound(bound);
+            *unwrap!(self.bound.write()) = bound;
         } else {
             trace!("killing root");
-            self.root.kill();
+            *unwrap!(self.root.write()) = None;
         }
     }
 }
@@ -166,15 +171,19 @@ where
 
     fn update_cut(&self, new_cut: f64) {
         *unwrap!(self.cut.write()) = new_cut;
-        let mut stack = self.root.trim(new_cut).into_iter().collect::<Vec<_>>();
-        while let Some(subtree) = stack.pop() {
-            if let SubTree::InternalNode(node) = &*unwrap!(subtree.read()) {
-                for edge in &node.children {
-                    stack.extend(edge.trim(new_cut))
-                }
+
+        let mut stack = match &*unwrap!(self.root.read()) {
+            Some(node) => vec![Arc::clone(node)],
+            None => Vec::new(),
+        };
+
+        while let Some(node) = stack.pop() {
+            for edge in &node.children {
+                stack.extend(edge.trim(new_cut))
             }
         }
-        info!("trimming finished");
+
+        info!("cut: trimming finished");
     }
 
     fn commit_evaluation(
@@ -211,11 +220,13 @@ where
             };
 
             // Bail out early if the root is a deadend
-            let mut state = self.root.descend(&env);
-            if let SubTree::Empty = state {
-                debug!("stopping: deadend at root");
-                return None;
-            }
+            let mut state = SubTree::InternalNode(match &*unwrap!(self.root.read()) {
+                Some(node) => Arc::clone(node),
+                None => {
+                    debug!("stopping: deadend at root");
+                    return None;
+                }
+            });
 
             // Descent loop
             let mut path = Path::default();
@@ -287,52 +298,16 @@ enum SubTree<'a, E> {
     Empty,
 }
 
-impl<'a, E: Default> From<Node<'a, E>> for SubTree<'a, E> {
-    fn from(node: Node<'a, E>) -> Self {
-        if node.is_deadend() {
-            SubTree::Empty
-        } else {
-            SubTree::InternalNode(Arc::new(node))
-        }
-    }
-}
-
-impl<'a, E: Default> SubTree<'a, E> {
-    fn bound(&self) -> Option<f64> {
-        match self {
-            SubTree::InternalNode(node) => node.bound(),
-            SubTree::Leaf(candidate) => Some(candidate.bound.value()),
-            SubTree::Empty => None,
-        }
-    }
-}
-
 /// An edge in the tree
 struct Edge<'a, E> {
     /// The destination of the edge.  This may not be expanded yet.
-    dst: Arc<RwLock<SubTree<'a, E>>>,
+    dst: RwLock<SubTree<'a, E>>,
 
     /// Edge statistics
     stats: E,
 
     /// The current bound for the pointed-to node.
     bound: RwLock<f64>,
-}
-
-impl<'a, E: Default> From<SubTree<'a, E>> for Edge<'a, E> {
-    fn from(subtree: SubTree<'a, E>) -> Self {
-        Edge {
-            stats: E::default(),
-            bound: RwLock::new(subtree.bound().unwrap_or(std::f64::INFINITY)),
-            dst: Arc::new(RwLock::new(subtree)),
-        }
-    }
-}
-
-impl<'a, E: Default> From<Candidate<'a>> for Edge<'a, E> {
-    fn from(candidate: Candidate<'a>) -> Self {
-        SubTree::Leaf(Box::new(candidate)).into()
-    }
 }
 
 impl<'a, E: Default> Edge<'a, E> {
@@ -356,14 +331,17 @@ impl<'a, E: Default> Edge<'a, E> {
 
     /// Trims the branch if it has an evaluation time guaranteed to be worse than
     /// `cut`. Returns the childrens to trim if any,
-    fn trim(&self, cut: f64) -> Option<Arc<RwLock<SubTree<'a, E>>>> {
+    fn trim(&self, cut: f64) -> Option<Arc<Node<'a, E>>> {
         if self.bound() >= cut {
             self.kill();
             None
-        } else if let SubTree::InternalNode(_) = *unwrap!(self.dst.read()) {
-            Some(Arc::clone(&self.dst))
         } else {
-            None
+            let subtree = unwrap!(self.dst.read());
+            if let SubTree::InternalNode(node) = &*subtree {
+                Some(Arc::clone(node))
+            } else {
+                None
+            }
         }
     }
 
@@ -378,7 +356,7 @@ impl<'a, E: Default> Edge<'a, E> {
                         return SubTree::InternalNode(Arc::clone(node));
                     }
                     SubTree::Leaf(_) => {
-                        // Need write access, see below
+                        // Need write access to expand, see below
                     }
                 }
             }
@@ -388,23 +366,22 @@ impl<'a, E: Default> Edge<'a, E> {
             // leaf below and loop again (where the first read access should not fail).
             {
                 let dst = &mut *unwrap!(self.dst.write());
-                if let SubTree::Leaf(_) = dst {
+                if let SubTree::Leaf(_) = &*dst {
                     // We got write access to the leaf; expand it.
                     if let SubTree::Leaf(candidate) =
                         std::mem::replace(dst, SubTree::Empty)
                     {
                         let choice = env.list_actions(&candidate);
                         if let Some(choice) = choice {
-                            let node = Node::from_candidates(
+                            if let Some(node) = Node::try_from_candidates(
                                 env.apply_choice(&candidate, choice),
-                            );
-                            if node.is_deadend() {
+                            ) {
+                                // Newly expanded node, with no stats yet.
+                                *dst = SubTree::InternalNode(node);
+                                return SubTree::Leaf(candidate);
+                            } else {
                                 // Actual dead-end; leave the SubTree::Empty there.
                                 return SubTree::Empty;
-                            } else {
-                                // Newly expanded node, with no stats yet.
-                                *dst = SubTree::InternalNode(Arc::new(node));
-                                return SubTree::Leaf(candidate);
                             }
                         } else {
                             // Fully specified implementation; we leave the SubTree::Empty here because if
@@ -434,9 +411,20 @@ pub struct Node<'a, E> {
 
 impl<'a, E: Default> Node<'a, E> {
     /// Creates a new children containing the given candidates, if any.
-    fn from_candidates(candidates: Vec<Candidate<'a>>) -> Self {
-        Node {
-            children: candidates.into_iter().map(Edge::from).collect(),
+    fn try_from_candidates(candidates: Vec<Candidate<'a>>) -> Option<Arc<Self>> {
+        if candidates.is_empty() {
+            None
+        } else {
+            Some(Arc::new(Node {
+                children: candidates
+                    .into_iter()
+                    .map(|candidate| Edge {
+                        bound: RwLock::new(candidate.bound.value()),
+                        dst: RwLock::new(SubTree::Leaf(Box::new(candidate))),
+                        stats: Default::default(),
+                    })
+                    .collect::<Vec<_>>(),
+            }))
         }
     }
 
@@ -446,10 +434,6 @@ impl<'a, E: Default> Node<'a, E> {
             .iter()
             .map(|edge| edge.bound())
             .min_by(|&lhs, &rhs| cmp_f64(lhs, rhs))
-    }
-
-    fn is_deadend(&self) -> bool {
-        self.bound().is_none()
     }
 
     /// Trim children (that is, replace with an empty `SubTree`) children whose bounds are

--- a/src/explorer/bandit_arm.rs
+++ b/src/explorer/bandit_arm.rs
@@ -111,7 +111,7 @@ impl<'a, 'b, P: TreePolicy> Tree<'a, 'b, P> {
         Tree {
             root: SubTree::from(Node::from_candidates(candidates)).into(),
             stop: AtomicBool::new(false),
-            cut: RwLock::new(std::f64::INFINITY),
+            cut: RwLock::new(config.initial_cut.unwrap_or(std::f64::INFINITY)),
             config,
             policy,
             stats: TreeStats::default(),

--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -182,6 +182,9 @@ impl Default for SearchAlgorithm {
 #[serde(default)]
 #[serde(deny_unknown_fields)]
 pub struct BanditConfig {
+    /// Indicates the initial cut to use (in nanoseconds).  This can be used when an existing
+    /// program (e.g. from a precedent run) is known to take that much amount of time.
+    pub initial_cut: Option<f64>,
     /// Indicates how to select between nodes of the search tree when none of their
     /// children have been evaluated.
     pub new_nodes_order: NewNodeOrder,
@@ -275,6 +278,7 @@ impl BanditConfig {
 impl Default for BanditConfig {
     fn default() -> Self {
         BanditConfig {
+            initial_cut: None,
             new_nodes_order: NewNodeOrder::default(),
             tree_policy: TreePolicy::default(),
             choice_ordering: ChoiceOrdering::default(),


### PR DESCRIPTION
This allows makes code slightly easier to reason about because we move
immutable values (with possibly mutable, lock-protected fields) instead
of mutable values.

In addition, this adds an `initial_cut` parameter to define an initial value for the cut when initializing the search.