### PR TITLE
Make new MCTS implementation the default

### DIFF
--- a/examples/print_event_log.rs
+++ b/examples/print_event_log.rs
@@ -1,4 +1,4 @@
-use telamon::explorer::TreeEvent;
+use telamon::explorer::bandit_arm::TreeEvent;
 use utils::tfrecord::{ReadError, RecordReader};
 
 fn main() -> Result<(), ReadError> {

--- a/src/bin/parse_event_log.rs
+++ b/src/bin/parse_event_log.rs
@@ -6,7 +6,7 @@ use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{self, Read};
 use std::path::PathBuf;
-use telamon::explorer::{choice::ActionEx, TreeEvent};
+use telamon::explorer::{bandit_arm::TreeEvent, choice::ActionEx};
 use utils::tfrecord::{ReadError, RecordReader};
 
 use flate2::read::{GzDecoder, ZlibDecoder};

--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -177,7 +177,7 @@ impl SearchAlgorithm {
 
 impl Default for SearchAlgorithm {
     fn default() -> Self {
-        SearchAlgorithm::MultiArmedBandit(BanditConfig::default())
+        SearchAlgorithm::Mcts(BanditConfig::default())
     }
 }
 

--- a/src/explorer/mod.rs
+++ b/src/explorer/mod.rs
@@ -1,17 +1,16 @@
 //! exploration of the search space.
-mod bandit_arm;
 mod candidate;
 mod logger;
 mod monitor;
 mod parallel_list;
 mod store;
 
+pub mod bandit_arm;
 pub mod choice;
 pub mod config;
 pub mod local_selection;
 pub mod mcts;
 
-pub use self::bandit_arm::{DeadEndSource, TreeEvent};
 pub use self::candidate::Candidate;
 pub use self::config::{BanditConfig, Config, SearchAlgorithm};
 pub use self::logger::LogMessage;


### PR DESCRIPTION
This patch makes the new MCTS implementation (in explorer::mcts) the
default over the previous explorer::bandit_arm.  explorer::bandit_arm is
kept for the moment for backwards compatibility, although the behavior
of the two implementations should be fairly similar.

The tests are now run using the new MCTS implementation, which allowed
to spot a couple of bugs -- namely, that the new implementation was not
properly detecting tree exhaustion and was not stopping in that case.
The patch also fixes that issue by marking nodes that were already
evaluated as dead, ensuring they won't be evaluated again in the future.
A little bit of thought may be needed to understand what that entails on
the theoretical "guarantees" of the MCTS algorithm.