### PR TITLE
Minimal support for Maxwell and Pascal architectures

### DIFF
--- a/backend/cuda/src/characterize/gpu.rs
+++ b/backend/cuda/src/characterize/gpu.rs
@@ -1,4 +1,28 @@
 //! Builds the description of a GPU.
+//! Unless otherwise specified, most of the information comes from the "CUDA C Programming Guide",
+//! available online at https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html
+//! For the sake of brevity, I will refer to this document as "the CPG".
+//!
+//! Some additional information comes from various nvidia whitepapers:
+//!
+//!  - For Kepler:
+//!    https://la.nvidia.com/content/PDF/product-specifications/GeForce_GTX_680_Whitepaper_FINAL.pdf
+//!
+//!  - For Maxwell:
+//!    https://international.download.nvidia.com/geforce-com/international/pdfs/GeForce-GTX-750-Ti-Whitepaper.pdf
+//!
+//!  - For Pascal:
+//!    https://images.nvidia.com/content/pdf/tesla/whitepaper/pascal-architecture-whitepaper.pdf
+//!
+//!  - For Volta:
+//!    https://images.nvidia.com/content/volta-architecture/pdf/volta-architecture-whitepaper.pdf
+//!
+//!  - For Turing:
+//!    https://www.nvidia.com/content/dam/en-zz/Solutions/design-visualization/technologies/turing-architecture/NVIDIA-Turing-Architecture-Whitepaper.pdf
+//!
+//! Note: Sometimes compute capabilities are used, and sometimes architecture names are used.  The
+//! mapping between those is described in section 2.5 "Compute Capability" of the CPG.
+
 use crate::characterize::instruction;
 use crate::DeviceAttribute::*;
 use crate::{Executor, Gpu, InstDesc};
@@ -73,10 +97,12 @@ pub fn functional_desc(executor: &Executor) -> Gpu {
 }
 
 /// Returns true if the GPU allows non-coherent loads.
+/// Not 100% sure what this referred to innitially, but we don't use it anyways.  I take this to
+/// correspond to the availability of the read-only cache which also backs up the texture cache.
 fn allow_nc_load(sm_major: i32, sm_minor: i32) -> bool {
     match (sm_major, sm_minor) {
         (2, _) | (3, 0) | (3, 2) => false,
-        (3, 5) | (3, 7) | (5, _) => true,
+        (3, 5) | (5, _) | (6, _) | (7, _) => true,
         _ => panic!("Unkown compute capability: {}.{}", sm_major, sm_minor),
     }
 }
