### PR TITLE
Embedding Namer in NameMap entirely

### DIFF
--- a/backend/cuda/src/printer.rs
+++ b/backend/cuda/src/printer.rs
@@ -68,7 +68,7 @@ impl CudaPrinter {
 
     /// Prints the variables declared by the `Namer`.
     fn var_decls(&mut self, name_map: &NameMap<Namer>) -> String {
-        let namer = name_map.get_namer();
+        let namer = name_map.namer();
         let print_decl = |(&t, n)| {
             let prefix = Namer::gen_prefix(t);
             format!(".reg.{} %{}<{}>;", Self::get_type(t), prefix, n)

--- a/backend/cuda/src/printer.rs
+++ b/backend/cuda/src/printer.rs
@@ -67,7 +67,8 @@ impl CudaPrinter {
     }
 
     /// Prints the variables declared by the `Namer`.
-    fn var_decls(&mut self, namer: &Namer) -> String {
+    fn var_decls(&mut self, name_map: &NameMap<Namer>) -> String {
+        let namer = name_map.get_namer();
         let print_decl = |(&t, n)| {
             let prefix = Namer::gen_prefix(t);
             format!(".reg.{} %{}<{}>;", Self::get_type(t), prefix, n)
@@ -81,7 +82,7 @@ impl CudaPrinter {
     }
 
     /// Declares block and thread indexes.
-    fn decl_par_indexes(function: &Function, namer: &mut NameMap) -> String {
+    fn decl_par_indexes(function: &Function, namer: &mut NameMap<Namer>) -> String {
         let mut decls = vec![];
         // Load block indexes.
         for (dim, dir) in function.block_dims().iter().zip(&["x", "y", "z"]) {
@@ -100,7 +101,7 @@ impl CudaPrinter {
     }
 
     /// Declares a shared memory block.
-    fn shared_mem_decl(&mut self, block: &MemoryRegion, namer: &mut NameMap) {
+    fn shared_mem_decl(&mut self, block: &MemoryRegion, namer: &mut NameMap<Namer>) {
         let ptr_type_name = Self::get_type(Type::I(32));
         let name = namer.name_addr(block.id());
         unwrap!(writeln!(
@@ -166,7 +167,7 @@ impl CudaPrinter {
     }
 
     /// Prints a parameter decalartion.
-    fn param_decl(&mut self, param: &ParamVal, namer: &NameMap) -> String {
+    fn param_decl(&mut self, param: &ParamVal, namer: &NameMap<Namer>) -> String {
         format!(
             ".param .{t}{attr} {name}",
             t = Self::get_type(param.t()),
@@ -192,72 +193,69 @@ impl CudaPrinter {
     /// Prints a `Function`.
     pub fn function(&mut self, function: &Function, gpu: &Gpu) -> String {
         let mut namer = Namer::default();
-        let param_decls;
-        {
-            let name_map = &mut NameMap::new(function, &mut namer);
-            param_decls = function
-                .device_code_args()
-                .map(|v| self.param_decl(v, name_map))
-                .collect_vec()
-                .join(",\n  ");
-            // LOAD PARAMETERS
-            for val in function.device_code_args() {
-                unwrap!(writeln!(
-                    self.buffer,
-                    "  ld.param.{t} {var_name}, [{name}];",
-                    t = Self::get_type(val.t()),
-                    var_name = name_map.name_param_val(val.key()),
-                    name = name_map.name_param(val.key())
-                ));
-            }
-            // INDEX LOAD
-            self.buffer.push_str(&"  ");
-            let idx_loads = Self::decl_par_indexes(function, name_map);
-            self.buffer.push_str(&idx_loads);
-            self.buffer.push_str(&"\n");
-            //MEM DECL
-            for block in function.mem_blocks() {
-                match block.alloc_scheme() {
-                    AllocationScheme::Shared => self.shared_mem_decl(block, name_map),
-                    AllocationScheme::PrivatisedGlobal => {
-                        self.privatise_global_block(block, name_map, function)
-                    }
-                    AllocationScheme::Global => (),
-                }
-            }
-            // Compute size casts
-            for dim in function.dimensions() {
-                if !dim.kind().intersects(DimKind::UNROLL | DimKind::LOOP) {
-                    continue;
-                }
-                for level in dim.induction_levels() {
-                    if let Some((_, ref incr)) = level.increment {
-                        let name = name_map.declare_size_cast(incr, level.t());
-                        if let Some(name) = name {
-                            let old_name = name_map.name_size(incr, Type::I(32));
-                            self.print_unary_op(
-                                [1, 1],
-                                ir::UnaryOp::Cast(level.t()),
-                                Type::I(32),
-                                &name,
-                                &old_name,
-                            );
-                        }
-                    }
-                }
-            }
-            let ind_levels = function.init_induction_levels().iter().chain(
-                function
-                    .block_dims()
-                    .iter()
-                    .flat_map(|d| d.induction_levels()),
-            );
-            for level in ind_levels {
-                self.parallel_induction_level(level, name_map);
-            }
-            self.cfg(function, function.cfg(), name_map);
+        let name_map = &mut NameMap::new(function, &mut namer);
+        let param_decls = function
+            .device_code_args()
+            .map(|v| self.param_decl(v, name_map))
+            .collect_vec()
+            .join(",\n  ");
+        // LOAD PARAMETERS
+        for val in function.device_code_args() {
+            unwrap!(writeln!(
+                self.buffer,
+                "  ld.param.{t} {var_name}, [{name}];",
+                t = Self::get_type(val.t()),
+                var_name = name_map.name_param_val(val.key()),
+                name = name_map.name_param(val.key())
+            ));
         }
-        let var_decls = self.var_decls(&namer);
+        // INDEX LOAD
+        self.buffer.push_str(&"  ");
+        let idx_loads = Self::decl_par_indexes(function, name_map);
+        self.buffer.push_str(&idx_loads);
+        self.buffer.push_str(&"\n");
+        //MEM DECL
+        for block in function.mem_blocks() {
+            match block.alloc_scheme() {
+                AllocationScheme::Shared => self.shared_mem_decl(block, name_map),
+                AllocationScheme::PrivatisedGlobal => {
+                    self.privatise_global_block(block, name_map, function)
+                }
+                AllocationScheme::Global => (),
+            }
+        }
+        // Compute size casts
+        for dim in function.dimensions() {
+            if !dim.kind().intersects(DimKind::UNROLL | DimKind::LOOP) {
+                continue;
+            }
+            for level in dim.induction_levels() {
+                if let Some((_, ref incr)) = level.increment {
+                    let name = name_map.declare_size_cast(incr, level.t());
+                    if let Some(name) = name {
+                        let old_name = name_map.name_size(incr, Type::I(32));
+                        self.print_unary_op(
+                            [1, 1],
+                            ir::UnaryOp::Cast(level.t()),
+                            Type::I(32),
+                            &name,
+                            &old_name,
+                        );
+                    }
+                }
+            }
+        }
+        let ind_levels = function.init_induction_levels().iter().chain(
+            function
+                .block_dims()
+                .iter()
+                .flat_map(|d| d.induction_levels()),
+        );
+        for level in ind_levels {
+            self.parallel_induction_level(level, name_map);
+        }
+        self.cfg(function, function.cfg(), name_map);
+        let var_decls = self.var_decls(&name_map);
         let mut body = String::new();
         body.push_str(&var_decls);
         body.push_str(&"\n");
@@ -352,7 +350,7 @@ impl CudaPrinter {
     }
 }
 
-impl Printer for CudaPrinter {
+impl Printer<Namer> for CudaPrinter {
     /// Get a proper string representation of an integer in target language
     fn get_int(n: u32) -> String {
         format!("{}", n)
@@ -547,7 +545,7 @@ impl Printer for CudaPrinter {
     fn name_operand<'a>(
         vector_levels: &[Vec<Dimension>; 2],
         op: &ir::Operand,
-        namer: &'a NameMap,
+        namer: &'a NameMap<Namer>,
     ) -> Cow<'a, str> {
         assert!(vector_levels[0].is_empty());
         if vector_levels[1].is_empty() {
@@ -574,7 +572,7 @@ impl Printer for CudaPrinter {
     fn name_inst<'a>(
         vector_levels: &[Vec<Dimension>; 2],
         inst: ir::InstId,
-        namer: &'a NameMap,
+        namer: &'a NameMap<Namer>,
     ) -> Cow<'a, str> {
         assert!(vector_levels[0].is_empty());
         if vector_levels[1].is_empty() {

--- a/backend/x86/src/printer.rs
+++ b/backend/x86/src/printer.rs
@@ -30,7 +30,7 @@ impl X86printer {
 
     /// Declared all variables that have been required from the namer
     fn var_decls(&mut self, name_map: &NameMap<Namer>) -> String {
-        let namer = name_map.get_namer();
+        let namer = name_map.namer();
         let print_decl = |(&t, &n)| match t {
             Type::PtrTo(..) => String::new(),
             _ => {

--- a/backend/x86/src/printer.rs
+++ b/backend/x86/src/printer.rs
@@ -15,7 +15,7 @@ pub struct X86printer {
 
 impl X86printer {
     /// Declares all parameters of the function with the appropriate type
-    fn param_decl(&mut self, param: &ParamVal, namer: &NameMap) -> String {
+    fn param_decl(&mut self, param: &ParamVal, namer: &NameMap<Namer>) -> String {
         let name = namer.name_param(param.key());
         match param {
             ParamVal::External(_, par_type) => {
@@ -29,7 +29,8 @@ impl X86printer {
     }
 
     /// Declared all variables that have been required from the namer
-    fn var_decls(&mut self, namer: &Namer) -> String {
+    fn var_decls(&mut self, name_map: &NameMap<Namer>) -> String {
+        let namer = name_map.get_namer();
         let print_decl = |(&t, &n)| match t {
             Type::PtrTo(..) => String::new(),
             _ => {
@@ -66,7 +67,11 @@ impl X86printer {
     }
 
     /// Declares block and thread indexes.
-    fn decl_par_indexes(&mut self, function: &Function, namer: &mut NameMap) -> String {
+    fn decl_par_indexes(
+        &mut self,
+        function: &Function,
+        namer: &mut NameMap<Namer>,
+    ) -> String {
         assert!(function.block_dims().is_empty());
         let mut decls = vec![];
         // Compute thread indexes.
@@ -79,84 +84,81 @@ impl X86printer {
     /// Prints a `Function`.
     pub fn function(&mut self, function: &Function) -> String {
         let mut namer = Namer::default();
-        let mut return_string;
-        {
-            let name_map = &mut NameMap::new(function, &mut namer);
-            let param_decls = function
-                .device_code_args()
-                .map(|v| self.param_decl(v, name_map))
-                .collect_vec()
-                .join(",\n  ");
-            // SIGNATURE AND OPEN BRACKET
-            return_string = if function.device_code_args().count() == 0 {
-                format!(
-                    include_str!("template/signature_no_arg.c.template"),
-                    name = function.name,
-                )
-            } else {
-                format!(
-                    include_str!("template/signature.c.template"),
-                    name = function.name,
-                    params = param_decls
-                )
-            };
-            // INDEX LOADS
-            let idx_loads = self.decl_par_indexes(function, name_map);
-            unwrap!(writeln!(self.buffer, "{}", idx_loads));
-            // LOAD PARAM
-            for val in function.device_code_args() {
-                unwrap!(writeln!(
-                    self.buffer,
-                    "{var_name} = {name};// LD_PARAM",
-                    var_name = name_map.name_param_val(val.key()),
-                    name = name_map.name_param(val.key())
-                ));
-            }
-            // MEM DECL
-            for block in function.mem_blocks() {
-                match block.alloc_scheme() {
-                    AllocationScheme::Shared => panic!("No shared mem in cpu!!"),
-                    AllocationScheme::PrivatisedGlobal => {
-                        self.privatise_global_block(block, name_map, function)
-                    }
-                    AllocationScheme::Global => (),
-                }
-            }
-            // Compute size casts
-            for dim in function.dimensions() {
-                if !dim.kind().intersects(DimKind::UNROLL | DimKind::LOOP) {
-                    continue;
-                }
-                for level in dim.induction_levels() {
-                    if let Some((_, ref incr)) = level.increment {
-                        let name = name_map.declare_size_cast(incr, level.t());
-                        if let Some(name) = name {
-                            let old_name = name_map.name_size(incr, Type::I(32));
-                            self.print_unary_op(
-                                [1, 1],
-                                ir::UnaryOp::Cast(level.t()),
-                                Type::I(32),
-                                &name,
-                                &old_name,
-                            );
-                        }
-                    }
-                }
-            }
-            // INIT
-            let ind_levels = function.init_induction_levels().iter().chain(
-                function
-                    .block_dims()
-                    .iter()
-                    .flat_map(|d| d.induction_levels()),
-            );
-            for level in ind_levels {
-                self.parallel_induction_level(level, name_map);
-            }
-            // BODY
-            self.cfg(function, function.cfg(), name_map);
+        let name_map = &mut NameMap::new(function, &mut namer);
+        let param_decls = function
+            .device_code_args()
+            .map(|v| self.param_decl(v, name_map))
+            .collect_vec()
+            .join(",\n  ");
+        // SIGNATURE AND OPEN BRACKET
+        let mut return_string = if function.device_code_args().count() == 0 {
+            format!(
+                include_str!("template/signature_no_arg.c.template"),
+                name = function.name,
+            )
+        } else {
+            format!(
+                include_str!("template/signature.c.template"),
+                name = function.name,
+                params = param_decls
+            )
+        };
+        // INDEX LOADS
+        let idx_loads = self.decl_par_indexes(function, name_map);
+        unwrap!(writeln!(self.buffer, "{}", idx_loads));
+        // LOAD PARAM
+        for val in function.device_code_args() {
+            unwrap!(writeln!(
+                self.buffer,
+                "{var_name} = {name};// LD_PARAM",
+                var_name = name_map.name_param_val(val.key()),
+                name = name_map.name_param(val.key())
+            ));
         }
-        let var_decls = self.var_decls(&namer);
+        // MEM DECL
+        for block in function.mem_blocks() {
+            match block.alloc_scheme() {
+                AllocationScheme::Shared => panic!("No shared mem in cpu!!"),
+                AllocationScheme::PrivatisedGlobal => {
+                    self.privatise_global_block(block, name_map, function)
+                }
+                AllocationScheme::Global => (),
+            }
+        }
+        // Compute size casts
+        for dim in function.dimensions() {
+            if !dim.kind().intersects(DimKind::UNROLL | DimKind::LOOP) {
+                continue;
+            }
+            for level in dim.induction_levels() {
+                if let Some((_, ref incr)) = level.increment {
+                    let name = name_map.declare_size_cast(incr, level.t());
+                    if let Some(name) = name {
+                        let old_name = name_map.name_size(incr, Type::I(32));
+                        self.print_unary_op(
+                            [1, 1],
+                            ir::UnaryOp::Cast(level.t()),
+                            Type::I(32),
+                            &name,
+                            &old_name,
+                        );
+                    }
+                }
+            }
+        }
+        // INIT
+        let ind_levels = function.init_induction_levels().iter().chain(
+            function
+                .block_dims()
+                .iter()
+                .flat_map(|d| d.induction_levels()),
+        );
+        for level in ind_levels {
+            self.parallel_induction_level(level, name_map);
+        }
+        // BODY
+        self.cfg(function, function.cfg(), name_map);
+        let var_decls = self.var_decls(&name_map);
         return_string.push_str(&var_decls);
         return_string.push_str(&self.buffer);
         // Close function bracket
@@ -346,7 +348,6 @@ impl X86printer {
 
     fn get_type(t: Type) -> String {
         match t {
-            //Type::PtrTo(..) => " uint8_t *",
             Type::PtrTo(..) => String::from("intptr_t"),
             Type::F(32) => String::from("float"),
             Type::F(64) => String::from("double"),
@@ -360,7 +361,7 @@ impl X86printer {
     }
 }
 
-impl Printer for X86printer {
+impl Printer<Namer> for X86printer {
     fn get_int(n: u32) -> String {
         format!("{}", n)
     }
@@ -508,7 +509,7 @@ impl Printer for X86printer {
     fn name_operand<'a>(
         vector_dims: &[Vec<Dimension>; 2],
         op: &ir::Operand,
-        namer: &'a NameMap,
+        namer: &'a NameMap<Namer>,
     ) -> Cow<'a, str> {
         assert!(vector_dims[0].is_empty());
         assert!(vector_dims[1].is_empty());
@@ -518,7 +519,7 @@ impl Printer for X86printer {
     fn name_inst<'a>(
         vector_dims: &[Vec<Dimension>; 2],
         inst: ir::InstId,
-        namer: &'a NameMap,
+        namer: &'a NameMap<Namer>,
     ) -> Cow<'a, str> {
         assert!(vector_dims[0].is_empty());
         assert!(vector_dims[1].is_empty());

--- a/src/codegen/name_map.rs
+++ b/src/codegen/name_map.rs
@@ -152,11 +152,11 @@ impl<'a, 'b, N: Namer> NameMap<'a, 'b, N> {
         name_map
     }
 
-    pub fn get_namer(&self) -> &N {
+    pub fn namer(&self) -> &N {
         &*self.namer
     }
 
-    pub fn get_mut_namer(&mut self) -> &mut N {
+    pub fn namer_mut(&mut self) -> &mut N {
         self.namer
     }
 

--- a/src/codegen/name_map.rs
+++ b/src/codegen/name_map.rs
@@ -33,9 +33,9 @@ pub trait Namer {
 
 /// Maps variables to names.
 // TODO(cc_perf): use an arena rather that ref-counted strings
-pub struct NameMap<'a, 'b> {
+pub struct NameMap<'a, 'b, N: Namer> {
     /// Provides fresh names.
-    namer: std::cell::RefCell<&'b mut Namer>,
+    namer: &'b mut N,
     /// Keeps track of the names of the variables used in the kernel
     variables: FnvHashMap<ir::VarId, VariableNames>,
     /// Keeps track of the name of the values produced by instructions.
@@ -62,9 +62,9 @@ pub struct NameMap<'a, 'b> {
     side_effect_guard: Option<RcStr>,
 }
 
-impl<'a, 'b> NameMap<'a, 'b> {
+impl<'a, 'b, N: Namer> NameMap<'a, 'b, N> {
     /// Creates a new `NameMap`.
-    pub fn new(function: &'a Function<'a>, namer: &'b mut Namer) -> Self {
+    pub fn new(function: &'a Function<'a>, namer: &'b mut N) -> Self {
         let mut mem_blocks = FnvHashMap::default();
         // Setup parameters names.
         let params = function
@@ -106,7 +106,7 @@ impl<'a, 'b> NameMap<'a, 'b> {
         }
         let variables = VariableNames::create(function, namer);
         let mut name_map = NameMap {
-            namer: std::cell::RefCell::new(namer),
+            namer,
             insts: FnvHashMap::default(),
             variables,
             num_loop: 0,
@@ -152,6 +152,14 @@ impl<'a, 'b> NameMap<'a, 'b> {
         name_map
     }
 
+    pub fn get_namer(&self) -> &N {
+        &*self.namer
+    }
+
+    pub fn get_mut_namer(&mut self) -> &mut N {
+        self.namer
+    }
+
     /// Returns the total number of threads.
     #[cfg(feature = "mppa")]
     pub fn total_num_threads(&self) -> u32 {
@@ -159,8 +167,8 @@ impl<'a, 'b> NameMap<'a, 'b> {
     }
 
     /// Generates a variable of the given `Type`.
-    pub fn gen_name(&self, t: Type) -> String {
-        self.namer.borrow_mut().name(t)
+    pub fn gen_name(&mut self, t: Type) -> String {
+        self.namer.name(t)
     }
 
     /// Generates an ID for a loop.
@@ -191,11 +199,9 @@ impl<'a, 'b> NameMap<'a, 'b> {
         indexes: Cow<FnvHashMap<ir::DimId, usize>>,
     ) -> Cow<str> {
         match *operand {
-            ir::Operand::Int(ref val, len) => {
-                Cow::Owned(self.namer.borrow().name_int(val, len))
-            }
+            ir::Operand::Int(ref val, len) => Cow::Owned(self.namer.name_int(val, len)),
             ir::Operand::Float(ref val, len) => {
-                Cow::Owned(self.namer.borrow().name_float(val, len))
+                Cow::Owned(self.namer.name_float(val, len))
             }
             ir::Operand::Inst(id, _, ref dim_map, _)
             | ir::Operand::Reduce(id, _, ref dim_map, _) => {
@@ -264,9 +270,7 @@ impl<'a, 'b> NameMap<'a, 'b> {
             .instantiation_dims()
             .iter()
             .map(|&(dim, size)| (dim, size as usize));
-        use std::ops::DerefMut;
-        let mut namer = self.namer.borrow_mut();
-        let names = VariableNames::new(t, dims, *namer.deref_mut());
+        let names = VariableNames::new(t, dims, self.namer);
         assert!(self.insts.insert(inst.id(), names).is_none());
     }
 
@@ -358,7 +362,7 @@ impl<'a, 'b> NameMap<'a, 'b> {
         match self.size_casts.entry((size, t)) {
             hash_map::Entry::Occupied(..) => None,
             hash_map::Entry::Vacant(entry) => {
-                Some(entry.insert(self.namer.borrow_mut().name(t)).to_string())
+                Some(entry.insert(self.namer.name(t)).to_string())
             }
         }
     }

--- a/src/codegen/name_map.rs
+++ b/src/codegen/name_map.rs
@@ -153,7 +153,7 @@ impl<'a, 'b, N: Namer> NameMap<'a, 'b, N> {
     }
 
     pub fn namer(&self) -> &N {
-        &*self.namer
+        self.namer
     }
 
     pub fn namer_mut(&mut self) -> &mut N {

--- a/src/codegen/variable.rs
+++ b/src/codegen/variable.rs
@@ -195,8 +195,6 @@ pub fn wrap_variables<'a>(space: &'a SearchSpace) -> Vec<Variable<'a>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::helper;
-    use crate::ir;
     use std;
 
     fn mk_map<K, V>(content: &[(K, V)]) -> FnvHashMap<K, V>


### PR DESCRIPTION
We used to have a RefCell<&mut Namer> inside of NameMap struct, but we use Namer both directly and through NameMap in printer. This leads to unconveniance like putting use of NameMap inside a block and is troublesome when calls to Namer can be a bit more complicated as it will be in Mppa (call to Namer for both wrapper and kernel code). NameMap now takes directly a mutable reference to a generic N implementing Namer (we very often use a &mut NameMap anyway, so it does not make much difference) and can provide immutable or mutable reference to this N.
Printer of cuda and x86 has been modified accordingly.