### PR TITLE
Re-enable clippy checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,8 @@ jobs:
     - script: cd telamon-gen && LEX="flex" cargo build --features "lex"
     - script: cargo fmt --all -- --check
       before_script: rustup component add rustfmt
-    # Comment Clippy's control like suggested: https://github.com/ulysseB/telamon/pull/130#pullrequestreview-157534346
-    # - script: cargo clippy
-    #   before_script: rustup component add clippy-preview
+    - script: cargo clippy --all --all-targets --tests --benches
+      before_script: rustup component add clippy
     - stage: documentation
       if: branch IN (master, staging)
       script: cargo doc --no-deps --all

--- a/backend/cuda/benches/model/main.rs
+++ b/backend/cuda/benches/model/main.rs
@@ -4,14 +4,12 @@ mod latency;
 mod memory;
 mod tests;
 
-use log::*;
 use regex::Regex;
 use telamon::device::{self, ArgMap, Context};
 use telamon::helper;
 use telamon::model::bound;
 use telamon::search_space::Action;
 use telamon_cuda as cuda;
-use utils::*;
 
 use log::info;
 use utils::unwrap;

--- a/backend/cuda/benches/model/memory.rs
+++ b/backend/cuda/benches/model/memory.rs
@@ -159,7 +159,7 @@ impl PerfModelTest for SharedLoad {
         let (ptr_0, pattern) =
             builder.tensor_access(&mem, mem.into(), ir::Type::F(64), &[&d1, &d0]);
         let ptr_1 = builder.mov(&ptr_0);
-        let ptr_to_mem_type = ir::Type::PtrTo(mem.into());
+        let ptr_to_mem_type = ir::Type::PtrTo(mem);
         let ptr_zero = builder.cast(&"arg_zero", ptr_to_mem_type);
         let acc_0 = builder.mov(&0f32);
         let d2 = builder.open_dim_ex(size_2, DimKind::LOOP);
@@ -274,7 +274,7 @@ impl PerfModelTest for SharedReplay {
         let mem = builder.allocate_shared(8 * 32 * 32 * 4);
         let d0 = builder.open_dim_ex(size_0, DimKind::THREAD);
         let d1 = builder.open_dim_ex(size_1, DimKind::THREAD);
-        let ptr_to_mem_type = ir::Type::PtrTo(mem.into());
+        let ptr_to_mem_type = ir::Type::PtrTo(mem);
         let ptr_zero = builder.cast(&"arg_zero", ptr_to_mem_type);
         let init = builder.mov(&0f32);
         let (addr_0, pattern) =
@@ -327,7 +327,7 @@ impl PerfModelTest for VectorSharedReplay {
         let mem = builder.allocate_shared(mem_size);
         let d0 = builder.open_dim_ex(size_0, DimKind::THREAD);
         let d1 = builder.open_dim_ex(size_1, DimKind::THREAD);
-        let ptr_to_mem_type = ir::Type::PtrTo(mem.into());
+        let ptr_to_mem_type = ir::Type::PtrTo(mem);
         let ptr_zero = builder.cast(&"arg_zero", ptr_to_mem_type);
         let init = builder.mov(&0f32);
         let idx = builder.mad(&d0, &32i32, &d1);

--- a/backend/cuda/src/api/array.rs
+++ b/backend/cuda/src/api/array.rs
@@ -85,7 +85,7 @@ unsafe impl<'a, T> Sync for Array<'a, T> {}
 unsafe impl<'a, T> Send for Array<'a, T> {}
 
 /// Randomize an array of `f32`.
-pub fn randomize_f32(array: &Array<f32>) {
+pub fn randomize_f32(array: &mut Array<f32>) {
     unsafe {
         randomize_float_array(array.context, array.array, array.len as u64, 0.0, 1.0);
     }

--- a/backend/cuda/src/api/fake.rs
+++ b/backend/cuda/src/api/fake.rs
@@ -4,7 +4,6 @@
 
 use crate::api;
 use std::marker::PhantomData;
-use std::ops::Deref;
 use telamon::device;
 
 /// An argument that can be passed to the executor.
@@ -17,7 +16,7 @@ pub trait Argument: Send + Sync {
 
 impl Argument for Box<dyn device::ScalarArgument> {
     fn as_size(&self) -> Option<u32> {
-        (*self).as_size()
+        (**self).as_size()
     }
 }
 

--- a/backend/cuda/src/api/mod.rs
+++ b/backend/cuda/src/api/mod.rs
@@ -55,7 +55,7 @@ mod tests {
             1,
         );
         let kernel = module.kernel("empty_fun");
-        let _ = kernel.execute(&[1, 1, 1], &[1, 1, 1], &mut []);
+        let _ = kernel.execute(&[1, 1, 1], &[1, 1, 1], &[]);
     }
 
     /// Tries to allocate an array.
@@ -80,7 +80,7 @@ mod tests {
         let block_dim: u32 = 16;
         let executor = Executor::init();
         let mut src = executor.allocate_array::<f32>(block_dim as usize);
-        let mut dst = executor.allocate_array::<f32>(block_dim as usize);
+        let dst = executor.allocate_array::<f32>(block_dim as usize);
         array::randomize_f32(&mut src);
         let module = executor.compile_ptx(
             ".version 3.0\n.target sm_30\n.address_size 64\n
@@ -103,11 +103,7 @@ mod tests {
             1,
         );
         let kernel = module.kernel("copy");
-        unwrap!(kernel.execute(
-            &[block_dim, 1, 1],
-            &[1, 1, 1],
-            &mut [&mut src, &mut dst]
-        ));
+        unwrap!(kernel.execute(&[block_dim, 1, 1], &[1, 1, 1], &[&src, &dst]));
         assert!(array::compare_f32(&src, &dst) < 1e-5);
     }
 }

--- a/backend/cuda/src/characterize/instruction.rs
+++ b/backend/cuda/src/characterize/instruction.rs
@@ -284,7 +284,7 @@ pub fn smx_read_bandwidth_l2_lines(gpu: &Gpu, executor: &Executor) -> f64 {
     info!("L2 lines SMX read bandwidth");
     let wraps = gpu.max_threads() / gpu.wrap_size;
     let line_len = gpu.l2_cache_line / 4;
-    let strides = (1..line_len + 1).collect_vec();
+    let strides = (1..=line_len).collect_vec();
     let access_per_wrap = f64::from(gpu.wrap_size / line_len);
     infer_smx_bandwidth(gpu, executor, wraps, &strides, true) * access_per_wrap
 }
@@ -294,7 +294,7 @@ pub fn smx_write_bandwidth_l2_lines(gpu: &Gpu, executor: &Executor) -> f64 {
     info!("L2 lines SMX write bandwidth");
     let wraps = gpu.max_threads() / gpu.wrap_size;
     let line_len = gpu.l2_cache_line / 4;
-    let strides = (1..line_len + 1).collect_vec();
+    let strides = (1..=line_len).collect_vec();
     let access_per_wrap = f64::from(gpu.wrap_size / line_len);
     infer_smx_bandwidth(gpu, executor, wraps, &strides, false) * access_per_wrap
 }
@@ -357,7 +357,7 @@ pub fn infer_smx_bandwidth(
 }
 
 /// In-depth analysis of memory accesses bandwidth.
-#[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
+#[allow(clippy::too_many_arguments)]
 pub fn smx_bandwidth(
     gpu: &Gpu,
     executor: &Executor,
@@ -411,7 +411,7 @@ pub fn smx_bandwidth(
 }
 
 /// In-depth analysis of memory stores bandwidth.
-#[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
+#[allow(clippy::too_many_arguments)]
 pub fn smx_store_bandwidth(
     gpu: &Gpu,
     executor: &Executor,

--- a/backend/cuda/src/gpu.rs
+++ b/backend/cuda/src/gpu.rs
@@ -423,9 +423,7 @@ impl device::Device for Gpu {
     fn can_vectorize(&self, dim: &ir::Dimension, op: &ir::Operator) -> bool {
         match *op {
             Operator::TmpLd(..) | Operator::TmpSt(..) => true,
-            Operator::Ld(ref t, _, ref pattern)
-                if pattern.is_consecutive(dim.id(), t) =>
-            {
+            Operator::Ld(t, _, ref pattern) if pattern.is_consecutive(dim.id(), t) => {
                 // TODO(ulysse): hack to avoid vectorizing by a factor of 3 until we
                 // support alignment contraints.
                 dim.possible_sizes()
@@ -433,7 +431,7 @@ impl device::Device for Gpu {
                     .unwrap_or(false)
             }
             Operator::St(_, ref operand, _, ref pattern)
-                if pattern.is_consecutive(dim.id(), &operand.t()) =>
+                if pattern.is_consecutive(dim.id(), operand.t()) =>
             {
                 // TODO(ulysse): hack to avoid vectorizing by a factor of 3 until we
                 // support alignment contraints.

--- a/backend/cuda/src/lib.rs
+++ b/backend/cuda/src/lib.rs
@@ -42,8 +42,8 @@ struct Namer {
 
 impl Namer {
     /// Generate a variable name prefix from a type.
-    fn gen_prefix(t: &ir::Type) -> &'static str {
-        match *t {
+    fn gen_prefix(t: ir::Type) -> &'static str {
+        match t {
             ir::Type::I(1) => "p",
             ir::Type::I(8) => "c",
             ir::Type::I(16) => "s",
@@ -59,7 +59,7 @@ impl Namer {
 
 impl codegen::Namer for Namer {
     fn name(&mut self, t: ir::Type) -> String {
-        let prefix = Namer::gen_prefix(&t);
+        let prefix = Namer::gen_prefix(t);
         let entry = self.num_var.entry(t).or_insert(0);
         let name = format!("%{}{}", prefix, *entry);
         *entry += 1;

--- a/backend/cuda/src/printer.rs
+++ b/backend/cuda/src/printer.rs
@@ -69,7 +69,7 @@ impl CudaPrinter {
     /// Prints the variables declared by the `Namer`.
     fn var_decls(&mut self, namer: &Namer) -> String {
         let print_decl = |(&t, n)| {
-            let prefix = Namer::gen_prefix(&t);
+            let prefix = Namer::gen_prefix(t);
             format!(".reg.{} %{}<{}>;", Self::get_type(t), prefix, n)
         };
         namer
@@ -115,8 +115,8 @@ impl CudaPrinter {
     }
 
     /// Prints a `Type` for the host.
-    fn host_type(t: &Type) -> &'static str {
-        match *t {
+    fn host_type(t: Type) -> &'static str {
+        match t {
             Type::PtrTo(..) => "CUdeviceptr",
             Type::F(32) => "float",
             Type::F(64) => "double",
@@ -134,7 +134,7 @@ impl CudaPrinter {
         IT: Iterator<Item = &'a Dimension<'a>> + 'a,
     {
         let mut sizes = ["1".to_string(), "1".to_string(), "1".to_string()];
-        for (i, d) in dims.into_iter().enumerate() {
+        for (i, d) in dims.enumerate() {
             assert!(i < 3);
             sizes[i] = Self::host_size(d.size())
         }
@@ -245,7 +245,7 @@ impl CudaPrinter {
                     }
                 }
             }
-            let ind_levels = function.init_induction_levels().into_iter().chain(
+            let ind_levels = function.init_induction_levels().iter().chain(
                 function
                     .block_dims()
                     .iter()
@@ -317,7 +317,7 @@ impl CudaPrinter {
         let extern_params = fun
             .params
             .iter()
-            .map(|p| format!("{} {}", Self::host_type(&p.t), p.name))
+            .map(|p| format!("{} {}", Self::host_type(p.t), p.name))
             .collect_vec()
             .join(", ");
         let res = write!(

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -43,7 +43,7 @@ impl MMSig {
         let ld_a_k = builder.open_tiled_dim(k_size.clone(), [16][..].into());
         let (ptr, pattern) =
             builder.tensor_access(&"a", None, DATA_TYPE, &[&ld_a_m, &ld_a_k]);
-        let ld_a = builder.ld_nc(DATA_TYPE.clone(), &ptr, pattern);
+        let ld_a = builder.ld_nc(DATA_TYPE, &ptr, pattern);
         builder.close_dim(&ld_a_m);
         builder.close_dim(&ld_a_k);
 
@@ -87,6 +87,7 @@ impl MMSig {
 }
 
 /// Descends in the search tree without saving the candidates.
+#[allow(clippy::let_and_return)]
 pub fn descend_without_copies(mut space: SearchSpace) {
     while let Some(mut choice) = {
         let choice = explorer::choice::default_list(&space).next();
@@ -99,7 +100,7 @@ pub fn descend_without_copies(mut space: SearchSpace) {
                 mem,
                 ref st_dims,
                 ref ld_dims,
-            } => space.lower_layout(mem, st_dims.clone(), ld_dims.clone()),
+            } => space.lower_layout(mem, st_dims, ld_dims),
         };
         if res.is_err() {
             return;
@@ -108,6 +109,7 @@ pub fn descend_without_copies(mut space: SearchSpace) {
 }
 
 /// Descends in the search tree and returns the candidates encountered.
+#[allow(clippy::let_and_return)]
 pub fn descend_with_copies(mut space: SearchSpace) -> Vec<SearchSpace> {
     let mut spaces = vec![];
     while let Some(mut choice) = {
@@ -121,7 +123,7 @@ pub fn descend_with_copies(mut space: SearchSpace) -> Vec<SearchSpace> {
                 mem,
                 ref st_dims,
                 ref ld_dims,
-            } => space.lower_layout(mem, st_dims.clone(), ld_dims.clone()),
+            } => space.lower_layout(mem, st_dims, ld_dims),
         };
         if res.is_err() {
             return spaces;

--- a/examples/matmul.rs
+++ b/examples/matmul.rs
@@ -15,6 +15,7 @@ const M: u32 = 1024;
 const N: u32 = 1024;
 const K: u32 = 1024;
 
+#[allow(clippy::many_single_char_names)]
 fn main() {
     // Step 0. Setup logging and the CUDA interface.
     env_logger::init();

--- a/kernels/src/kernel.rs
+++ b/kernels/src/kernel.rs
@@ -109,6 +109,7 @@ pub trait Kernel<'a>: Sized {
 
     /// Tests the correctness of the bound of kernels and returns the list of tested leafs
     /// along with the actual evaluation time.
+    #[allow(clippy::collapsible_if)]
     fn test_bound<AM>(
         params: Self::Parameters,
         num_tests: usize,

--- a/kernels/src/linalg.rs
+++ b/kernels/src/linalg.rs
@@ -1,4 +1,6 @@
 //! Linera algebra kernels.
+#![allow(clippy::many_single_char_names)]
+
 use crate::kernel::Kernel;
 use crate::utils::*;
 use crate::{build_candidate, create_size, infer_tiling, Scalar};

--- a/src/bin/parse_event_log.rs
+++ b/src/bin/parse_event_log.rs
@@ -172,7 +172,7 @@ where
             node: Box::new(Node {
                 children: Default::default(),
                 evaluations: vec![],
-                id: id,
+                id,
                 tag: None,
             }),
         });

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -300,7 +300,7 @@ impl<'a> MemoryRegion<'a> {
         block_dims: &[Dimension<'a>],
     ) -> Vec<ParamVal<'a>> {
         let mut out = if self.mem_space == MemSpace::GLOBAL {
-            let t = ir::Type::PtrTo(self.id.into());
+            let t = ir::Type::PtrTo(self.id);
             let t = unwrap!(space.ir_instance().device().lower_type(t, space));
             vec![ParamVal::GlobalMem(self.id, self.alloc_size(), t)]
         } else {

--- a/src/codegen/name_map.rs
+++ b/src/codegen/name_map.rs
@@ -143,12 +143,10 @@ impl<'a, 'b> NameMap<'a, 'b> {
                 name_map
                     .insts
                     .insert(inst.id(), name_map.variables[&var].clone());
-            } else {
-                if let Some((inst_id, dim_map)) = inst.as_reduction() {
-                    name_map.decl_alias(inst, inst_id, dim_map);
-                } else if inst.t().is_some() {
-                    name_map.decl_inst(inst);
-                }
+            } else if let Some((inst_id, dim_map)) = inst.as_reduction() {
+                name_map.decl_alias(inst, inst_id, dim_map);
+            } else if inst.t().is_some() {
+                name_map.decl_inst(inst);
             }
         }
         name_map

--- a/src/codegen/printer.rs
+++ b/src/codegen/printer.rs
@@ -25,6 +25,7 @@ impl MulMode {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub trait Printer {
     /// Get the representation of an integer in the target language.
     fn get_int(n: u32) -> String;
@@ -353,7 +354,7 @@ pub trait Printer {
             return;
         }
         let addr = namer.name_addr(block.id());
-        let addr_type = Self::lower_type(Type::PtrTo(block.id().into()), fun);
+        let addr_type = Self::lower_type(Type::PtrTo(block.id()), fun);
         let size = namer.name_size(block.local_size(), Type::I(32));
         let d0 = namer.name_index(fun.block_dims()[0].id()).to_string();
         let var = fun.block_dims()[1..].iter().fold(d0, |old_var, dim| {

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -20,6 +20,7 @@ use std::io::Write;
 use utils::*;
 
 /// Holds the specifications of a target.
+#[allow(clippy::trivially_copy_pass_by_ref)]
 pub trait Device: Sync {
     /// Prints the code corresponding to a device `Function`.
     fn print(&self, function: &Function, out: &mut Write);

--- a/src/device/x86/context.rs
+++ b/src/device/x86/context.rs
@@ -171,7 +171,7 @@ enum ThunkArg {
 /// Given a function string and its arguments as ThunkArg, compile to a binary, executes it and
 /// returns the time elapsed. Converts ThunkArgs to HoldTHunk as we want to allocate memory for
 /// temporary arrays at the last possible moment
-fn function_evaluate(fun_str: &str, args: &Vec<ThunkArg>) -> Result<f64, ()> {
+fn function_evaluate(fun_str: &str, args: &[ThunkArg]) -> Result<f64, ()> {
     debug!("running code {}", fun_str);
     let temp_dir = unwrap!(tempfile::tempdir());
     let templib_name = temp_dir

--- a/src/device/x86/mod.rs
+++ b/src/device/x86/mod.rs
@@ -26,8 +26,8 @@ struct Namer {
 
 impl Namer {
     /// Generate a variable name prefix from a type.
-    fn gen_prefix(t: &ir::Type) -> &'static str {
-        match *t {
+    fn gen_prefix(t: ir::Type) -> &'static str {
+        match t {
             ir::Type::I(1) => "p",
             ir::Type::I(8) => "c",
             ir::Type::I(16) => "s",
@@ -44,7 +44,7 @@ impl Namer {
 
 impl codegen::Namer for Namer {
     fn name(&mut self, t: ir::Type) -> String {
-        let prefix = Namer::gen_prefix(&t);
+        let prefix = Namer::gen_prefix(t);
         match t {
             ir::Type::PtrTo(..) => {
                 let name = format!("{}{}", prefix, self.num_glob_ptr);

--- a/src/device/x86/printer.rs
+++ b/src/device/x86/printer.rs
@@ -33,7 +33,7 @@ impl X86printer {
         let print_decl = |(&t, &n)| match t {
             Type::PtrTo(..) => String::new(),
             _ => {
-                let prefix = Namer::gen_prefix(&t);
+                let prefix = Namer::gen_prefix(t);
                 let mut s = format!("{} ", Self::get_type(t));
                 s.push_str(
                     &(0..n)
@@ -133,7 +133,7 @@ impl X86printer {
                 }
             }
             // INIT
-            let ind_levels = function.init_induction_levels().into_iter().chain(
+            let ind_levels = function.init_induction_levels().iter().chain(
                 function
                     .block_dims()
                     .iter()
@@ -202,8 +202,8 @@ impl X86printer {
         for i in 0..n {
             let start = format!("d{}", i);
             let mut vec_str = vec![start];
-            for j in 0..i {
-                vec_str.push(format!("{}", unwrap!(dims[j].size().as_int())));
+            for dim in dims.iter().take(i) {
+                vec_str.push(format!("{}", unwrap!(dim.size().as_int())));
             }
             vec_ret.push(vec_str.join(" * "));
         }
@@ -226,7 +226,7 @@ impl X86printer {
     /// Prints code that generates the required number of threads, stores the handles in an array
     fn thread_gen(&mut self, func: &Function) -> String {
         if func.num_threads() == 1 {
-            return format!(include_str!("template/monothread_init.c.template"));
+            return include_str!("template/monothread_init.c.template").to_string();
         }
         let mut loop_decl = String::new();
         let mut ind_vec = Vec::new();

--- a/src/explorer/bandit_arm.rs
+++ b/src/explorer/bandit_arm.rs
@@ -197,7 +197,7 @@ impl<'a, 'b, P: TreePolicy> Tree<'a, 'b, P> {
 
     fn timestamp(&self) -> f64 {
         let time = self.start_time.elapsed();
-        time.as_secs() as f64 + time.subsec_nanos() as f64 * 1e-9
+        time.as_secs() as f64 + f64::from(time.subsec_nanos()) * 1e-9
     }
 
     /// Removes the dead ends along the given path. Assumes the path points to a dead-end.

--- a/src/explorer/candidate.rs
+++ b/src/explorer/candidate.rs
@@ -69,7 +69,7 @@ impl<'a> Candidate<'a> {
                 mem,
                 ref st_dims,
                 ref ld_dims,
-            } => space.lower_layout(mem, st_dims.clone(), ld_dims.clone()),
+            } => space.lower_layout(mem, st_dims, ld_dims),
         }?;
         let bound = bound(&space, context);
         let delta = 1.0e-2 * self.bound.value();

--- a/src/explorer/choice.rs
+++ b/src/explorer/choice.rs
@@ -136,7 +136,7 @@ pub fn list<'a>(
                         let dims = fun.dims().take(i).map(|x| x.stmt_id());
                         dims.chain(fun.insts().map(|x| x.stmt_id())).flat_map(
                             move |rhs| {
-                                let orders = space.domain().get_order(lhs.into(), rhs);
+                                let orders = space.domain().get_order(lhs, rhs);
                                 gen_choice(orders.list(), &|o| Action::Order(lhs, rhs, o))
                             },
                         )

--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -493,7 +493,7 @@ impl FromStr for ChoiceOrdering {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(ChoiceOrdering(
-            s.split(",")
+            s.split(',')
                 .map(str::parse)
                 .collect::<Result<Vec<_>, _>>()?,
         ))

--- a/src/explorer/local_selection.rs
+++ b/src/explorer/local_selection.rs
@@ -151,7 +151,7 @@ impl NewNodeOrder {
     /// Called in montecarlo_descend, dispatch the choice of the next candidate according to our
     /// configuration
     pub fn pick_candidate<'a>(
-        &self,
+        self,
         new_nodes: &[Candidate<'a>],
         cut: f64,
     ) -> Option<usize> {
@@ -160,13 +160,13 @@ impl NewNodeOrder {
     }
 
     /// Returns the index of the next candidate to consider.
-    pub fn pick_index<IT>(&self, nodes: IT, cut: f64) -> Option<usize>
+    pub fn pick_index<IT>(self, nodes: IT, cut: f64) -> Option<usize>
     where
         IT: Iterator<Item = (usize, f64)> + Clone,
     {
-        let nodes = nodes.filter(|&(_, b)| b < cut);
+        let mut nodes = nodes.filter(|&(_, b)| b < cut);
         match self {
-            NewNodeOrder::Api => nodes.into_iter().next().map(|(idx, _)| idx),
+            NewNodeOrder::Api => nodes.next().map(|(idx, _)| idx),
             NewNodeOrder::WeightedRandom => choose_cand_weighted(nodes, cut),
             NewNodeOrder::Bound => choose_cand_best(nodes),
             NewNodeOrder::Random => choose_cand_rand(nodes),

--- a/src/explorer/logger.rs
+++ b/src/explorer/logger.rs
@@ -64,7 +64,6 @@ impl From<mpsc::RecvError> for LogError {
     }
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 pub fn log<E: Send + Serialize>(
     config: &Config,
     recv: mpsc::Receiver<LogMessage<E>>,

--- a/src/explorer/mcts.rs
+++ b/src/explorer/mcts.rs
@@ -9,6 +9,8 @@
 //! The MctsWalker, parameterized with the appropriate bandit and rollout policies, can be used to
 //! explore the resulting search tree in an MCTS-like fashion.
 
+#![allow(clippy::type_complexity)]
+
 use std::cell::RefCell;
 use std::cmp::PartialEq;
 use std::fmt::{self, Debug, Display};
@@ -68,6 +70,7 @@ struct NodeInner<'c, N, E> {
     ///
     /// This is directly a pointer to the parent node and edge index in order to avoid an
     /// additional indirection through the `Edge` when following a path upwards.
+    #[allow(dead_code)]
     parent: Option<(WeakNode<'c, N, E>, usize)>,
 
     /// Child edges.  Edges have a backward pointer to the node and additional metadata such as the
@@ -95,6 +98,7 @@ struct NodeInner<'c, N, E> {
     candidate: RwLock<Option<Box<SearchSpace<'c>>>>,
 
     /// Additional algorithm-specific data associated with the node.
+    #[allow(dead_code)]
     data: N,
 }
 
@@ -167,6 +171,7 @@ impl<'c, N, E> Node<'c, N, E> {
     }
 
     /// Pointer to the algorithm-specific data payload.
+    #[allow(dead_code)]
     fn data(&self) -> &N {
         &self.inner.data
     }
@@ -295,7 +300,7 @@ impl<'a> Env<'a> {
     pub fn list_actions(&self, candidate: &SearchSpace<'_>) -> Vec<Action> {
         choice::list(self.choice_ordering, candidate)
             .next()
-            .unwrap_or(Vec::new())
+            .unwrap_or_default()
     }
 
     /// Apply an action to an existing candidate, consuming the existing candidate.
@@ -310,7 +315,7 @@ impl<'a> Env<'a> {
                 mem,
                 st_dims,
                 ld_dims,
-            } => candidate.lower_layout(mem, st_dims, ld_dims),
+            } => candidate.lower_layout(mem, &st_dims, &ld_dims),
         } {
             Some(candidate)
         } else {

--- a/src/explorer/mod.rs
+++ b/src/explorer/mod.rs
@@ -237,7 +237,6 @@ pub fn find_best_ex<'a>(
 
 /// Launch all threads needed for the search. wait for each one of them to finish. Monitor is
 /// supposed to return the best candidate found
-#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 fn launch_search<'a, T: Store<'a>>(
     config: &Config,
     candidate_store: T,

--- a/src/explorer/monitor.rs
+++ b/src/explorer/monitor.rs
@@ -63,7 +63,6 @@ impl<'a> Default for Status<'a> {
 /// This function is an interface supposed to make a connection between the
 /// Store and the evaluator. Retrieve evaluations, retains the results and
 /// update the store accordingly.
-#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 pub fn monitor<'a, T, E>(
     config: &Config,
     candidate_store: &T,

--- a/src/helper/builder.rs
+++ b/src/helper/builder.rs
@@ -52,7 +52,7 @@ impl<'a> Builder<'a> {
     ) -> InstId {
         let lhs_op = self.get_op(lhs);
         let rhs_op = self.get_op(rhs);
-        let rounding = default_rounding(&lhs_op.t());
+        let rounding = default_rounding(lhs_op.t());
         self.inst(op::BinOp(op, lhs_op, rhs_op, rounding))
     }
 
@@ -83,7 +83,7 @@ impl<'a> Builder<'a> {
         let lhs_op = self.get_op(lhs);
         let rhs_op = self.get_op(rhs);
         let t = lhs_op.t();
-        let rounding = default_rounding(&t);
+        let rounding = default_rounding(t);
         self.inst(op::Mul(lhs_op, rhs_op, rounding, t))
     }
 
@@ -96,7 +96,7 @@ impl<'a> Builder<'a> {
     ) -> InstId {
         let lhs_op = self.get_op(lhs);
         let rhs_op = self.get_op(rhs);
-        let rounding = default_rounding(&t);
+        let rounding = default_rounding(t);
         let op = op::Mul(lhs_op, rhs_op, rounding, t);
         self.inst(op)
     }
@@ -112,7 +112,7 @@ impl<'a> Builder<'a> {
         let mul_lhs_op = self.get_op(mul_lhs);
         let mul_rhs_op = self.get_op(mul_rhs);
         let add_rhs_op = self.get_op(add_rhs);
-        let rounding = default_rounding(&mul_lhs_op.t());
+        let rounding = default_rounding(mul_lhs_op.t());
         let op = op::Mad(mul_lhs_op, mul_rhs_op, add_rhs_op, rounding);
         self.inst(op)
     }
@@ -349,8 +349,7 @@ impl<'a> Builder<'a> {
     /// Allocates a memory block in shared memory.
     pub fn allocate_shared(&mut self, size: u32) -> ir::MemId {
         let id = self.allocate(size, true);
-        self.actions
-            .push(Action::MemSpace(id.into(), MemSpace::SHARED));
+        self.actions.push(Action::MemSpace(id, MemSpace::SHARED));
         id
     }
 
@@ -435,7 +434,7 @@ impl<'a> Builder<'a> {
         dims: &[&'b LogicalDim],
     ) -> Vec<(&'b LogicalDim, ir::Size<'a>)> {
         let data_size = ir::Size::new_const(unwrap!(t.len_byte()));
-        dims.into_iter()
+        dims.iter()
             .rev()
             .scan(data_size, |size, &dim| {
                 let increment = size.clone();
@@ -481,7 +480,7 @@ impl<'a> Builder<'a> {
 }
 
 /// Returns the default rounding for a given operand type.
-fn default_rounding(t: &Type) -> op::Rounding {
+fn default_rounding(t: Type) -> op::Rounding {
     if t.is_integer() {
         op::Rounding::Exact
     } else {

--- a/src/helper/tensor.rs
+++ b/src/helper/tensor.rs
@@ -18,7 +18,7 @@ pub struct DimSize<'a> {
 
 impl<'a> DimSize<'a> {
     /// Convert the size into the size type used by the IR.
-    pub fn into_ir_size<'b>(&self, builder: &Builder<'b>) -> ir::Size<'b> {
+    pub fn to_ir_size<'b>(&self, builder: &Builder<'b>) -> ir::Size<'b> {
         let params = self.params.iter().map(|p| builder.find_param(p)).collect();
         ir::Size::new(self.factor, params, self.max_size)
     }
@@ -187,7 +187,7 @@ where
             .iter()
             .zip_eq(tiling)
             .map(|(dim, tiling)| {
-                let size = dim.0.into_ir_size(builder);
+                let size = dim.0.to_ir_size(builder);
                 builder.open_tiled_dim(size, tiling)
             })
             .collect_vec();
@@ -196,7 +196,7 @@ where
             let increments = dims
                 .iter()
                 .zip_eq(&self.iter_dims)
-                .map(|(dim, (_, stride))| (dim, stride.into_ir_size(builder)))
+                .map(|(dim, (_, stride))| (dim, stride.to_ir_size(builder)))
                 .collect_vec();
             ptr = builder.induction_var(&self.name, increments.clone());
             pattern = builder.tensor_access_pattern(None, increments);

--- a/src/ir/access_pattern.rs
+++ b/src/ir/access_pattern.rs
@@ -27,7 +27,7 @@ pub enum AccessPattern<'a> {
 
 impl<'a> AccessPattern<'a> {
     /// Indicates if memory accesses access to consecutive elements on the given dimension.
-    pub fn is_consecutive(&self, dim: ir::DimId, t: &ir::Type) -> bool {
+    pub fn is_consecutive(&self, dim: ir::DimId, t: ir::Type) -> bool {
         match self {
             AccessPattern::Unknown(..) => false,
             AccessPattern::Tensor { dims, .. } => dims

--- a/src/ir/mem.rs
+++ b/src/ir/mem.rs
@@ -141,7 +141,7 @@ impl BlockMap {
     }
 
     /// Returns the list of memory blocks.
-    pub fn blocks<'b>(&'b self) -> impl Iterator<Item = &'b Block> {
+    pub fn blocks(&self) -> impl Iterator<Item = &Block> {
         self.blocks.iter()
     }
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -121,7 +121,7 @@ impl NewObjs {
 
     /// Registers a new memory block.
     pub fn add_mem_block(&mut self, id: MemId) {
-        self.mem_blocks.push(id.into());
+        self.mem_blocks.push(id);
     }
 
     /// Adds a mapping between dimensions.
@@ -283,13 +283,13 @@ where
 
     /// Returns an iterator over the filled elements of the
     /// slice. Holes are skipped.
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = &'a T> + Clone {
+    pub fn iter(&self) -> impl Iterator<Item = &T> + Clone {
         self.vec.iter().filter_map(Option::as_ref)
     }
 
     /// Returns a mutable iterator over the filled elements of the
     /// slice. Holes are skipped.
-    pub fn iter_mut<'a>(&'a mut self) -> impl Iterator<Item = &'a mut T> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
         self.vec.iter_mut().filter_map(Option::as_mut)
     }
 }

--- a/src/ir/operand.rs
+++ b/src/ir/operand.rs
@@ -123,7 +123,7 @@ impl<'a, L> Operand<'a, L> {
         match *self {
             Int(_, n_bit) => Type::I(n_bit),
             Float(_, n_bit) => Type::F(n_bit),
-            Addr(mem) => ir::Type::PtrTo(mem.into()),
+            Addr(mem) => ir::Type::PtrTo(mem),
             Index(..) => Type::I(32),
             Param(p) => p.t,
             Variable(_, t) => t,

--- a/src/ir/operator.rs
+++ b/src/ir/operator.rs
@@ -71,7 +71,7 @@ pub enum BinOp {
 
 impl BinOp {
     /// Returns a string representing the operator.
-    fn name(&self) -> &'static str {
+    fn name(self) -> &'static str {
         match self {
             BinOp::Add => "add",
             BinOp::Sub => "sub",
@@ -85,7 +85,7 @@ impl BinOp {
     }
 
     /// Returns the type of the binay operator given the type of its operands.
-    pub fn t(&self, operand_type: ir::Type) -> ir::Type {
+    pub fn t(self, operand_type: ir::Type) -> ir::Type {
         match self {
             BinOp::Lt | BinOp::Leq | BinOp::Equals => ir::Type::I(1),
             _ => operand_type,
@@ -93,7 +93,7 @@ impl BinOp {
     }
 
     /// Indicates if the result must be rounded when operating on floats.
-    fn requires_rounding(&self) -> bool {
+    fn requires_rounding(self) -> bool {
         match self {
             BinOp::Lt | BinOp::Leq | BinOp::Equals => false,
             _ => true,
@@ -113,15 +113,15 @@ pub enum UnaryOp {
 
 impl UnaryOp {
     /// Gives the return type of the operand given its input type.
-    fn t(&self, op_type: ir::Type) -> ir::Type {
+    fn t(self, op_type: ir::Type) -> ir::Type {
         match self {
             UnaryOp::Mov => op_type,
-            UnaryOp::Cast(t) => *t,
+            UnaryOp::Cast(t) => t,
         }
     }
 
     /// Returns the name of the operand.
-    fn name(&self) -> &'static str {
+    fn name(self) -> &'static str {
         match self {
             UnaryOp::Mov => "mov",
             UnaryOp::Cast(..) => "cast",

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -16,24 +16,24 @@ pub enum Type {
 
 impl Type {
     /// Returns true if the type is an integer.
-    pub fn is_integer(&self) -> bool {
-        match *self {
+    pub fn is_integer(self) -> bool {
+        match self {
             Type::I(_) | Type::PtrTo(_) => true,
             Type::F(_) => false,
         }
     }
 
     /// Returns true if the type is a float.
-    pub fn is_float(&self) -> bool {
-        match *self {
+    pub fn is_float(self) -> bool {
+        match self {
             Type::F(_) => true,
             Type::I(_) | Type::PtrTo(..) => false,
         }
     }
 
     /// Returns the number of bytes of the type.
-    pub fn len_byte(&self) -> Option<u32> {
-        match *self {
+    pub fn len_byte(self) -> Option<u32> {
+        match self {
             Type::I(i) | Type::F(i) => Some(u32::from(div_ceil(i, 8))),
             Type::PtrTo(_) => None,
         }
@@ -42,7 +42,7 @@ impl Type {
 
 impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
+        match self {
             Type::I(s) => write!(f, "i{}", s),
             Type::F(s) => write!(f, "f{}", s),
             Type::PtrTo(mem) => write!(f, "ptr to {:?}", mem),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![warn(clippy::all)]
+#![allow(clippy::block_in_if_condition_stmt)]
 
 pub mod codegen;
 #[macro_use]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -191,7 +191,7 @@ fn set_latency(
 
 /// Updates the dependency maps to account for the data dependencies to an instruction.
 // TODO(cleanup): refactor to reduce the number of parameters.
-#[cfg_attr(feature = "cargo-clippy", allow(clippy))]
+#[allow(clippy::all)]
 fn set_data_deps(
     space: &SearchSpace,
     local_info: &LocalInfo,
@@ -337,7 +337,7 @@ fn repeat_level(
 
 /// Adds a dependency origination from a dim map.
 // TODO(cleanup): refactor to reduce the number of parameters.
-#[cfg_attr(feature = "cargo-clippy", allow(clippy))]
+#[allow(clippy::all)]
 fn apply_dim_map(
     device: &Device,
     space: &SearchSpace,

--- a/src/model/size.rs
+++ b/src/model/size.rs
@@ -34,9 +34,9 @@ pub fn bounds(size: &ir::PartialSize, space: &SearchSpace, ctx: &Context) -> Ran
     let divisors = size.divisors();
     let factor = param_factors
         .iter()
-        .map(|p| unwrap!(ctx.param_as_size(&p.name)) as u64)
+        .map(|p| u64::from(ctx.param_as_size(&p.name).unwrap()))
         .product::<u64>()
-        * factor as u64;
+        * u64::from(factor);
     let mut total_min = factor.to_biguint().unwrap();
     let mut total_max = total_min.clone();
     for &dim in dim_size_factors {
@@ -62,8 +62,8 @@ pub fn dim_bounds(dim: ir::DimId, space: &SearchSpace) -> Range {
     let size = space.domain().get_size(dim);
     let universe = unwrap!(space.ir_instance().dim(dim).possible_sizes());
     Range {
-        min: size.min(universe) as u64,
-        max: size.max(universe) as u64,
+        min: size.min(universe).into(),
+        max: size.max(universe).into(),
     }
 }
 
@@ -94,9 +94,9 @@ pub fn factors(
     let divisors = size.divisors();
     let factor = param_factors
         .iter()
-        .map(|p| unwrap!(ctx.param_as_size(&p.name)) as u64)
+        .map(|p| u64::from(ctx.param_as_size(&p.name).unwrap()))
         .product::<u64>()
-        * factor as u64;
+        * u64::from(factor);
     let mut total_gcd = factor.to_biguint().unwrap();
     let mut total_lcm = total_gcd.clone();
     for &dim in dim_size_factors {
@@ -120,7 +120,7 @@ pub fn dim_factors(dim: ir::DimId, space: &SearchSpace) -> FactorRange {
     let size = space.domain().get_size(dim);
     let universe = unwrap!(space.ir_instance().dim(dim).possible_sizes());
     FactorRange {
-        gcd: size.gcd(universe) as u64,
-        lcm: size.lcm(universe) as u64,
+        gcd: size.gcd(universe).into(),
+        lcm: size.lcm(universe).into(),
     }
 }

--- a/src/search_space/dim_map.rs
+++ b/src/search_space/dim_map.rs
@@ -10,8 +10,8 @@ use log::debug;
 pub fn lower_layout(
     fun: &mut ir::Function,
     mem: ir::MemId,
-    st_dims: Vec<ir::DimId>,
-    ld_dims: Vec<ir::DimId>,
+    st_dims: &[ir::DimId],
+    ld_dims: &[ir::DimId],
     domain: &DomainStore,
 ) -> Result<Vec<Action>, ()> {
     debug!("lower_layout({:?}) triggered", mem);
@@ -27,7 +27,7 @@ pub fn lower_layout(
         actions.extend(dim_kind::restrict_delayed(ld_dim, fun, domain, not_vec)?);
     }
     fun.lower_layout(mem, st_dims, ld_dims);
-    for &inst_id in fun.mem_block(mem.into()).uses() {
+    for &inst_id in fun.mem_block(mem).uses() {
         let inst = fun.inst(inst_id);
         actions.extend(operand::inst_invariants(fun, inst));
     }
@@ -53,10 +53,7 @@ fn lower_dim_map(
         ));
     }
     // FIXME: allow global memory
-    actions.push(Action::MemSpace(
-        lowered_dim_map.mem.into(),
-        MemSpace::SHARED,
-    ));
+    actions.push(Action::MemSpace(lowered_dim_map.mem, MemSpace::SHARED));
     //actions.push(Action::InstFlag(st, InstFlag::COHERENT));
     //actions.push(Action::InstFlag(ld, InstFlag::COHERENT));
     let store = lowered_dim_map.store;

--- a/src/search_space/mod.rs
+++ b/src/search_space/mod.rs
@@ -73,8 +73,8 @@ impl<'a> SearchSpace<'a> {
     pub fn lower_layout(
         &mut self,
         mem: ir::MemId,
-        st_dims: Vec<ir::DimId>,
-        ld_dims: Vec<ir::DimId>,
+        st_dims: &[ir::DimId],
+        ld_dims: &[ir::DimId],
     ) -> Result<(), ()> {
         let actions = {
             let ir_instance = Arc::make_mut(&mut self.ir_instance);

--- a/telamon-capi/src/lib.rs
+++ b/telamon-capi/src/lib.rs
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn kernel_matmul_new(
 /// functions. The `params` pointer becomes invalid and must not be used again
 /// after calling `kernel_free`.
 #[no_mangle]
-pub unsafe extern "C" fn kernel_free(params: *mut KernelParameters) -> () {
+pub unsafe extern "C" fn kernel_free(params: *mut KernelParameters) {
     std::mem::drop(Box::from_raw(params));
 }
 
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn kernel_optimize(
         };
         Config::from_json(config_str)
     };
-    let _bench_result = match device {
+    match device {
         DeviceId::X86 => (*params).optimize_kernel(&config, &mut x86::Context::default()),
         DeviceId::Cuda => {
             #[cfg(feature = "cuda")]

--- a/telamon-gen/cc_tests/Cargo.toml
+++ b/telamon-gen/cc_tests/Cargo.toml
@@ -18,9 +18,7 @@ log = "0.4.1"
 num = "0.2.0"
 serde = "1.0"
 serde_derive = "1.0"
-
-[dependencies.telamon-utils]
-path = "../../telamon-utils"
+utils = {package = "telamon-utils", path = "../../telamon-utils"}
 
 [features]
 default = ["gen_applicators"]

--- a/telamon-gen/cc_tests/src/main.rs
+++ b/telamon-gen/cc_tests/src/main.rs
@@ -1,7 +1,7 @@
-#![allow(dead_code, unused_imports)]
+#![allow(dead_code, unused_imports, clippy::all)]
 extern crate itertools;
 #[macro_use]
-extern crate telamon_utils as utils;
+extern crate utils;
 #[macro_use]
 extern crate log;
 extern crate env_logger;

--- a/telamon-gen/src/lib.rs
+++ b/telamon-gen/src/lib.rs
@@ -1,5 +1,6 @@
 // Enables `quote!` to work on bigger chunks of code.
 #![recursion_limit = "256"]
+#![allow(clippy::all)]
 
 use utils::generated_file;
 pub mod ast;

--- a/telamon-gen/src/print/mod.rs
+++ b/telamon-gen/src/print/mod.rs
@@ -55,7 +55,7 @@ macro_rules! register_template {
         file.read_to_string(&mut template).unwrap();*/
 
         let name = concat_sep!(".", $(stringify!($name)),*);
-        $engine.register_template_string(name, template.trim_right()).unwrap();
+        $engine.register_template_string(name, template.trim_end()).unwrap();
     }
 }
 

--- a/telamon-gen/tests/lexer.rs
+++ b/telamon-gen/tests/lexer.rs
@@ -7,6 +7,7 @@ use telamon_gen::lexer::*;
 use errno::Errno;
 
 #[test]
+#[allow(clippy::cyclomatic_complexity)]
 fn lexer_initial() {
     // Invalid's Token
     assert_eq!(

--- a/telamon-utils/src/iterator.rs
+++ b/telamon-utils/src/iterator.rs
@@ -157,17 +157,13 @@ impl<T: Clone + Ord> Iterator for PartialPermutations<T> {
                 // Move the end of the new permutation into a temporary buffer.
                 let mut tmp_vec = Vec::with_capacity(k - i);
                 let buffer = tmp_vec.as_mut_ptr();
-                std::ptr::copy_nonoverlapping(
-                    perm.offset((n - k + i) as isize),
-                    buffer,
-                    k - i,
-                );
+                std::ptr::copy_nonoverlapping(perm.add(n - k + i), buffer, k - i);
                 // Copy the new unused values.
-                std::ptr::copy(perm.offset(i as isize), perm.offset(k as isize), n - k);
+                std::ptr::copy(perm.add(i), perm.add(k), n - k);
                 // Copy andreverse the new end of the permutation
                 for j in 0..(k - i) {
-                    let src = buffer.offset(j as isize);
-                    let dst = perm.offset((k - j - 1) as isize);
+                    let src = buffer.add(j);
+                    let dst = perm.add(k - j - 1);
                     std::ptr::copy_nonoverlapping(src, dst, 1);
                 }
             }

--- a/telamon-utils/src/lib.rs
+++ b/telamon-utils/src/lib.rs
@@ -1,4 +1,5 @@
 //! Generic helper functions.
+#![warn(clippy::all)]
 
 mod cache;
 mod dag;
@@ -192,13 +193,13 @@ pub fn log2_u32(x: u32) -> Option<u32> {
 #[macro_export]
 macro_rules! generated_file {
     ($name:ident) => {
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy))]
+        #[allow(clippy::all)]
         mod $name {
             include!(concat!(env!("OUT_DIR"), "/", stringify!($name), ".rs"));
         }
     };
     (pub $name:ident) => {
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy))]
+        #[allow(clippy::all)]
         pub mod $name {
             include!(concat!(env!("OUT_DIR"), "/", stringify!($name), ".rs"));
         }

--- a/telamon-utils/src/multimap.rs
+++ b/telamon-utils/src/multimap.rs
@@ -26,21 +26,23 @@ where
     }
 }
 
-impl<K: Hash + Eq, V, S: BuildHasher> MultiHashMap<K, V, S> {
+impl<K: Hash + Eq, V> MultiHashMap<K, V, RandomState> {
     /// Creates an empty `MultiHashMap`.
-    pub fn new() -> MultiHashMap<K, V, RandomState> {
+    pub fn new() -> Self {
         MultiHashMap {
             map: hash_map::HashMap::new(),
         }
     }
 
     /// Creates an empty hash map with the given initial capacity.
-    pub fn with_capacity(capacity: usize) -> MultiHashMap<K, V, RandomState> {
+    pub fn with_capacity(capacity: usize) -> Self {
         MultiHashMap {
             map: hash_map::HashMap::with_capacity(capacity),
         }
     }
+}
 
+impl<K: Hash + Eq, V, S: BuildHasher> MultiHashMap<K, V, S> {
     /// Creates an empty `MultiHashMap` which will use the given hash builder to hash
     /// keys.
     pub fn with_hasher(hash_builder: S) -> Self {

--- a/telamon-utils/src/vec_set.rs
+++ b/telamon-utils/src/vec_set.rs
@@ -69,25 +69,19 @@ where
             // Iterate simultaneously on both vectors to remove duplicate elements.
             let (mut lhs_idx, mut lhs_del, mut rhs_idx, mut rhs_del) = (0, 0, 0, 0);
             while lhs_idx < lhs_old_len && rhs_idx < rhs_old_len {
-                let lhs = self.data.as_mut_ptr().offset(lhs_idx as isize);
-                let rhs = other.data.as_mut_ptr().offset(rhs_idx as isize);
+                let lhs = self.data.as_mut_ptr().add(lhs_idx);
+                let rhs = other.data.as_mut_ptr().add(rhs_idx);
                 match (*lhs).cmp(&*rhs) {
                     std::cmp::Ordering::Less => {
                         if lhs_del > 0 {
-                            let lhs_dst = self
-                                .data
-                                .as_mut_ptr()
-                                .offset((lhs_idx - lhs_del) as isize);
+                            let lhs_dst = self.data.as_mut_ptr().add(lhs_idx - lhs_del);
                             std::ptr::copy_nonoverlapping(lhs, lhs_dst, 1);
                         }
                         lhs_idx += 1;
                     }
                     std::cmp::Ordering::Greater => {
                         if rhs_del > 0 {
-                            let rhs_dst = other
-                                .data
-                                .as_mut_ptr()
-                                .offset((rhs_idx - rhs_del) as isize);
+                            let rhs_dst = other.data.as_mut_ptr().add(rhs_idx - rhs_del);
                             std::ptr::copy_nonoverlapping(rhs, rhs_dst, 1);
                         }
                         rhs_idx += 1;
@@ -104,14 +98,13 @@ where
             }
             // Complete vectors that are not yet explored.
             if lhs_idx < lhs_old_len && lhs_del > 0 {
-                let lhs_src = self.data.as_ptr().offset(lhs_idx as isize);
-                let lhs_dst = self.data.as_mut_ptr().offset((lhs_idx - lhs_del) as isize);
+                let lhs_src = self.data.as_ptr().add(lhs_idx);
+                let lhs_dst = self.data.as_mut_ptr().add(lhs_idx - lhs_del);
                 std::ptr::copy(lhs_src, lhs_dst, lhs_old_len - lhs_idx);
             }
             if rhs_idx < rhs_old_len && rhs_del > 0 {
-                let rhs_src = other.data.as_ptr().offset(rhs_idx as isize);
-                let rhs_dst =
-                    other.data.as_mut_ptr().offset((rhs_idx - rhs_del) as isize);
+                let rhs_src = other.data.as_ptr().add(rhs_idx);
+                let rhs_dst = other.data.as_mut_ptr().add(rhs_idx - rhs_del);
                 std::ptr::copy(rhs_src, rhs_dst, rhs_old_len - rhs_idx);
             }
             // Set the size of vectors to the correct size since we can now safely panic.

--- a/tests/common/fake.rs
+++ b/tests/common/fake.rs
@@ -46,9 +46,9 @@ impl device::Device for Device {
             Operator::TmpLd(..)
             | Operator::TmpSt(..)
             | Operator::BinOp(ir::BinOp::Add, ..) => true,
-            Operator::Ld(ref t, _, ref pattern) => pattern.is_consecutive(dim.id(), t),
+            Operator::Ld(t, _, ref pattern) => pattern.is_consecutive(dim.id(), t),
             Operator::St(_, ref operand, _, ref pattern) => {
-                pattern.is_consecutive(dim.id(), &operand.t())
+                pattern.is_consecutive(dim.id(), operand.t())
             }
             _ => false,
         }

--- a/tests/cuda.rs
+++ b/tests/cuda.rs
@@ -100,7 +100,7 @@ fn thread_reduction_map() {
     let size_32 = builder.cst_size(32);
     let d0 = builder.open_dim_ex(size_32, DimKind::THREAD);
     let init = builder.mov(&0f32);
-    builder.open_mapped_dim(&d0.into());
+    builder.open_mapped_dim(&d0);
     let cst_size_2 = builder.cst_size(2);
     builder.open_dim_ex(cst_size_2, DimKind::LOOP);
     builder.add(&helper::Reduce(init), &1f32);
@@ -148,8 +148,8 @@ fn induction_var_nested() {
     let size_1 = builder.cst_size(1);
     let size_4 = builder.cst_size(4);
     let size_5 = builder.cst_size(5);
-    let size_k = k.into_ir_size(&builder);
-    let size_k_tile_4 = k4.into_ir_size(&builder);
+    let size_k = k.to_ir_size(&builder);
+    let size_k_tile_4 = k4.to_ir_size(&builder);
     let d0 = builder.open_dim_ex(size_k_tile_4.clone(), DimKind::LOOP);
     let d1 = builder.open_dim_ex(size_4, DimKind::LOOP);
     let d2 = builder.open_dim_ex(size_5, DimKind::UNROLL);
@@ -273,7 +273,7 @@ fn perf_model_0() {
 
     let mut builder = helper::Builder::new(&signature, context.device());
     let size_16 = builder.cst_size(16);
-    let n_tiled = n.into_ir_size(&builder);
+    let n_tiled = n.to_ir_size(&builder);
 
     let _d0 = builder.open_dim_ex(n_tiled.clone(), DimKind::LOOP);
     let d1 = builder.open_dim_ex(size_16.clone(), DimKind::LOOP);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,4 @@
 //! Contains integration tests for Exhaust.
-#[macro_use]
-extern crate log;
-
 mod common;
 
 use crate::common::*;
@@ -251,27 +248,15 @@ fn block_dims() {
     let mut builder = helper::Builder::new(&signature, context.device());
     let d0 = builder.open_dim(Size::new_const(4));
     let inst = builder.mov(&0i32);
-    let s1 = n.into_ir_size(&builder);
+    let s1 = n.to_ir_size(&builder);
     let d1 = builder.open_dim_ex(s1, DimKind::BLOCK);
     let d2 = builder.open_dim_ex(Size::new_const(2), DimKind::BLOCK);
     let d3 = builder.open_dim_ex(Size::new_const(3), DimKind::BLOCK);
     let space = builder.get();
-    assert_eq!(
-        space.domain().get_is_iteration_dim(inst.into(), d0[0]),
-        Bool::TRUE
-    );
-    assert_eq!(
-        space.domain().get_is_iteration_dim(inst.into(), d1[0]),
-        Bool::TRUE
-    );
-    assert_eq!(
-        space.domain().get_is_iteration_dim(inst.into(), d2[0]),
-        Bool::TRUE
-    );
-    assert_eq!(
-        space.domain().get_is_iteration_dim(inst.into(), d3[0]),
-        Bool::TRUE
-    );
+    assert_eq!(space.domain().get_is_iteration_dim(inst, d0[0]), Bool::TRUE);
+    assert_eq!(space.domain().get_is_iteration_dim(inst, d1[0]), Bool::TRUE);
+    assert_eq!(space.domain().get_is_iteration_dim(inst, d2[0]), Bool::TRUE);
+    assert_eq!(space.domain().get_is_iteration_dim(inst, d3[0]), Bool::TRUE);
     assert_eq!(
         space.domain().get_dim_kind(d0[0]),
         DimKind::LOOP | DimKind::THREAD | DimKind::UNROLL
@@ -340,7 +325,7 @@ fn unroll_dims() {
     let mut builder = helper::Builder::new(&signature, context.device());
     let d0 = builder.open_dim(Size::new_const(64));
     let d1 = builder.open_dim(Size::new_const(4096));
-    let s2 = n.into_ir_size(&builder);
+    let s2 = n.to_ir_size(&builder);
     let d2 = builder.open_dim(s2);
     builder.mov(&0i32);
     let space = builder.get();
@@ -364,7 +349,7 @@ fn reduce_dim_invariants() {
     builder.close_dim(&d0);
 
     let d1 = builder.open_dim(Size::new_const(4));
-    builder.action(Action::IsIterationDim(reduce.into(), d1[0], Bool::TRUE));
+    builder.action(Action::IsIterationDim(reduce, d1[0], Bool::TRUE));
     builder.close_dim(&d1);
     let d2 = builder.open_dim(Size::new_const(4));
     builder.mov(&0i32);
@@ -381,7 +366,7 @@ fn reduce_dim_invariants() {
     );
     assert!(Order::OUTER.contains(space.domain().get_order(d1[0].into(), init.into())));
     assert_eq!(
-        space.domain().get_is_iteration_dim(reduce.into(), d2[0]),
+        space.domain().get_is_iteration_dim(reduce, d2[0]),
         Bool::FALSE
     );
     gen_best(&context, space);


### PR DESCRIPTION
Clippy has gone a long way since #130, including working with stable
Rust and being less pedantic by default.  This patch makes Telamon
conform to the clippy lints (with some locally disabled checks that did
not seem appropriate), and re-enables clippy checking on Travis.

Clippy lints are skipped on telamon-gen due to the large amount of
warnings; they can be re-introduced slowly (e.g. file-by-file or
lint-by-lint) -- or not, depending on the future of telamon-gen.