@@ -84,45 +110,74 @@ fn allow_nc_load(sm_major: i32, sm_minor: i32) -> bool {
 /// Returns true if the GPU allows L1 caching of global memory accesses.
 fn allow_l1_for_global_mem(sm_major: i32, sm_minor: i32) -> bool {
     match (sm_major, sm_minor) {
-        (2, _) | (3, 7) | (5, 2) => true,
-        (3, 0) | (3, 2) | (3, 5) | (5, 0) => false,
+        (2, _) => true,
+        (3, 0) | (3, 2) | (3, 5) => false,
+        // Some 3.5 devices allow L1 as well.  Ignore them.
+        (3, 7) => true,
+        (5, 0) => false,
+        (5, 2) | (5, 3) => true,
+        // FIXME: nvidia docs are not clear on this for compute capabilities 6.x and 7.x, saying
+        // "Global memory behaves the same way as devices of compute capability 5.x".  But CC 5.0
+        // behaves differently from CC 5.2+ and does not allow using L1 for global memory -- I will
+        // assume this means to use the CC 5.2+ behavior and allow L1 cache, but we should check
+        // this.
+        (6, _) | (7, _) => true,
         _ => panic!("Unkown compute capability: {}.{}", sm_major, sm_minor),
     }
 }
 
 /// Returns the maximum number of resident blocks on an SMX.
+/// From line "Maximum number of resident blocks per multiprocessor" on Table 14.
 fn block_per_smx(sm_major: i32, sm_minor: i32) -> u32 {
-    match sm_major {
-        2 => 8,
-        3 => 16,
-        5 => 32,
+    match (sm_major, sm_minor) {
+        (2, _) => 8,
+        (3, _) => 16,
+        (5, _) => 32,
+        (6, _) => 32,
+        (7, 0) => 32,
+        (7, 5) => 16,
         _ => panic!("Unkown compute capability: {}.{}", sm_major, sm_minor),
     }
 }
 
 /// Returns the size of the L1 cache.
+/// From the "Architecture" subsection of each compute capability.
 fn l1_cache_size(sm_major: i32, sm_minor: i32) -> u32 {
-    match sm_major {
-        2 | 3 => 16 * 1024,
-        5 => 24 * 1024,
+    match (sm_major, sm_minor) {
+        // FIXME: For CC 3.x the same on-chip memory is used for L1 and shared memory, and we can
+        // select 48KB+16KB, 32KB+32KB or 16KB+48KB.  Default is 48KB shared memory and 16KB L1
+        // cache, which is reflected here.
+        (2, _) | (3, _) => 16 * 1024,
+        (5, _) => 24 * 1024,
+        // Yes, 6.1 has a larger L1 cache than both 6.0 and 6.2.  Go figure.
+        (6, 0) | (6, 2) => 24 * 1024,
+        (6, 1) => 48 * 1024,
+        // FIXME: As for CC 3.x, CC 7.x uses the same on-chip memory for L1 cache and shared memory,
+        // but can't be configured exactly -- the driver makes that choice for us.  We'll figure
+        // out the proper behavior when we have the corresponding hardware.
         _ => panic!("Unkown compute capability: {}.{}", sm_major, sm_minor),
     }
 }
 
-/// Returns the stride between shared memory banks.
+/// Returns the stride (in bytes) between shared memory banks.
+/// From the "Shared memory" subsection of each compute capability, where it is expressed in bits
+/// (e.g. "Successive 32-bit words map to successive banks").
 fn shared_bank_stride(sm_major: i32, sm_minor: i32) -> u32 {
     match sm_major {
-        2 => 4,
-        3 | 5 => 8,
+        2 | 5 | 6 | 7 => 4,
+        // Kepler used 64-bit addressing mode
+        3 => 8,
         _ => panic!("Unkown compute capability: {}.{}", sm_major, sm_minor),
     }
 }
 
 /// Returns the maximum number of resident thread per SMX.
+/// From line "Maximum number of resident threads per multiprocessor" on Table 14.
 fn thread_per_smx(sm_major: i32, sm_minor: i32) -> u32 {
-    match sm_major {
-        2 => 1536,
-        3 | 5 => 2048,
+    match (sm_major, sm_minor) {
+        (2, _) => 1536,
+        (3, _) | (5, _) | (6, _) | (7, 0) => 2048,
+        (7, 5) => 1024,
         _ => panic!("Unkown compute capability: {}.{}", sm_major, sm_minor),
     }
 }
@@ -131,11 +186,27 @@ fn thread_per_smx(sm_major: i32, sm_minor: i32) -> u32 {
 fn smx_rates(gpu: &Gpu, executor: &Executor) -> InstDesc {
     let (wrap_scheds, issues_per_wrap) = wrap_scheds_per_smx(gpu.sm_major, gpu.sm_minor);
     let issue = wrap_scheds * issues_per_wrap * gpu.wrap_size;
+    // alu comes from line "32-bit floating-point add, multiply, multiply-add" on Table 2
+    // "Throughput of Native Arithmetic Instruction"
+    //
+    // mem comes from the various whitepapers, looking at the SM diagrams
+    //
+    // sync comes from section 5.4.3 "Synchronize instructions"
     let (alu, mem, sync) = match (gpu.sm_major, gpu.sm_minor) {
-        (2, 0) => (32, 16, 32), // Sync unknown for 2.0
-        (2, 1) => (48, 32, 32), // Sync unknown for 2.0
+        (2, 0) => (32, 16, 32), // Sync unknown for 2.x
+        (2, 1) => (48, 32, 32), // Sync unknown for 2.x
+        // Kepler
         (3, _) => (192, 32, 128),
+        // Maxwell
         (5, _) => (128, 32, 64),
+        // Pascal
+        (6, 0) => (64, 16, 32),
+        (6, 1) => (128, 16, 64),
+        (6, 2) => (128, 16, 64),
+        // Volta
+        (7, 0) => (64, 32, 16),
+        // Turing
+        (7, 5) => (64, 16, 16),
         (major, minor) => panic!("Unkown compute capability: {}.{}", major, minor),
     };
     let l1_lines_bw = instruction::smx_bandwidth_l1_lines(gpu, executor);
@@ -189,12 +260,22 @@ fn gpu_rates(gpu: &Gpu, smx_rates: &InstDesc) -> InstDesc {
 
 /// Returns the number of wrap scheduler in a single SMX and the number of independent
 /// instruction issued per wrap scheduler.
+/// This comes from the "Architecture" subsection for each compute capability on the CPG.
 fn wrap_scheds_per_smx(sm_major: u8, sm_minor: u8) -> (u32, u32) {
     match (sm_major, sm_minor) {
+        // Fermi
         (2, 0) => (2, 1),
         (2, 1) => (2, 2),
+        // Kepler
         (3, _) => (4, 2),
+        // Maxwell
         (5, _) => (4, 1),
+        // Pascal
+        (6, 0) => (2, 1),
+        (6, 1) => (4, 1),
+        (6, 2) => (4, 1),
+        // Volta, Turing
+        (7, _) => (4, 1),
         _ => panic!("Unkown compute capability: {}.{}", sm_major, sm_minor),
     }
 }

--- a/backend/cuda/src/context.rs
+++ b/backend/cuda/src/context.rs
@@ -91,7 +91,7 @@ impl<'a> Context<'a> {
             info!("candidate skipped because of its bound");
             return Ok(std::f64::INFINITY);
         }
-        let t0 = self.ticks_to_ns(unwrap!(thunk.execute()));
+        let t0 = self.ticks_to_ns(thunk.execute()?);
         if mode.skip_bad_candidates() && t0 * SKIP_THRESHOLD >= bound {
             info!("candidate skipped after its first evaluation");
             return Ok(t0);

--- a/backend/cuda/src/gpu.rs
+++ b/backend/cuda/src/gpu.rs
@@ -476,13 +476,12 @@ impl device::Device for Gpu {
             | ir::Operator::TmpSt(..) => InstFlag::COHERENT,
             _ => panic!("invalid memory access operator"),
         };
-        // Remove the `CACHE_READ_ONLY` option if the gpu does not support `ld.nc`.
-        if !self.allow_nc_load {
+        // TODO(model): CACHE_READ_ONLY and CACHE_SHARED are currently not supported by the
+        // performance model.  Disable them, even if the hardware supports them.
+        if !self.allow_nc_load || true {
             flags.restrict(!InstFlag::CACHE_READ_ONLY);
         }
-        // Remove the `CACHE_SHARED` option if the GPU does not allow using L1 cache for
-        // global accesses.
-        if !self.allow_l1_for_global_mem {
+        if !self.allow_l1_for_global_mem || true {
             flags.restrict(!InstFlag::CACHE_SHARED);
         }
         flags

--- a/backend/cuda/src/gpu.rs
+++ b/backend/cuda/src/gpu.rs
@@ -478,10 +478,13 @@ impl device::Device for Gpu {
         };
         // TODO(model): CACHE_READ_ONLY and CACHE_SHARED are currently not supported by the
         // performance model.  Disable them, even if the hardware supports them.
-        if !self.allow_nc_load || true {
+        flags.restrict(!InstFlag::CACHE_READ_ONLY);
+        flags.restrict(!InstFlag::CACHE_SHARED);
+
+        if !self.allow_nc_load {
             flags.restrict(!InstFlag::CACHE_READ_ONLY);
         }
-        if !self.allow_l1_for_global_mem || true {
+        if !self.allow_l1_for_global_mem {
             flags.restrict(!InstFlag::CACHE_SHARED);
         }
         flags

--- a/backend/cuda/src/template/device.ptx
+++ b/backend/cuda/src/template/device.ptx
@@ -1,4 +1,4 @@
-.version 3.1
+.version 6.1
 .target sm_{sm_major}{sm_minor}
 .address_size {addr_size}
 

--- a/src/search_space/choices.exh
+++ b/src/search_space/choices.exh
@@ -103,7 +103,7 @@ require forall $outer_dim in Dimensions:
     dim_kind($dim) is not BLOCK
     || order($outer_dim, $dim) is not OUTER
     || tiling_factor($logical) >=
-      "$logical.total_size().max()/$fun.device().max_inner_block_size()"
+      "($logical.total_size().max() + $fun.device().max_inner_block_size() - 1)/$fun.device().max_inner_block_size()"
 require forall $outer_dim in Dimensions:
   forall $dim in StaticDims:
     dim_kind($dim) is not BLOCK


### PR DESCRIPTION
This patch adds minimal support for Maxwell and Pascal CUDA GPUs, by
adding information from the CUDA C Programming Guide on those GPUs and
overall ensuring that generated kernels can run on them.  The
performance model is not yet updated for those architectures, and as
such may give (wildly) incorrect lower bounds -- which shouldn't prevent
the generated kernels from being correct still.

In addition, this also fixes a pre-existing bug where constraints on inner block dimensions were not properly computed due to a division rounding error, which caused crashes when running Telamon on Maxwell/Pascal gpus.