### PR TITLE
Do not create variables for extra dimensions when unrolling

### DIFF
--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -431,6 +431,10 @@ impl<'a> Instruction<'a> {
         &self.instantiation_dims
     }
 
+    pub fn initial_iteration_dims(&self) -> &FnvHashSet<ir::DimId> {
+        self.instruction.initial_iteration_dims()
+    }
+
     /// Indicates if the instruction performs a reduction, in wich case it returns the
     /// instruction that initializes the reduction, the `DimMap` to readh it and the
     /// reduction dimensions.

--- a/src/codegen/name_map.rs
+++ b/src/codegen/name_map.rs
@@ -269,6 +269,7 @@ impl<'a, 'b, N: Namer> NameMap<'a, 'b, N> {
         let dims = inst
             .instantiation_dims()
             .iter()
+            .filter(|&(dim, _)| inst.initial_iteration_dims().contains(dim))
             .map(|&(dim, size)| (dim, size as usize));
         let names = VariableNames::new(t, dims, self.namer);
         assert!(self.insts.insert(inst.id(), names).is_none());
@@ -427,7 +428,10 @@ impl VariableNames {
             .iter()
             .zip_eq(&self.names.dims)
             .map(|(index, size)| match index {
-                VarNameIndex::FromDim(dim) => dim_indexes.get(dim).cloned().unwrap_or(0),
+                VarNameIndex::FromDim(dim) => dim_indexes
+                    .get(dim)
+                    .cloned()
+                    .expect("missing iteration dim"),
                 VarNameIndex::Last => size - 1,
             })
             .collect_vec();


### PR DESCRIPTION
The title for this one was had to find :)

When unrolling, we are generating fresh names for the variables on each
loop iteration.  Currently, we do so for all iteration dimensions --
including those that the instruction was not actually using.  This can
happen when we decide to replicate an instruction instead of storing the
result to registers or memory.

However, this was causing an issue when an initializer was replicated in
such a way but the corresponding reduction was not (the opposite is
clearly wrong and we have constraints to prevent it from happening).  In
that case, the reduction is not nested in the replicating dimension and
hence we were storing into the variable for iteration `0` -- but
reducing by using the value computed in the last iteration of the
initializer.

This patch fixes the issue by ensuring that we do not replicate
instructions on extra dimensions added after the creation of the
function.  In addition, instead of using iteration `0` when a dimension
is not iterated over, we now panic, hopefully preventing this type of
bug from creeping in again in the future.