### PR TITLE
Log the probability distributions used for selecting children

### DIFF
--- a/src/explorer/mcts.rs
+++ b/src/explorer/mcts.rs
@@ -1319,7 +1319,12 @@ impl NewNodeOrder {
                 .map(Selector::exact),
             NewNodeOrder::WeightedRandom => {
                 if cut.is_infinite() {
-                    Selector::random(bounds.map(|(idx, b)| (idx, b.recip())).collect())
+                    let epsilon = 1e-6;
+                    Selector::random(
+                        bounds
+                            .map(|(idx, b)| (idx, (b + epsilon).recip()))
+                            .collect(),
+                    )
                 } else {
                     Selector::random(bounds.map(|(idx, b)| (idx, 1. - b / cut)).collect())
                 }


### PR DESCRIPTION
This patch adds to the log events the information about *how* a child
node was selected.  For now, this means adding either the probability
distribution (for random picking) or the scores (for deterministic
picking) associated with each node; in the future, we may log more
precise information such as the raw state of the policy -- from which
the aforementioned values can be computed.