### PR TITLE
[bandit] Make UCT algorithm customisable

### DIFF
--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -201,13 +201,27 @@ pub struct BanditConfig {
 pub enum TreePolicy {
     /// Take the candidate with the best bound.
     Bound,
+
     /// Consider the nodes with a probability proportional to the distance between the
     /// cut and the bound.
     WeightedRandom,
-    /// TAG algorithm
+
+    /// Policies based on TAG, as described in
+    ///
+    ///   Bandit-Based Optimization on Graphs with Application to Library Performance Tuning
+    ///   De Mesmay, Rimmel, Voronenko, Püschel
+    ///   ICML 2009
+    ///
+    /// Those policies make decisions based on the relative proportions of the top N samples in
+    /// each branch, without relying directly on the values.  This obviates the issue of selecting
+    /// a good threshold value for good vs bad samples (we don't know what a good value is until
+    /// after we have found it!), but introduces an issue with staleness:
     #[serde(rename = "tag")]
     TAG(TAGConfig),
-    /// UCT algorithm
+
+    /// Policies based on UCT, including variants such as p-UCT.  Those policies optimize a reduced
+    /// value (such as average score or best score) among the samples seen in a branch, along with
+    /// an uncertainty term to boost rarely explored branches.
     #[serde(rename = "uct")]
     UCT(UCTConfig),
 }

--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -313,8 +313,8 @@ pub enum ValueReduction {
     Mean,
     /// Use the best evaluation time.  This yields an algorithm similar to maxUCT from
     ///
-    ///     Trial-based Heuristic Tree Search for Finite Horizon MDPs,
-    ///     Thomas Keller and Malte Helmert
+    ///   Trial-based Heuristic Tree Search for Finite Horizon MDPs,
+    ///   Thomas Keller and Malte Helmert
     Best,
 }
 


### PR DESCRIPTION
In order to facilitate performing experiments, this makes the UCT-based
algorithm customizable in term of optimization formula (UCT and pUCT
currently supported), value transformation (execution time vs execution
speed vs log time), sample reduction (max vs mean) and scale.

The UCT and TAG policy are also rewritten to ensure we only read once
node data that can be modified by other threads.