### PR TITLE
Actually stop exploration when a deadend is found in tree

### DIFF
--- a/src/explorer/mod.rs
+++ b/src/explorer/mod.rs
@@ -90,7 +90,6 @@ impl<'l, 'a: 'l> TreeBuilder<'l, 'a> {
                 bandit_config,
                 policy,
                 log_sender.clone(),
-                config.timeout,
             );
 
             unwrap!(scope


### PR DESCRIPTION
Due to changes in #193 being incorrectly scoped, in case we found a
deadend in the tree that was concurrently cut by another thread, we
would end up in a tight loop of ignoring it repeatedly.

This was causing the timeout issue from #192.  The issue actually
couldn't happen in the master branch, but was coming from a separate
branch from which #193 was extracted and the fix for #192 backported,
hence the confusion.

This patch removes the fix from #192 which is no longer useful (and was
actually not effective).  Sorry for the noise!