### PR TITLE
Save the generated code for the best candidate

### DIFF
--- a/backend/x86/src/cpu.rs
+++ b/backend/x86/src/cpu.rs
@@ -5,8 +5,11 @@ use telamon::ir::{self, Type};
 use telamon::model::{self, HwPressure};
 use telamon::search_space::*;
 
+use itertools::*;
 use std::io::Write;
 use utils::*;
+
+use crate::printer::X86printer;
 
 /// Represents CUDA GPUs.
 #[derive(Clone)]
@@ -24,8 +27,17 @@ impl Cpu {
 }
 
 impl device::Device for Cpu {
-    fn print(&self, _fun: &Function, out: &mut Write) {
-        unwrap!(write!(out, "Basic CPU"));
+    fn print(&self, fun: &Function, out: &mut Write) {
+        let mut printer = X86printer::default();
+        write!(out, "{}", printer.wrapper_function(fun)).unwrap();
+        write!(
+            out,
+            "{}",
+            fun.device_code_args()
+                .map(|x| format!("{:?}", x))
+                .format("\n")
+        )
+        .unwrap();
     }
 
     fn check_type(&self, t: Type) -> Result<(), ir::TypeError> {

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -1,4 +1,6 @@
 //! Describes a `Function` that is ready to execute on a device.
+use std::{self, fmt};
+
 use crate::codegen::{
     self, cfg, dimension, Cfg, Dimension, InductionLevel, InductionVar,
 };
@@ -10,7 +12,6 @@ use utils::*;
 use itertools::Itertools;
 use log::{debug, trace};
 use matches::matches;
-use std;
 
 /// A function ready to execute on a device, derived from a constrained IR instance.
 pub struct Function<'a> {
@@ -153,6 +154,7 @@ impl<'a> std::ops::Deref for Function<'a> {
 }
 
 /// Represents the value of a parameter passed to the kernel by the host.
+#[derive(Debug)]
 pub enum ParamVal<'a> {
     /// A parameter given by the caller.
     External(&'a ir::Parameter, ir::Type),
@@ -451,5 +453,11 @@ impl<'a> Instruction<'a> {
     /// Indicates where to store the result of the instruction.
     pub fn result_variable(&self) -> Option<ir::VarId> {
         self.instruction.result_variable()
+    }
+}
+
+impl<'a> fmt::Display for Instruction<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.instruction, fmt)
     }
 }

--- a/src/codegen/printer.rs
+++ b/src/codegen/printer.rs
@@ -227,14 +227,15 @@ pub trait Printer<N: Namer> {
     fn enable_threads(
         &mut self,
         fun: &Function,
-        threads: &[bool],
+        threads: &[Option<ir::DimId>],
         namer: &mut NameMap<N>,
     ) {
         let mut guard: Option<String> = None;
-        for (&is_active, dim) in threads.iter().zip_eq(fun.thread_dims().iter()) {
-            if is_active {
+        for (&active_dim_id, dim) in threads.iter().zip_eq(fun.thread_dims().iter()) {
+            if active_dim_id.is_some() {
                 continue;
             }
+
             let new_guard = namer.gen_name(ir::Type::I(1));
             let index = namer.name_index(dim.id());
             self.print_equals(ir::Type::I(32), &new_guard, index, &Self::get_int(0));

--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -4,19 +4,28 @@
 
 extern crate toml;
 
+use std::fs::File;
+use std::io::{self, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::{self, error, fmt, str::FromStr};
+
 use config;
 use getopts;
 use itertools::Itertools;
 use num_cpus;
 use serde::{Deserialize, Serialize};
-use std::{self, error, fmt, str::FromStr};
-use utils::unwrap;
+use utils::{tfrecord, unwrap};
+
+use crate::explorer::eventlog::EventLog;
 
 /// Stores the configuration of the exploration.
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(default)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
+    /// Path to the output directory to use.  All other paths (e.g. `log_file`) are relative to
+    /// this directory.  Defaults to the current working directory.
+    pub output_dir: String,
     /// Name of the file in wich to store the logs.
     pub log_file: String,
     /// Name of the file in which to store the binary event log.
@@ -117,6 +126,23 @@ impl Config {
         }
         SearchAlgorithm::parse_arguments(arguments, config);
     }
+
+    pub fn output_path<P: AsRef<Path>>(&self, path: P) -> io::Result<PathBuf> {
+        let output_dir = Path::new(&self.output_dir);
+        // Ensure the output directory exists
+        std::fs::create_dir_all(output_dir)?;
+        Ok(output_dir.join(path))
+    }
+
+    pub fn create_log(&self) -> io::Result<BufWriter<File>> {
+        let mut f = File::create(self.output_path(&self.log_file)?)?;
+        writeln!(f, "LOGGER\n{}", self)?;
+        Ok(BufWriter::new(f))
+    }
+
+    pub fn create_eventlog(&self) -> io::Result<tfrecord::Writer<EventLog>> {
+        EventLog::create(self.output_path(&self.event_log)?)
+    }
 }
 
 impl fmt::Display for Config {
@@ -128,8 +154,9 @@ impl fmt::Display for Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            log_file: String::from("watch.log"),
-            event_log: String::from("eventlog.tfrecord.gz"),
+            output_dir: ".".to_string(),
+            log_file: "watch.log".to_string(),
+            event_log: "eventlog.tfrecord.gz".to_string(),
             num_workers: num_cpus::get(),
             algorithm: SearchAlgorithm::default(),
             stop_bound: None,

--- a/src/explorer/mod.rs
+++ b/src/explorer/mod.rs
@@ -253,10 +253,19 @@ fn launch_search<'a, T: Store<'a>>(
 ) -> Option<Candidate<'a>> {
     let (monitor_sender, monitor_receiver) = channel::mpsc::channel(100);
     let maybe_candidate = crossbeam::scope(|scope| {
-        let best_cand_opt = scope
-            .builder()
-            .name("Telamon - Monitor".to_string())
-            .spawn(|| monitor(config, &candidate_store, monitor_receiver, log_sender));
+        let best_cand_opt =
+            scope
+                .builder()
+                .name("Telamon - Monitor".to_string())
+                .spawn(|| {
+                    monitor(
+                        config,
+                        context,
+                        &candidate_store,
+                        monitor_receiver,
+                        log_sender,
+                    )
+                });
         explore_space(config, &candidate_store, monitor_sender, context);
         unwrap!(best_cand_opt)
     })

--- a/src/ir/dim_map.rs
+++ b/src/ir/dim_map.rs
@@ -1,4 +1,7 @@
+use std::fmt;
+
 use crate::ir;
+use itertools::Itertools;
 use linked_list;
 use linked_list::LinkedList;
 use utils::*;
@@ -75,5 +78,18 @@ impl<'a> IntoIterator for &'a DimMap {
 
     fn into_iter(self) -> Self::IntoIter {
         self.map.iter()
+    }
+}
+
+impl fmt::Display for DimMap {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "[{}]",
+            self.map
+                .iter()
+                .map(|(lhs, rhs)| format!("{} = {}", lhs, rhs))
+                .format(", ")
+        )
     }
 }

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -1,11 +1,12 @@
 //! Provides a representation of functions.
+use std::{self, fmt};
+
 use crate::device::Device;
 use crate::ir::{self, Dimension, InstId, Instruction, Operator, Statement, StmtId};
 use crate::ir::{mem, AccessPattern, Operand, SparseVec};
 use crate::search_space::MemSpace;
 use itertools::Itertools;
 use log::debug;
-use std;
 use utils::*;
 
 /// Represents an argument of a function.
@@ -17,6 +18,12 @@ pub struct Parameter {
     pub t: ir::Type,
     /// If the parameter point to an array, indicates the element type.
     pub elem_t: Option<ir::Type>,
+}
+
+impl fmt::Display for Parameter {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.name)
+    }
 }
 
 /// Holds the signature of a function.

--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -246,3 +246,9 @@ impl<'a, L> Statement<'a, L> for Instruction<'a, L> {
         self.defined_vars.insert(var);
     }
 }
+
+impl<'a, L> fmt::Display for Instruction<'a, L> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{:?}:  {}", self.id, self.operator)
+    }
+}

