### PR TITLE
Compactify the debug log format for readability

### DIFF
--- a/src/explorer/choice.rs
+++ b/src/explorer/choice.rs
@@ -1,4 +1,6 @@
 //! Choices that can be applied to split the search space.
+use std::fmt;
+
 use crate::explorer::config;
 use crate::ir::{self, Statement};
 use crate::search_space::{Action, Domain, NumSet, Order, SearchSpace};
@@ -8,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use utils::unwrap;
 
 /// Either a regular action or a manually applied action.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ActionEx {
     Action(Action),
     LowerLayout {
@@ -16,6 +18,24 @@ pub enum ActionEx {
         st_dims: Vec<ir::DimId>,
         ld_dims: Vec<ir::DimId>,
     },
+}
+
+impl fmt::Debug for ActionEx {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            // Actions are already explicitely self-describing enough
+            ActionEx::Action(action) => write!(f, "{:?}", action),
+            ActionEx::LowerLayout {
+                mem,
+                st_dims,
+                ld_dims,
+            } => write!(
+                f,
+                "LowerLayout {{ mem: {:?}, st_dims: {:?}, ld_dims: {:?} }}",
+                mem, st_dims, ld_dims
+            ),
+        }
+    }
 }
 
 /// Represents a choice that splits a search space in multiple ones.

--- a/src/ir/dimension.rs
+++ b/src/ir/dimension.rs
@@ -3,15 +3,19 @@ use crate::ir::{self, Statement};
 use lazy_static::lazy_static;
 use log::trace;
 use serde::{Deserialize, Serialize};
-use std;
+use std::{self, fmt};
 use utils::*;
 
 /// Provides a unique identifier for iteration dimensions.
-#[derive(
-    Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
-)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[repr(transparent)]
 pub struct DimId(pub u32);
+
+impl fmt::Debug for DimId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "${}", self.0)
+    }
+}
 
 impl Into<usize> for DimId {
     fn into(self) -> usize {

--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -3,20 +3,24 @@ use crate::ir::{
     self, DimMapScope, LoweringMap, Operand, Operator, Statement, StmtId, Type,
 };
 use serde::{Deserialize, Serialize};
-use std;
+use std::{self, fmt};
 
 use utils::*;
 
 /// Uniquely identifies an instruction.
-#[derive(
-    Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
-)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[repr(transparent)]
 pub struct InstId(pub u32);
 
-impl Into<usize> for InstId {
-    fn into(self) -> usize {
-        self.0 as usize
+impl fmt::Debug for InstId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "@{}", self.0)
+    }
+}
+
+impl From<InstId> for usize {
+    fn from(id: InstId) -> usize {
+        id.0 as usize
     }
 }
 

--- a/src/ir/statement.rs
+++ b/src/ir/statement.rs
@@ -1,19 +1,29 @@
 //! Provides a generic decription of basic blocks.
-use crate::ir;
+use std::fmt;
 
 use serde::{Deserialize, Serialize};
 use utils::*;
 
+use crate::ir;
+
 /// Provides a unique identifer for a basic block.
-#[derive(
-    Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
-)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[repr(C)]
 pub enum StmtId {
     /// cbindgen:field-names=[id]
     Inst(ir::InstId),
     /// cbindgen:field-names=[id]
     Dim(ir::DimId),
+}
+
+impl fmt::Debug for StmtId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Inner types print a specific sigil already
+        match self {
+            StmtId::Inst(inst_id) => write!(f, "{:?}", inst_id),
+            StmtId::Dim(dim_id) => write!(f, "{:?}", dim_id),
+        }
+    }
 }
 
 impl From<ir::InstId> for StmtId {

--- a/telamon-gen/src/print/runtime/integer_set.rs
+++ b/telamon-gen/src/print/runtime/integer_set.rs
@@ -7,10 +7,20 @@ use quote::quote;
 /// Defines the `NumericSet` type.
 pub fn get() -> TokenStream {
     quote! {
-        #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
+        #[derive(Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
         #[repr(C)]
         pub struct NumericSet {
             enabled_values: u16
+        }
+
+        impl std::fmt::Debug for NumericSet {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "NS{{")?;
+                for (i, bit) in self.list().enumerate() {
+                    write!(f, "{}{}", if i == 0 { "" } else { ", " } , bit.enabled_values)?;
+                }
+                write!(f, "}}")
+            }
         }
 
         #[allow(dead_code)]

--- a/telamon-gen/src/print/runtime/integer_set.rs
+++ b/telamon-gen/src/print/runtime/integer_set.rs
@@ -15,11 +15,7 @@ pub fn get() -> TokenStream {
 
         impl std::fmt::Debug for NumericSet {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                write!(f, "NS{{")?;
-                for (i, bit) in self.list().enumerate() {
-                    write!(f, "{}{}", if i == 0 { "" } else { ", " } , bit.enabled_values)?;
-                }
-                write!(f, "}}")
+                write!(f, "NS{{{}}}", self.list().map(|bit| bit.enabled_values).format(", "))
             }
         }
 


### PR DESCRIPTION
 - The `Action(..)` wrapper is not rendered anymore
 - Dimension IDs are represented using `$n` instead of `DimId(n)`
 - Instruction IDs are represented using `@n` instead of `InstId(n)`
 - Statements are naked, i.e. instructions are represented as `@n`
   instead of `Inst(InstId(n))` and dimensions as `$n` instead of
   `Dim(DimId(n))`.
 - Numeric sets are represented as `NS { 2, 4 }` instead of
   `NumericSet { enabled_values: 6 }`.  Ideally we would want the actual
   values here, but that would require foregoing the `Debug` trait for a
   custom one since this requires knowing the universe at printing time.