### PR TITLE
Add a round-robin baseline policy

### DIFF
--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -231,6 +231,9 @@ pub enum TreePolicy {
     /// an uncertainty term to boost rarely explored branches.
     #[serde(rename = "uct")]
     UCT(UCTConfig),
+
+    /// Always select the least visited child.
+    RoundRobin,
 }
 
 impl Default for TreePolicy {

--- a/src/explorer/mcts.rs
+++ b/src/explorer/mcts.rs
@@ -1419,7 +1419,7 @@ impl UCTPolicy {
     fn value(&self, stats: &UCTStats) -> (f64, usize) {
         use self::config::ValueReduction;
 
-        let num_visits = stats.num_visits();
+        let num_visits = stats.common.num_visits();
 
         let value = match self.value_reduction {
             ValueReduction::Best => stats.best_evaluation(),
@@ -1658,12 +1658,39 @@ impl<'c, N: 'c> TreePolicy<'c, N, UCTStats> for UCTPolicy {
 }
 
 #[derive(Debug)]
+pub struct CommonStats {
+    /// Number of visits across this edge.  Note that this is the number of descents; there may
+    /// have been less backpropagations due to dead-ends.
+    num_visits: AtomicUsize,
+}
+
+impl Default for CommonStats {
+    fn default() -> Self {
+        CommonStats {
+            num_visits: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl CommonStats {
+    /// Call when the edge is selected during a descent
+    fn down(&self) {
+        self.num_visits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// The number of visits through this edge.
+    fn num_visits(&self) -> usize {
+        self.num_visits.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Debug)]
 pub struct UCTStats {
     best_evaluation: RwLock<f64>,
 
     sum_evaluations: RwLock<f64>,
 
-    num_visits: AtomicUsize,
+    common: CommonStats,
 }
 
 impl Default for UCTStats {
@@ -1671,14 +1698,14 @@ impl Default for UCTStats {
         UCTStats {
             best_evaluation: RwLock::new(std::f64::NEG_INFINITY),
             sum_evaluations: RwLock::new(0f64),
-            num_visits: AtomicUsize::new(0),
+            common: CommonStats::default(),
         }
     }
 }
 
 impl UCTStats {
     fn down(&self) {
-        self.num_visits.fetch_add(1, Ordering::Relaxed);
+        self.common.down()
     }
 
     fn up(&self, eval: f64) {
@@ -1710,10 +1737,6 @@ impl UCTStats {
             .sum_evaluations
             .read()
             .expect("sum_evaluations: poisoned")
-    }
-
-    fn num_visits(&self) -> usize {
-        self.num_visits.load(Ordering::Relaxed)
     }
 }
 
@@ -1768,7 +1791,9 @@ impl<'c, N: 'c> TreePolicy<'c, N, TAGStats> for TAGPolicy {
         // doesn't get changed by concurrent accesses.
         let edges = children
             .iter()
-            .map(|(index, edge, node)| (index, (edge, node, edge.data().num_visits())))
+            .map(|(index, edge, node)| {
+                (index, (edge, node, edge.data().common.num_visits()))
+            })
             .filter(|(_idx, (_edge, node, _num_visits))| {
                 node.bound().unwrap().value() < cut
             })
@@ -1870,17 +1895,14 @@ impl<'c, N: 'c> TreePolicy<'c, N, TAGStats> for TAGPolicy {
 pub struct TAGStats {
     /// All evaluations seen for the pointed-to node.
     evaluations: RwLock<Evaluations>,
-
-    /// Number of visits across this edge.  Note that this is the number of descents; there may
-    /// have been less backpropagations due to dead-ends.
-    num_visits: AtomicUsize,
+    common: CommonStats,
 }
 
 impl Default for TAGStats {
     fn default() -> Self {
         TAGStats {
             evaluations: RwLock::new(Evaluations::new()),
-            num_visits: AtomicUsize::new(0),
+            common: CommonStats::default(),
         }
     }
 }
@@ -1888,7 +1910,7 @@ impl Default for TAGStats {
 impl TAGStats {
     /// Called when the edge is selected during a descent
     fn down(&self) {
-        self.num_visits.fetch_add(1, Ordering::Relaxed);
+        self.common.down()
     }
 
     /// Called when backpropagating across this edge after an evaluation
@@ -1897,11 +1919,6 @@ impl TAGStats {
             .write()
             .expect("evaluations: poisoned")
             .record(eval, topk);
-    }
-
-    /// The number of visits through this edge.
-    fn num_visits(&self) -> usize {
-        self.num_visits.load(Ordering::Relaxed)
     }
 }
 
@@ -1965,5 +1982,34 @@ impl<'a> IntoIterator for &'a Evaluations {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
+    }
+}
+
+pub struct RoundRobinPolicy;
+
+impl<'c, N: 'c> TreePolicy<'c, N, CommonStats> for RoundRobinPolicy {
+    fn pick_child(
+        &'_ self,
+        _cut: f64,
+        view: &NodeView<'_, 'c, N, CommonStats>,
+    ) -> Option<(EdgeViewIndex, Selector<EdgeIndex>)> {
+        Selector::maximum(
+            view.iter()
+                .map(|(index, edge, _node)| (index, -(edge.data().num_visits() as f64)))
+                .collect(),
+        )
+        .map(|selector| {
+            let (index, selector) = view.select_with(selector);
+            view[index].0.data().down();
+            (index, selector)
+        })
+    }
+
+    fn backpropagate(
+        &self,
+        _parent: &Node<'c, N, CommonStats>,
+        _index: EdgeIndex,
+        _eval: Option<f64>,
+    ) {
     }
 }

--- a/src/explorer/mod.rs
+++ b/src/explorer/mod.rs
@@ -182,6 +182,9 @@ pub fn find_best_ex<'a>(
                 self::config::TreePolicy::WeightedRandom => {
                     builder.build(self::config::NewNodeOrder::WeightedRandom)
                 }
+                self::config::TreePolicy::RoundRobin => panic!(
+                    "Round-robin policy not supported with legacy 'bandit' implementation.  Use `'mcts'` instead."
+                ),
             }
         }
         config::SearchAlgorithm::Mcts(ref bandit_config) => {
@@ -215,6 +218,11 @@ pub fn find_best_ex<'a>(
                     Box::new(config::NewNodeOrder::WeightedRandom),
                     default_policy,
                 ),
+                config::TreePolicy::RoundRobin => builder
+                    .search::<(), mcts::CommonStats>(
+                        Box::new(mcts::RoundRobinPolicy),
+                        default_policy,
+                    ),
             }
         }
         config::SearchAlgorithm::BoundOrder => crossbeam::scope(|scope| {


### PR DESCRIPTION
This adds a baseline policy using round-robin selection, i.e. which is
selecting the child which was visited least at each step.

**This depends on #207 (due to reformatting) and target the corresponding branch; don't merge to master before #207**