### PR TITLE
Check for timeout even in deadend hell

### DIFF
--- a/src/explorer/bandit_arm.rs
+++ b/src/explorer/bandit_arm.rs
@@ -101,6 +101,11 @@ pub struct Tree<'a, 'b, P: TreePolicy> {
     policy: P,
     stats: TreeStats,
     log: std::sync::mpsc::SyncSender<LogMessage<TreeEvent>>,
+    /// Time at which the `Tree` structure was created.  This is a reasonably good approximation of
+    /// the time at which the search was started.
+    start_time: std::time::Instant,
+    /// Optional timeout after which the search will stop.
+    timeout: Option<std::time::Duration>,
 }
 
 impl<'a, 'b, P: TreePolicy> Tree<'a, 'b, P> {
@@ -110,6 +115,7 @@ impl<'a, 'b, P: TreePolicy> Tree<'a, 'b, P> {
         config: &'b BanditConfig,
         policy: P,
         log_sender: std::sync::mpsc::SyncSender<LogMessage<TreeEvent>>,
+        timeout: Option<u64>,
     ) -> Self {
         let root = Node::try_from_candidates(candidates);
         let bound = root.as_ref().and_then(|root| root.bound());
@@ -123,6 +129,8 @@ impl<'a, 'b, P: TreePolicy> Tree<'a, 'b, P> {
             policy,
             stats: TreeStats::default(),
             log: log_sender,
+            start_time: std::time::Instant::now(),
+            timeout: timeout.map(|timeout| std::time::Duration::from_secs(timeout * 60)),
         }
     }
 
@@ -210,8 +218,29 @@ where
         // Retry loop (in case of deadends)
         loop {
             if self.stop.load(Ordering::Relaxed) {
-                debug!("stopping: requested");
+                info!("stopping: requested");
                 return None;
+            }
+
+            // TODO: We now have two places where we are checking the timeout: here in the tree
+            // search, and in the generic monitor infrastructure.  Historically, we were only
+            // checking in the generic monitor infrastructure to stop evaluating implementations
+            // once the timeout is reached; however, the tree search can spend a long time finding
+            // only deadends but no implementations.  In that case the search would go on forever
+            // as we would stay in the tree search and never get back to the monitoring
+            // infrastructure.
+            //
+            // Anyways, performing that check twice is easier than reworking the generic
+            // infrastructure (which... actually my understanding is that it should still work, but
+            // the control flow is complex enough now that I don't know anymore) to understand the
+            // concept of a cooperative yield from the underlying algorithm.  The check in the
+            // generic code is still useful for other algorithms which may not incorporate its own
+            // timeout logic.
+            if let Some(timeout) = self.timeout {
+                if self.start_time.elapsed() > timeout {
+                    info!("stopping: timeout");
+                    return None;
+                }
             }
 
             let cut: f64 = { *unwrap!(self.cut.read()) };

--- a/src/explorer/mod.rs
+++ b/src/explorer/mod.rs
@@ -90,6 +90,7 @@ impl<'l, 'a: 'l> TreeBuilder<'l, 'a> {
                 bandit_config,
                 policy,
                 log_sender.clone(),
+                config.timeout,
             );
 
             unwrap!(scope


### PR DESCRIPTION
When the tree search threads get stuck in a series of deadend without
finding implementations, the only way for them to get out of there is
for the `stop` field of the tree to be set to `true`.  This happens when
the monitor calls `stop_evaluation` after a timeout on its future.

This should work, but it seems like in some situations it doesn't.  But
in order to avoid creating gigabytes of log files, this patch adds an
additional safeguard by also checking the timeout from the tree search
directly.