### PR TITLE
Factorize and modernize eventlog reading code

### DIFF
--- a/examples/print_event_log.rs
+++ b/examples/print_event_log.rs
@@ -1,17 +1,29 @@
-use telamon::explorer::bandit_arm::TreeEvent;
-use utils::tfrecord::{ReadError, RecordReader};
+use std::io;
+use std::path::PathBuf;
 
-fn main() -> Result<(), ReadError> {
-    let mut f = std::fs::File::open("eventlog.tfrecord")?;
+use serde_json;
+use structopt::StructOpt;
 
-    for record_bytes in (&mut f).records() {
-        match bincode::deserialize(&record_bytes?).unwrap() {
-            TreeEvent::Evaluation { actions, .. }
-            | TreeEvent::EvaluationV2 { actions, .. } => {
-                println!("{:?}", actions.into_iter().collect::<Vec<_>>())
-            }
-            TreeEvent::DeadEnd { .. } => (),
-        }
+use telamon::explorer::{eventlog::EventLog, mcts};
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "parse_event_log")]
+struct Opt {
+    #[structopt(
+        parse(from_os_str),
+        short = "i",
+        long = "input",
+        default_value = "eventlog.tfrecord.gz"
+    )]
+    eventlog: PathBuf,
+}
+
+fn main() -> io::Result<()> {
+    let opt = Opt::from_args();
+
+    for record_bytes in EventLog::open(&opt.eventlog)?.records() {
+        let message: mcts::Message = bincode::deserialize(&record_bytes?).unwrap();
+        println!("{}", serde_json::to_string(&message).unwrap());
     }
 
     Ok(())

--- a/src/explorer/eventlog.rs
+++ b/src/explorer/eventlog.rs
@@ -1,0 +1,96 @@
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::path::Path;
+
+use flate2::{read, write, Compression};
+use utils::tfrecord;
+
+enum EventLogInner {
+    Raw(File),
+    Gz(read::GzDecoder<write::GzEncoder<File>>),
+    Zlib(read::ZlibDecoder<write::ZlibEncoder<File>>),
+}
+
+pub struct EventLog {
+    inner: EventLogInner,
+}
+
+impl EventLog {
+    fn wrap(file: File, extension: Option<&str>) -> Self {
+        let inner = match extension {
+            Some("gz") => EventLogInner::Gz(read::GzDecoder::new(write::GzEncoder::new(
+                file,
+                Compression::default(),
+            ))),
+            Some("zz") => EventLogInner::Zlib(read::ZlibDecoder::new(
+                write::ZlibEncoder::new(file, Compression::default()),
+            )),
+            _ => EventLogInner::Raw(file),
+        };
+
+        EventLog { inner }
+    }
+
+    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<tfrecord::Reader<Self>> {
+        let extension = path
+            .as_ref()
+            .extension()
+            .and_then(OsStr::to_str)
+            .map(str::to_string);
+        let file = File::open(path)?;
+        Ok(tfrecord::Reader::from_reader(Self::wrap(
+            file,
+            extension.as_ref().map(String::as_ref),
+        )))
+    }
+
+    pub fn create<P: AsRef<Path>>(path: P) -> io::Result<tfrecord::Writer<Self>> {
+        let extension = path
+            .as_ref()
+            .extension()
+            .and_then(OsStr::to_str)
+            .map(str::to_string);
+        let file = File::create(path)?;
+        Ok(tfrecord::Writer::from_writer(Self::wrap(
+            file,
+            extension.as_ref().map(String::as_ref),
+        )))
+    }
+
+    pub fn finish(self) -> io::Result<File> {
+        match self.inner {
+            EventLogInner::Raw(file) => Ok(file),
+            EventLogInner::Gz(file) => file.into_inner().finish(),
+            EventLogInner::Zlib(file) => file.into_inner().finish(),
+        }
+    }
+}
+
+impl Read for EventLog {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match &mut self.inner {
+            EventLogInner::Raw(file) => file.read(buf),
+            EventLogInner::Gz(file) => file.read(buf),
+            EventLogInner::Zlib(file) => file.read(buf),
+        }
+    }
+}
+
+impl Write for EventLog {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match &mut self.inner {
+            EventLogInner::Raw(file) => file.write(buf),
+            EventLogInner::Gz(file) => file.write(buf),
+            EventLogInner::Zlib(file) => file.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match &mut self.inner {
+            EventLogInner::Raw(file) => file.flush(),
+            EventLogInner::Gz(file) => file.flush(),
+            EventLogInner::Zlib(file) => file.flush(),
+        }
+    }
+}

--- a/src/explorer/mod.rs
+++ b/src/explorer/mod.rs
@@ -8,6 +8,7 @@ mod store;
 pub mod bandit_arm;
 pub mod choice;
 pub mod config;
+pub mod eventlog;
 pub mod local_selection;
 pub mod mcts;
 


### PR DESCRIPTION
This patch simplifies the handling of eventlog reading by:

 - Introducing an `eventlog` module which takes care of opening the
   eventlog files properly wrt compression, and uses it when opening
   eventlog files.

 - Refactors the tfrecord reading code to expose an interface similar to
   that of "wrapper" formats such as the `csv` crate.  More
   specifically, the tfrecord reader and writer traits are converted to
   wrapping structures.