--- a/src/ir/mem.rs
+++ b/src/ir/mem.rs
@@ -1,4 +1,6 @@
 //! A module for handling accesses to the device memory.
+use std::fmt;
+
 use crate::ir::{self, dim, InstId, Type};
 
 use serde::{Deserialize, Serialize};
@@ -14,6 +16,12 @@ pub struct MemId(pub u32);
 impl From<MemId> for usize {
     fn from(id: MemId) -> usize {
         id.0 as usize
+    }
+}
+
+impl fmt::Display for MemId {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(fmt, "#{}", self.0)
     }
 }
 

--- a/src/ir/operand.rs
+++ b/src/ir/operand.rs
@@ -1,4 +1,6 @@
 //! Describes the different kinds of operands an instruction can have.
+use std::fmt;
+
 use self::Operand::*;
 use crate::ir::{self, DimMap, InstId, Instruction, Parameter, Type};
 use num::bigint::BigInt;
@@ -234,6 +236,24 @@ impl<'a> Operand<'a, ()> {
             Addr(id) => Addr(id),
             Reduce(id, t, dim_map, dims) => Reduce(id, t, dim_map, dims),
             InductionVar(id, t) => InductionVar(id, t),
+        }
+    }
+}
+
+impl<'a, L> fmt::Display for Operand<'a, L> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Int(val, len) => write!(fmt, "{}u{}", val, len),
+            Float(val, len) => write!(fmt, "{}f{}", val, len),
+            Inst(id, t, dim_map, scope) => write!(fmt, "{:?} [{}]", id, dim_map),
+            Index(id) => write!(fmt, "{}", id),
+            Param(param) => write!(fmt, "{}", param),
+            Addr(id) => write!(fmt, "({})", id),
+            Reduce(id, t, dim_map, dims) => {
+                write!(fmt, "reduce({:?}, {:?}) [{}]", id, dims, dim_map)
+            }
+            InductionVar(id, t) => write!(fmt, "ind"),
+            Variable(var, t) => write!(fmt, "({}){}", t, var),
         }
     }
 }

--- a/src/ir/variable.rs
+++ b/src/ir/variable.rs
@@ -1,4 +1,6 @@
 //! Encodes the data-flow information.
+use std::fmt;
+
 use crate::ir;
 
 use serde::{Deserialize, Serialize};
@@ -14,6 +16,12 @@ pub struct VarId(pub u16);
 impl From<VarId> for usize {
     fn from(val_id: VarId) -> Self {
         val_id.0 as usize
+    }
+}
+
+impl fmt::Display for VarId {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "${}", self.0)
     }
 }
 


### PR DESCRIPTION
Whenever a new best candidate is found, we generate the following files
in the output directory (`XXX` is a number incremented upon each
successful evaluation, as used in `watch.log`):

 - `best_XXX.c` contains the generated code, including wrapper calls

 - `best_XXX.cfg` contains the Cfg of the candidate and provides a
   higher-level description of what the generated code does (or should
   be doing).

This patch also includes various improvement to the Cfg pretty-printing to make it more readable and more useful in debugging situations.