### PR TITLE
Remove lifetime in Candidate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ linked-list = "0.0.3"
 log = "0.4.1"
 matches = "0.1.6"
 ndarray = "0.11.2"
-num = "0.2.0"
+num = { version = "0.2.0", features = ["serde"] }
 num_cpus = "1.8.0"
 parking_lot = "0.5.5"
 pbr = "1.0.0"
@@ -58,8 +58,7 @@ rand = "0.5.5"
 rayon = "1.0.1"
 regex = "0.2.10"
 rpds = { version = "0.5.0", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0.22"
 serde_yaml = "0.8"
 structopt = "0.2"

--- a/backend/cuda/benches/model/main.rs
+++ b/backend/cuda/benches/model/main.rs
@@ -50,7 +50,7 @@ fn run<T: PerfModelTest>(pattern: &Regex) {
         T::gen_signature(&mut base_builder);
         base_builder.get()
     };
-    let mut builder = helper::Builder::new(&base, context.device());
+    let mut builder = helper::Builder::new(base.into(), context.device());
     let state = T::gen_function(&mut builder);
     let actions = T::get_actions(&state);
 

--- a/backend/cuda/src/characterize/instruction.rs
+++ b/backend/cuda/src/characterize/instruction.rs
@@ -1,4 +1,6 @@
 //! Microbenchmarks to get the description of each instruction.
+use std::sync::Arc;
+
 use crate::characterize::{create_table, gen, math, Table};
 use crate::{Context, Executor, Gpu, InstDesc, Kernel, PerfCounter};
 use itertools::Itertools;
@@ -23,7 +25,7 @@ where
     T: ScalarArgument + Zero,
 {
     let args = [("n", ir::Type::I(32)), ("arg", T::t())];
-    let base = gen::base(&args, &["out"], gpu);
+    let base = Arc::new(gen::base(&args, &["out"], gpu));
 
     let mut table = create_table(&["n"], counters_list);
     let mut context = Context::from_gpu(gpu.clone(), executor);
@@ -33,8 +35,15 @@ where
     let counters = executor.create_perf_counter_set(counters_list);
     let n_size = DimSize::new_param("n", n as u32);
     for &n_chained in range {
-        let fun =
-            gen::inst_chain::<T>(&base, gpu, inst_gen, &n_size, n_chained, "arg", "out");
+        let fun = gen::inst_chain::<T>(
+            Arc::clone(&base),
+            Arc::<Gpu>::clone(context.gpu()),
+            inst_gen,
+            &n_size,
+            n_chained,
+            "arg",
+            "out",
+        );
         let entry = [u64::from(n_chained)];
         gen::run(&mut context, &fun, &[], &counters, &entry, &mut table);
     }
@@ -165,9 +174,14 @@ fn load(gpu: &Gpu, executor: &Executor, stride: u32, num_load: u32) -> f64 {
 
     let array_size = std::cmp::max(num_load * stride, 1) as usize;
 
-    let init_base = gen::base(&[], &["array"], gpu);
-    let init_fun =
-        gen::init_stride_array(&init_base, gpu, "array", num_load, stride as i32);
+    let init_base = Arc::new(gen::base(&[], &["array"], gpu));
+    let init_fun = gen::init_stride_array(
+        Arc::clone(&init_base),
+        Arc::new(gpu.clone()),
+        "array",
+        num_load,
+        stride as i32,
+    );
     let init_dev_fun = codegen::Function::build(&init_fun);
     let init_dev_kernel = Kernel::compile(&init_dev_fun, gpu, executor, 1);
 
@@ -179,12 +193,20 @@ fn load(gpu: &Gpu, executor: &Executor, stride: u32, num_load: u32) -> f64 {
     let counters = executor.create_perf_counter_set(&perf_counters);
     let mut table = create_table(&["chain"], &perf_counters);
 
-    let base = gen::base(&[("n", ir::Type::I(32))], &["array", "out"], gpu);
+    let base = Arc::new(gen::base(&[("n", ir::Type::I(32))], &["array", "out"], gpu));
     gen::bind_scalar("n", n as i32, &mut context);
     gen::bind_array::<i64>("out", 1, &mut context);
     let n_size = DimSize::new_param("n", n);
     for &n_chained in &n_chained_range {
-        let fun = gen::load_chain(&base, gpu, 1, &n_size, n_chained, "array", "out");
+        let fun = gen::load_chain(
+            Arc::clone(&base),
+            Arc::<Gpu>::clone(context.gpu()),
+            1,
+            &n_size,
+            n_chained,
+            "array",
+            "out",
+        );
         let prefix = [u64::from(n_chained)];
         gen::run(&mut context, &fun, &[], &counters, &prefix, &mut table);
     }
@@ -220,13 +242,20 @@ pub fn load_shared(gpu: &Gpu, executor: &Executor) -> f64 {
     let counters = executor.create_perf_counter_set(&perf_counters);
     let mut table = create_table(&["chain"], &perf_counters);
 
-    let base = gen::base(&[("n_iter", ir::Type::I(32))], &["out"], gpu);
+    let base = Arc::new(gen::base(&[("n_iter", ir::Type::I(32))], &["out"], gpu));
     let mut context = Context::from_gpu(gpu.clone(), executor);
     gen::bind_scalar("n_iter", n_iter, &mut context);
     gen::bind_array::<i64>("out", 1, &mut context);
     let n_size = DimSize::new_param("n_iter", n_iter as u32);
     for &n_chained in &n_chained_range {
-        let fun = gen::shared_load_chain(&base, gpu, &n_size, n_chained, 32, "out");
+        let fun = gen::shared_load_chain(
+            Arc::clone(&base),
+            Arc::<Gpu>::clone(context.gpu()),
+            &n_size,
+            n_chained,
+            32,
+            "out",
+        );
         let prefix = [u64::from(n_chained)];
         gen::run(&mut context, &fun, &[], &counters, &prefix, &mut table);
     }
@@ -350,7 +379,7 @@ pub fn smx_bandwidth(
     let mut table = create_table(&["wraps", "stride", "blocks", "n"], &perf_counters);
     // Setup the context
     let scalar_args = [("blocks", ir::Type::I(32)), ("n", ir::Type::I(32))];
-    let base = gen::base(&scalar_args, &["array", "out"], gpu);
+    let base = Arc::new(gen::base(&scalar_args, &["array", "out"], gpu));
     let mut context = Context::from_gpu(gpu.clone(), executor);
     gen::bind_array::<f32>("array", array_size as usize, &mut context);
     gen::bind_array::<f32>("out", 1, &mut context);
@@ -361,8 +390,8 @@ pub fn smx_bandwidth(
         assert!(num_wraps <= MAX_WRAPS);
         for &stride in strides {
             let fun = gen::parallel_load(
-                &base,
-                gpu,
+                Arc::clone(&base),
+                Arc::<Gpu>::clone(context.gpu()),
                 &block_size,
                 &n_size,
                 chained,
@@ -400,7 +429,7 @@ pub fn smx_store_bandwidth(
     let mut table = create_table(&["wraps", "stride", "blocks", "n"], &perf_counters);
     // Setup the context
     let scalar_args = [("blocks", ir::Type::I(32)), ("n", ir::Type::I(32))];
-    let base = gen::base(&scalar_args, &["array"], gpu);
+    let base = Arc::new(gen::base(&scalar_args, &["array"], gpu));
     let mut context = Context::from_gpu(gpu.clone(), executor);
     gen::bind_array::<f32>("array", array_size as usize, &mut context);
     // Fill the table
@@ -410,8 +439,8 @@ pub fn smx_store_bandwidth(
         assert!(num_wraps <= MAX_WRAPS);
         for &stride in strides {
             let fun = gen::parallel_store(
-                &base,
-                gpu,
+                Arc::clone(&base),
+                Arc::<Gpu>::clone(context.gpu()),
                 &block_size,
                 &n_size,
                 chained,
@@ -441,14 +470,20 @@ pub fn print_load_in_loop(gpu: &Gpu, executor: &Executor) {
     let mut table = create_table(&["threads"], &perf_counters);
     // Setup the context.
     let scalar_args = [("k", ir::Type::I(32))];
-    let base = gen::base(&scalar_args, &["out"], gpu);
+    let base = Arc::new(gen::base(&scalar_args, &["out"], gpu));
     let mut context = Context::from_gpu(gpu.clone(), executor);
     gen::bind_scalar("k", K, &mut context);
     gen::bind_array::<f32>("out", 32 * 4 * 4, &mut context);
     // Fill the table
     let k_size = DimSize::new_param("k", K as u32);
     for &num_threads in &[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024] {
-        let fun = gen::load_in_loop(&base, gpu, &k_size, num_threads, "out");
+        let fun = gen::load_in_loop(
+            Arc::clone(&base),
+            Arc::<Gpu>::clone(context.gpu()),
+            &k_size,
+            num_threads,
+            "out",
+        );
         let num_threads = u64::from(num_threads);
         gen::run(
             &mut context,
@@ -491,7 +526,7 @@ pub fn syncthread(gpu: &Gpu, executor: &Executor) -> InstDesc {
     // Set parameters
     let n = 1000;
     let chained_range = (10..129).collect_vec();
-    let base = gen::base(&[("n", ir::Type::I(32))], &[], gpu);
+    let base = Arc::new(gen::base(&[("n", ir::Type::I(32))], &[], gpu));
     // Setup the execution context
     let mut context = Context::from_gpu(gpu.clone(), executor);
     gen::bind_scalar("n", n as i32, &mut context);
@@ -500,7 +535,13 @@ pub fn syncthread(gpu: &Gpu, executor: &Executor) -> InstDesc {
     let counters = executor.create_perf_counter_set(&perf_counters);
     let n_size = DimSize::new_param("n", n as u32);
     for &n_chained in &chained_range {
-        let fun = gen::syncthread(&base, gpu, &n_size, n_chained, 32);
+        let fun = gen::syncthread(
+            Arc::clone(&base),
+            Arc::<Gpu>::clone(context.gpu()),
+            &n_size,
+            n_chained,
+            32,
+        );
         let entry = [u64::from(n_chained)];
         gen::run(&mut context, &fun, &[], &counters, &entry, &mut table);
     }
@@ -535,13 +576,22 @@ pub fn loop_iter_overhead(gpu: &Gpu, executor: &Executor) -> InstDesc {
     let counters = executor.create_perf_counter_set(&perf_counters);
     let mut table = create_table(&["n"], &perf_counters);
     // Setup the context
-    let base = gen::base(&[("m", ir::Type::I(32)), ("n", ir::Type::I(32))], &[], gpu);
+    let base = Arc::new(gen::base(
+        &[("m", ir::Type::I(32)), ("n", ir::Type::I(32))],
+        &[],
+        gpu,
+    ));
     let mut context = Context::from_gpu(gpu.clone(), executor);
     gen::bind_scalar("m", M as i32, &mut context);
     // Fill the table
     let n_size = DimSize::new_param("n", *unwrap!(n_range.last()) as u32);
     let m_size = DimSize::new_param("m", M);
-    let fun = gen::two_empty_loops(&base, gpu, &m_size, &n_size);
+    let fun = gen::two_empty_loops(
+        Arc::clone(&base),
+        Arc::<Gpu>::clone(context.gpu()),
+        &m_size,
+        &n_size,
+    );
     gen::run(
         &mut context,
         &fun,
@@ -582,12 +632,18 @@ pub fn loop_iter_end_latency(gpu: &Gpu, executor: &Executor, add_latency: f64) -
     let counters = executor.create_perf_counter_set(&perf_counters);
     let mut table = create_table(&["n"], &perf_counters);
     // Setup the context.
-    let base = gen::base(&[("n", ir::Type::I(32))], &["out"], gpu);
+    let base = Arc::new(gen::base(&[("n", ir::Type::I(32))], &["out"], gpu));
     let mut context = Context::from_gpu(gpu.clone(), executor);
     gen::bind_array::<f32>("out", 1, &mut context);
     // Fill the table.
     let n_size = DimSize::new_param("n", *unwrap!(n_range.last()) as u32);
-    let fun = gen::loop_chained_adds(&base, gpu, &n_size, 10, "out");
+    let fun = gen::loop_chained_adds(
+        Arc::clone(&base),
+        Arc::<Gpu>::clone(context.gpu()),
+        &n_size,
+        10,
+        "out",
+    );
     gen::run(
         &mut context,
         &fun,
@@ -620,14 +676,22 @@ pub fn syncthread_end_latency(gpu: &Gpu, executor: &Executor, add_latency: f64) 
     let counters = executor.create_perf_counter_set(&perf_counters);
     let mut table = create_table(&["chained"], &perf_counters);
     // Setup the context.
-    let base = gen::base(&[("n", ir::Type::I(32))], &["out"], gpu);
+    let base = Arc::new(gen::base(&[("n", ir::Type::I(32))], &["out"], gpu));
     let mut context = Context::from_gpu(gpu.clone(), executor);
     gen::bind_scalar("n", N, &mut context);
     gen::bind_array::<f32>("out", 1, &mut context);
     // Fill the table.
     let n_size = DimSize::new_param("n", N as u32);
     for &n_chained in &chained_range {
-        let fun = gen::chain_in_syncthread(&base, gpu, &n_size, n_chained, 10, 32, "out");
+        let fun = gen::chain_in_syncthread(
+            Arc::clone(&base),
+            Arc::<Gpu>::clone(context.gpu()),
+            &n_size,
+            n_chained,
+            10,
+            32,
+            "out",
+        );
         let entry = [u64::from(n_chained)];
         gen::run(&mut context, &fun, &[], &counters, &entry, &mut table);
     }

--- a/backend/cuda/src/kernel.rs
+++ b/backend/cuda/src/kernel.rs
@@ -54,14 +54,14 @@ impl<'a, 'b> Kernel<'a, 'b> {
 
     /// Runs a kernel and returns the number of cycles it takes to execute in cycles.
     pub fn evaluate(&self, args: &Context) -> Result<u64, ()> {
-        let cuda_kernel = self.module.kernel(&self.function.name);
+        let cuda_kernel = self.module.kernel(self.function.name());
         self.gen_args(args).execute(&cuda_kernel, self.executor)
     }
 
     /// Runs a kernel and returns the number of cycles it takes to execute in nanoseconds,
     /// measured using cuda event rather than hardware counters.
     pub fn evaluate_real(&self, args: &Context, num_samples: usize) -> Vec<f64> {
-        let cuda_kernel = self.module.kernel(&self.function.name);
+        let cuda_kernel = self.module.kernel(self.function.name());
         self.gen_args(args)
             .time_in_real_conds(&cuda_kernel, num_samples, self.executor)
     }
@@ -69,7 +69,7 @@ impl<'a, 'b> Kernel<'a, 'b> {
     /// Instruments the kernel with the given performance counters.
     #[cfg(feature = "real_gpu")]
     pub fn instrument(&self, args: &Context, counters: &PerfCounterSet) -> Vec<u64> {
-        let cuda_kernel = self.module.kernel(&self.function.name);
+        let cuda_kernel = self.module.kernel(self.function.name());
         self.gen_args(args)
             .instrument(&cuda_kernel, counters, self.executor)
     }
@@ -78,7 +78,7 @@ impl<'a, 'b> Kernel<'a, 'b> {
     pub fn gen_thunk(self, args: &'a Context) -> Thunk<'a> {
         let args = self.gen_args(args);
         Thunk {
-            name: self.function.name.clone(),
+            name: self.function.name().to_string(),
             module: self.module,
             executor: self.executor,
             ptx: self.ptx,

--- a/backend/cuda/src/printer.rs
+++ b/backend/cuda/src/printer.rs
@@ -265,7 +265,7 @@ impl CudaPrinter {
             sm_major = gpu.sm_major,
             sm_minor = gpu.sm_minor,
             addr_size = gpu.addr_size,
-            name = function.name,
+            name = function.name(),
             params = param_decls,
             num_thread = function.num_threads(),
             body = body
@@ -276,6 +276,9 @@ impl CudaPrinter {
         let block_sizes = Self::host_3sizes(fun.block_dims().iter());
         let thread_sizes = Self::host_3sizes(fun.thread_dims().iter().rev());
         let extern_param_names = fun
+            .space()
+            .ir_instance()
+            .signature()
             .params
             .iter()
             .map(|x| &x.name as &str)
@@ -314,6 +317,9 @@ impl CudaPrinter {
             .collect_vec()
             .join(", ");
         let extern_params = fun
+            .space()
+            .ir_instance()
+            .signature()
             .params
             .iter()
             .map(|p| format!("{} {}", Self::host_type(p.t), p.name))
@@ -322,7 +328,7 @@ impl CudaPrinter {
         let res = write!(
             out,
             include_str!("template/host.c"),
-            name = fun.name,
+            name = fun.name(),
             ptx_code = self.function(fun, gpu).replace("\n", "\\n\\\n"),
             extern_params = extern_params,
             extern_param_names = extern_param_names,

--- a/backend/x86/src/printer.rs
+++ b/backend/x86/src/printer.rs
@@ -94,12 +94,12 @@ impl X86printer {
         let mut return_string = if function.device_code_args().count() == 0 {
             format!(
                 include_str!("template/signature_no_arg.c.template"),
-                name = function.name,
+                name = function.name(),
             )
         } else {
             format!(
                 include_str!("template/signature.c.template"),
-                name = function.name,
+                name = function.name(),
                 params = param_decls
             )
         };
@@ -325,7 +325,7 @@ impl X86printer {
         if func.device_code_args().count() == 0 {
             format!(
                 include_str!("template/host_no_arg.c.template"),
-                fun_name = func.name,
+                fun_name = func.name(),
                 fun_str = fun_str,
                 gen_threads = self.thread_gen(func),
                 dim_decl = self.build_thread_id_struct(func),
@@ -335,7 +335,7 @@ impl X86printer {
             let fun_params = self.params_call(func);
             format!(
                 include_str!("template/host.c.template"),
-                fun_name = func.name,
+                fun_name = func.name(),
                 fun_str = fun_str,
                 fun_params_cast = self.fun_params_cast(func),
                 fun_params = fun_params,

--- a/examples/matmul.rs
+++ b/examples/matmul.rs
@@ -40,7 +40,7 @@ fn main() {
     };
 
     // Step 2. Define the kernel body
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     // Define te tiling factors for dimensions `m`, `n` and `k`.
     let m_tiling = helper::TilingPattern::new_fixed(&[32, 4]);
     let n_tiling = helper::TilingPattern::new_fixed(&[32, 4]);

--- a/kernels/benches/cuda_search.rs
+++ b/kernels/benches/cuda_search.rs
@@ -11,6 +11,13 @@ fn main() {
     env_logger::init();
     let executor = cuda::Executor::init();
     let cublas_handle = CublasHandle::new();
+
+    let params = linalg::MatMulP::new(256, 256, 256);
+    benchmark::<linalg::MatMul<f32>, _>(params, &executor, |params, ctx| {
+        matmul_reference(&cublas_handle, params, ctx)
+    });
+
+    /*
     // 1.5
     benchmark::<linalg::Axpy<f32>, _>((1 << 25, true), &executor, |params, ctx| {
         saxpy_reference(&cublas_handle, params, ctx)
@@ -75,6 +82,7 @@ fn main() {
     // FIXME: add more input sizes for benchmarks
     // - non-powers of 2
     // - repeat B
+    // */
 }
 
 /// The number of times to run the generated code to evaluate its performance.

--- a/kernels/benches/cuda_variance.rs
+++ b/kernels/benches/cuda_variance.rs
@@ -43,7 +43,7 @@ where
     let (signature, kernel, context) = KernelBuilder::default()
         .name(name)
         .build::<K, cuda::Context>(params.clone(), &mut context);
-    let candidates = kernel.build_body(&signature, context);
+    let candidates = kernel.build_body(signature.into(), context);
     let candidates = std::iter::repeat(())
         .flat_map(|()| {
             let order = explorer::config::NewNodeOrder::WeightedRandom;

--- a/kernels/src/lib.rs
+++ b/kernels/src/lib.rs
@@ -18,10 +18,10 @@ use telamon::{explorer, model, search_space};
 use ::ndarray::{ArrayBase, Data, Dimension, FoldWhile, Zip};
 
 /// Creates a candidate from the search space and registers the tile sizes in it.
-fn build_candidate<'a>(
-    space: search_space::SearchSpace<'a>,
+fn build_candidate(
+    space: search_space::SearchSpace,
     ctx: &dyn device::Context,
-) -> explorer::Candidate<'a> {
+) -> explorer::Candidate {
     let bound = model::bound(&space, ctx);
     explorer::Candidate::new(space, bound)
 }

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -224,7 +224,7 @@ impl<'a> fmt::Debug for Cfg<'a> {
 /// Builds the CFG from the list of dimensions and instructions. Also returns the list of
 /// thread and block dimensions.
 pub fn build<'a>(
-    space: &'a SearchSpace<'a>,
+    space: &'a SearchSpace,
     insts: Vec<Instruction<'a>>,
     dims: Vec<Dimension<'a>>,
 ) -> (Vec<Dimension<'a>>, Vec<Dimension<'a>>, Cfg<'a>) {
@@ -316,7 +316,7 @@ impl<'a> fmt::Debug for CfgEvent<'a> {
 
 /// Generates the list of `CfgEvent`s and the list of block and thread dimensions.
 fn gen_events<'a>(
-    space: &'a SearchSpace<'a>,
+    space: &'a SearchSpace,
     insts: Vec<Instruction<'a>>,
     dims: Vec<Dimension<'a>>,
 ) -> (Vec<Dimension<'a>>, Vec<Dimension<'a>>, Vec<CfgEvent<'a>>) {

--- a/src/codegen/dimension.rs
+++ b/src/codegen/dimension.rs
@@ -72,7 +72,7 @@ impl<'a> Dimension<'a> {
     }
 
     /// Creates a new dimension from an `ir::Dimension`.
-    fn new(dim: &'a ir::Dimension<'a>, space: &SearchSpace) -> Self {
+    fn new(dim: &'a ir::Dimension, space: &SearchSpace) -> Self {
         let kind = space.domain().get_dim_kind(dim.id());
         assert!(kind.is_constrained());
         Dimension {
@@ -108,7 +108,7 @@ impl<'a> Dimension<'a> {
 }
 
 /// Creates the final list of dimensions by grouping fused `ir::Dimension`.
-pub fn group_merged_dimensions<'a>(space: &'a SearchSpace<'a>) -> Vec<Dimension<'a>> {
+pub fn group_merged_dimensions<'a>(space: &'a SearchSpace) -> Vec<Dimension<'a>> {
     let mut groups: Vec<Dimension> = Vec::new();
     'dim: for dim in space.ir_instance().dims() {
         for group in &mut groups {
@@ -170,7 +170,7 @@ impl<'a> InductionVar<'a> {
 pub struct InductionVarValue<'a> {
     ind_var: ir::IndVarId,
     outer_level: Option<ir::DimId>,
-    operand: Option<&'a ir::Operand<'a>>,
+    operand: Option<&'a ir::Operand>,
     t: ir::Type,
 }
 
@@ -190,11 +190,7 @@ impl<'a> InductionVarValue<'a> {
     }
 
     /// Returns and induction var value that just contains an operand.
-    fn new(
-        ind_var: ir::IndVarId,
-        operand: &'a ir::Operand<'a>,
-        space: &SearchSpace,
-    ) -> Self {
+    fn new(ind_var: ir::IndVarId, operand: &'a ir::Operand, space: &SearchSpace) -> Self {
         let t = unwrap!(space.ir_instance().device().lower_type(operand.t(), space));
         InductionVarValue {
             ind_var,
@@ -243,7 +239,7 @@ impl<'a> InductionVarValue<'a> {
 /// kernel.
 pub fn register_induction_vars<'a>(
     dims: &mut Vec<Dimension<'a>>,
-    space: &'a SearchSpace<'a>,
+    space: &'a SearchSpace,
 ) -> (Vec<InductionVar<'a>>, Vec<InductionLevel<'a>>) {
     let mut ind_levels_map = FnvMultiHashMap::default();
     let mut ind_vars = Vec::new();
@@ -305,7 +301,7 @@ type IndVarIncrement<'a> = (ir::DimId, codegen::Size<'a>);
 /// thread and the induction levels that are updated during loops. Both lists are sorted
 /// in the order in which levels should be computed.
 fn get_ind_var_levels<'a>(
-    ind_var: &'a ir::InductionVar<'a>,
+    ind_var: &'a ir::InductionVar,
     space: &SearchSpace,
 ) -> (Vec<IndVarIncrement<'a>>, Vec<IndVarIncrement<'a>>) {
     let (mut const_levels, mut mut_levels) = (Vec::new(), Vec::new());

--- a/src/codegen/size.rs
+++ b/src/codegen/size.rs
@@ -28,7 +28,7 @@ impl<'a> Size<'a> {
     }
 
     /// Converts an `ir::Size` to `Self`.
-    pub fn from_ir(size: &ir::PartialSize<'a>, space: &SearchSpace) -> Self {
+    pub fn from_ir(size: &'a ir::PartialSize, space: &SearchSpace) -> Self {
         let (cst_factor, param_factors, dim_size_factors) = size.factors();
         let dim_size_divisors = size.divisors();
         let factor = cst_factor
@@ -40,7 +40,11 @@ impl<'a> Size<'a> {
             .iter()
             .map(|&d| dim_size(d, space))
             .product();
-        Size::new(factor, param_factors.to_vec(), divisor)
+        Size::new(
+            factor,
+            param_factors.into_iter().map(|p| &**p).collect(),
+            divisor,
+        )
     }
 
     /// Returns the size of a dimension if it is staticaly known.

--- a/src/codegen/variable.rs
+++ b/src/codegen/variable.rs
@@ -195,6 +195,7 @@ pub fn wrap_variables<'a>(space: &'a SearchSpace) -> Vec<Variable<'a>> {
 #[cfg(test)]
 mod tests {
     use std;
+    use std::sync::Arc;
 
     use crate::device::fake;
     use crate::helper;
@@ -213,9 +214,9 @@ mod tests {
     #[test]
     fn chained_alias() {
         let _ = ::env_logger::try_init();
-        let device = fake::Device::default();
-        let signature = ir::Signature::new("test".to_string());
-        let mut builder = helper::Builder::new(&signature, &device);
+        let device = Arc::new(fake::Device::default());
+        let signature = Arc::new(ir::Signature::new("test".to_string()));
+        let mut builder = helper::Builder::new(signature, device);
         // This code builds the following function:
         // ```pseudocode
         // for i in 0..16:

--- a/src/device/argument.rs
+++ b/src/device/argument.rs
@@ -31,7 +31,7 @@ pub unsafe trait ScalarArgument:
     fn raw_ptr(&self) -> *const libc::c_void;
 
     /// Returns an operand holding the argument value as a constant.
-    fn as_operand<L>(&self) -> ir::Operand<'static, L>
+    fn as_operand<L>(&self) -> ir::Operand<L>
     where
         Self: Sized;
 
@@ -65,7 +65,7 @@ macro_rules! float_scalar_argument {
                 self as *const $ty as *const libc::c_void
             }
 
-            fn as_operand<L>(&self) -> ir::Operand<'static, L> {
+            fn as_operand<L>(&self) -> ir::Operand<L> {
                 ir::Operand::new_float(unwrap!(Ratio::from_float(*self)), size_bits!($ty))
             }
 
@@ -104,7 +104,7 @@ macro_rules! int_scalar_argument {
                 self as *const $ty as *const libc::c_void
             }
 
-            fn as_operand<L>(&self) -> ir::Operand<'static, L> {
+            fn as_operand<L>(&self) -> ir::Operand<L> {
                 ir::Operand::new_int((*self).into(), size_bits!($ty))
             }
 

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -19,7 +19,7 @@ use utils::*;
 
 /// Holds the specifications of a target.
 #[allow(clippy::trivially_copy_pass_by_ref)]
-pub trait Device: Sync {
+pub trait Device: Send + Sync + 'static {
     /// Prints the code corresponding to a device `Function`.
     fn print(&self, function: &Function, out: &mut dyn Write);
     /// Indicates if a `Type` can be implemented on the device.

--- a/src/explorer/candidate.rs
+++ b/src/explorer/candidate.rs
@@ -16,9 +16,9 @@ use utils::unwrap;
 
 /// A node of the search tree.
 #[derive(Clone)]
-pub struct Candidate<'a> {
+pub struct Candidate {
     /// Represents a part of the full search space.
-    pub space: SearchSpace<'a>,
+    pub space: SearchSpace,
     /// Gives a lower bound in nanoseconds on the execution time of `fun`.
     pub bound: Bound,
     /// The depth of the candidate in the search tree.
@@ -27,13 +27,13 @@ pub struct Candidate<'a> {
     pub actions: List<ActionEx>,
 }
 
-impl<'a> Candidate<'a> {
+impl Candidate {
     /// Creates a new candidate, with depth 0.
-    pub fn new(space: SearchSpace<'a>, bound: Bound) -> Self {
+    pub fn new(space: SearchSpace, bound: Bound) -> Self {
         Self::with_actions(space, bound, std::iter::empty())
     }
 
-    pub fn with_actions<II>(space: SearchSpace<'a>, bound: Bound, actions: II) -> Self
+    pub fn with_actions<II>(space: SearchSpace, bound: Bound, actions: II) -> Self
     where
         II: IntoIterator<Item = ActionEx>,
     {
@@ -51,7 +51,7 @@ impl<'a> Candidate<'a> {
         &self,
         context: &dyn Context,
         choice: Vec<ActionEx>,
-    ) -> Vec<Candidate<'a>> {
+    ) -> Vec<Candidate> {
         let res = choice
             .into_iter()
             .flat_map(|action| {
@@ -129,7 +129,7 @@ impl<'a> Candidate<'a> {
     }
 }
 
-impl<'a> std::fmt::Display for Candidate<'a> {
+impl std::fmt::Display for Candidate {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         writeln!(
             f,
@@ -143,22 +143,22 @@ impl<'a> std::fmt::Display for Candidate<'a> {
     }
 }
 
-impl<'a> PartialEq for Candidate<'a> {
-    fn eq(&self, rhs: &Candidate<'a>) -> bool {
+impl PartialEq for Candidate {
+    fn eq(&self, rhs: &Candidate) -> bool {
         self.bound == rhs.bound
     }
 }
 
-impl<'a> Eq for Candidate<'a> {}
+impl Eq for Candidate {}
 
-impl<'a> PartialOrd for Candidate<'a> {
-    fn partial_cmp(&self, rhs: &Candidate<'a>) -> Option<Ordering> {
+impl PartialOrd for Candidate {
+    fn partial_cmp(&self, rhs: &Candidate) -> Option<Ordering> {
         self.bound.partial_cmp(&rhs.bound)
     }
 }
 
-impl<'a> Ord for Candidate<'a> {
-    fn cmp(&self, rhs: &Candidate<'a>) -> Ordering {
+impl Ord for Candidate {
+    fn cmp(&self, rhs: &Candidate) -> Ordering {
         unwrap!(self.partial_cmp(rhs))
     }
 }

--- a/src/explorer/choice.rs
+++ b/src/explorer/choice.rs
@@ -95,7 +95,7 @@ where
 
 pub fn list<'a>(
     iter_choice: impl IntoIterator<Item = &'a config::ChoiceGroup> + 'a,
-    space: &'a SearchSpace<'a>,
+    space: &'a SearchSpace,
 ) -> impl Iterator<Item = Choice> + 'a {
     use crate::explorer::config::ChoiceGroup::*;
 
@@ -160,7 +160,7 @@ pub fn list<'a>(
 /// This function is to be either removed or reimplemented eventually. It is just a replacement for
 /// the previous list implementation (exposes the choices in the same order). Default should
 /// preferably be handled in config file
-pub fn default_list<'a>(space: &'a SearchSpace<'a>) -> impl Iterator<Item = Choice> + 'a {
+pub fn default_list<'a>(space: &'a SearchSpace) -> impl Iterator<Item = Choice> + 'a {
     list(&config::DEFAULT_ORDERING, space)
 }
 

--- a/src/explorer/store.rs
+++ b/src/explorer/store.rs
@@ -6,10 +6,10 @@ use serde::Serialize;
 
 /// A Trait defining a structure containing the candidates, meant to explore the
 /// search space
-pub trait Store<'a>: Sync {
+pub trait Store: Sync {
     /// Transmits the information needed to update the store after a `Candidate` is
     /// evaluated.
-    type PayLoad: 'a + Send;
+    type PayLoad: Send;
     /// The type of events this store can emit during search.
     type Event: Send + Serialize;
     /// Updates the value that will be used to prune the search space
@@ -26,7 +26,7 @@ pub trait Store<'a>: Sync {
         eval: f64,
     );
     /// Retrieve a Candidate for evaluation, returns `None` if no candidate remains.
-    fn explore(&self, context: &dyn Context) -> Option<(Candidate<'a>, Self::PayLoad)>;
+    fn explore(&self, context: &dyn Context) -> Option<(Candidate, Self::PayLoad)>;
     /// Displays statistics about the candidate store.
     fn print_stats(&self) {}
 }

--- a/src/helper/signature.rs
+++ b/src/helper/signature.rs
@@ -91,7 +91,7 @@ where
         AM: device::ArgMap<'b>,
     {
         self.signature
-            .add_array(self.context.device(), name.to_string(), S::t());
+            .add_array(&*self.context.device(), name.to_string(), S::t());
         let param = unwrap!(self.signature.params.last());
         let array = self.context.bind_array::<S>(param, size);
         let rng = &mut self.rng;

--- a/src/ir/access_pattern.rs
+++ b/src/ir/access_pattern.rs
@@ -2,6 +2,7 @@
 use crate::device::Device;
 use crate::ir;
 use crate::search_space::MemSpace;
+use serde::{Deserialize, Serialize};
 use utils::*;
 
 /// A stride on a given dimensions.
@@ -13,19 +14,19 @@ pub enum Stride {
     Unknown,
 }
 
-#[derive(Clone, Debug)]
-pub enum AccessPattern<'a> {
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum AccessPattern {
     /// Unknown access pattern.
     Unknown(Option<ir::MemId>),
     /// Access with a fixed stride on each dimensions. Accesses on two different
     /// dimensions should not overlap.
     Tensor {
         mem_id: Option<ir::MemId>,
-        dims: FnvHashMap<ir::DimId, ir::PartialSize<'a>>,
+        dims: FnvHashMap<ir::DimId, ir::PartialSize>,
     },
 }
 
-impl<'a> AccessPattern<'a> {
+impl AccessPattern {
     /// Indicates if memory accesses access to consecutive elements on the given dimension.
     pub fn is_consecutive(&self, dim: ir::DimId, t: ir::Type) -> bool {
         match self {

--- a/src/ir/induction_var.rs
+++ b/src/ir/induction_var.rs
@@ -1,23 +1,26 @@
 use crate::ir;
+use serde::{Deserialize, Serialize};
 use utils::*;
 
 /// Unique identifier for `InductionVar`
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
 pub struct IndVarId(pub u32);
 
 /// A multidimentional induction variable. No dimension should appear twice in dims.
-#[derive(Clone, Debug)]
-pub struct InductionVar<'a, L = ir::LoweringMap> {
-    dims: Vec<(ir::DimId, ir::PartialSize<'a>)>,
-    base: ir::Operand<'a, L>,
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct InductionVar<L = ir::LoweringMap> {
+    dims: Vec<(ir::DimId, ir::PartialSize)>,
+    base: ir::Operand<L>,
 }
 
-impl<'a, L> InductionVar<'a, L> {
+impl<L> InductionVar<L> {
     /// Creates a new induction var. Size represents the increment over each diemnsion
     /// taken independenly.
     pub fn new(
-        dims: Vec<(ir::DimId, ir::PartialSize<'a>)>,
-        base: ir::Operand<'a, L>,
+        dims: Vec<(ir::DimId, ir::PartialSize)>,
+        base: ir::Operand<L>,
     ) -> Result<Self, ir::Error> {
         ir::TypeError::check_integer(base.t())?;
         // Assert dimensions are unique.
@@ -50,18 +53,18 @@ impl<'a, L> InductionVar<'a, L> {
     }
 
     /// Returns the base operand of the induction variable.
-    pub fn base(&self) -> &ir::Operand<'a, L> {
+    pub fn base(&self) -> &ir::Operand<L> {
         &self.base
     }
 
     /// Returns the list of induction dimensions along with the corresponding increments.
-    pub fn dims(&self) -> &[(ir::DimId, ir::PartialSize<'a>)] {
+    pub fn dims(&self) -> &[(ir::DimId, ir::PartialSize)] {
         &self.dims
     }
 }
 
-impl<'a> InductionVar<'a, ()> {
-    pub fn freeze(self, cnt: &mut ir::Counter) -> InductionVar<'a> {
+impl InductionVar<()> {
+    pub fn freeze(self, cnt: &mut ir::Counter) -> InductionVar {
         InductionVar {
             dims: self.dims,
             base: self.base.freeze(cnt),

--- a/src/ir/mem.rs
+++ b/src/ir/mem.rs
@@ -28,7 +28,7 @@ impl fmt::Display for MemId {
 }
 
 /// A block of memory allocated on the device by the kernel.
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Block {
     id: MemId,
     uses: Vec<InstId>,
@@ -82,7 +82,7 @@ impl Block {
 }
 
 /// Holds the blocks of memory to allocate on the device.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub struct BlockMap {
     blocks: ir::SparseVec<MemId, Block>,
     layouts: FnvHashSet<MemId>,

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -14,6 +14,7 @@ mod types;
 mod variable;
 
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 use std;
 use std::marker::PhantomData;
 use utils::unwrap;
@@ -24,7 +25,7 @@ pub use self::dimension::{
     DimId, DimMapping, DimMappingId, Dimension, LogicalDim, LogicalDimId,
 };
 pub use self::error::{Error, TypeError};
-pub use self::function::{Function, Parameter, Signature};
+pub use self::function::{Body, Function, Parameter, Signature};
 pub use self::induction_var::{IndVarId, InductionVar};
 pub use self::instruction::{InstId, Instruction};
 pub use self::mem::MemId;
@@ -200,7 +201,7 @@ impl LoweredDimMap {
 /// An index type `I` is also used in order to provide strong typing
 /// guarantees since `SparseVec` is meant to hold `DimId -> Dimension`
 /// and `InstId -> Instruction` mappings.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct SparseVec<I, T> {
     vec: Vec<Option<T>>,
     capacity: usize,

--- a/src/ir/statement.rs
+++ b/src/ir/statement.rs
@@ -39,17 +39,17 @@ impl From<ir::DimId> for StmtId {
 }
 
 /// Represents a basic block in an Exhaust function.
-pub trait Statement<'a, L = ir::LoweringMap> {
+pub trait Statement<L = ir::LoweringMap> {
     /// Returns the unique identifier of the `Statement`.
     fn stmt_id(&self) -> StmtId;
 
     /// Returns 'self' if it is an instruction.
-    fn as_inst(&self) -> Option<&ir::Instruction<'a, L>> {
+    fn as_inst(&self) -> Option<&ir::Instruction<L>> {
         None
     }
 
     /// Returns 'self' if it is a dimension
-    fn as_dim(&self) -> Option<&ir::Dimension<'a, L>> {
+    fn as_dim(&self) -> Option<&ir::Dimension<L>> {
         None
     }
 

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -1,9 +1,10 @@
 /// Describes the types instruction and operands can take.
 use crate::ir;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use utils::*;
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 /// Values and intructions types.
 pub enum Type {
     /// Type for integer values, with a fixed number of bits.

--- a/src/ir/variable.rs
+++ b/src/ir/variable.rs
@@ -26,7 +26,7 @@ impl fmt::Display for VarId {
 }
 
 /// A variable produced by the code.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Variable {
     id: VarId,
     t: ir::Type,
@@ -42,7 +42,7 @@ pub struct Variable {
 /// This is usefull to limit the size of the search space by removing useless decisions.
 /// For example, we don't want to store in memory the operand of a store. Also, we don't
 /// want to store in RAM a value we just loaded from RAM.
-#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MemoryLevel {
     /// The variable must be stored in registers and the producer and consumer must not be
     /// separated by synchronisations.
@@ -131,7 +131,7 @@ impl Variable {
 }
 
 /// Specifies how is a `Variable` defined.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum VarDef {
     /// Takes the variable produced by an instruction.
     Inst(ir::InstId),

--- a/src/model/level.rs
+++ b/src/model/level.rs
@@ -95,7 +95,7 @@ pub fn sum_pressure(
     // Compute the pressure induced by the dimensions overhead.
     let mut pressure =
         HwPressure::min(nest.iter().map(|d| &local_info.dim_overhead[d].0))
-            .unwrap_or_else(|| HwPressure::zero(ctx.device()));
+            .unwrap_or_else(|| HwPressure::zero(&*ctx.device()));
     if nest.is_empty() {
         let min_num_threads = match bound_level {
             BottleneckLevel::Global => local_info.parallelism.min_num_threads,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -64,7 +64,7 @@ pub fn bound(space: &SearchSpace, context: &dyn Context) -> Bound {
     trace!("code_points {:?}", code_points);
     populate(
         space,
-        context.device(),
+        &*context.device(),
         &local_info,
         &code_points,
         &mut levels,
@@ -83,7 +83,7 @@ pub fn bound(space: &SearchSpace, context: &dyn Context) -> Bound {
                 &mut levels_dag,
             ),
             level::DagAction::ApplyDimMap(dim_map) => apply_dim_map(
-                context.device(),
+                &*context.device(),
                 space,
                 &local_info,
                 &levels,
@@ -123,7 +123,7 @@ pub fn bound(space: &SearchSpace, context: &dyn Context) -> Bound {
         unwrap!(levels[0].repeated_latency.as_ref()).value()
     );
     let bound = cmp::max(latency, throughput_bound);
-    bound.explain(context.device(), &levels, code_points.dag.nodes())
+    bound.explain(&*context.device(), &levels, code_points.dag.nodes())
 }
 
 /// Populates the dependency maps and the levels with dependency edges and back-edges.

--- a/src/search_space/mod.rs
+++ b/src/search_space/mod.rs
@@ -6,6 +6,7 @@ use crate::codegen;
 use crate::device::Context;
 use crate::ir;
 use log::debug;
+use std::sync::Arc;
 
 mod dim_map;
 mod operand;
@@ -18,19 +19,18 @@ pub use self::choices::{
 };
 
 use self::choices::{apply_action, init_domain, DomainDiff};
-use std::sync::Arc;
 
 /// A partially specified implementation.
 #[derive(Clone)]
-pub struct SearchSpace<'a> {
-    ir_instance: Arc<ir::Function<'a>>,
+pub struct SearchSpace {
+    ir_instance: Arc<ir::Function>,
     domain: DomainStore,
 }
 
-impl<'a> SearchSpace<'a> {
+impl SearchSpace {
     /// Creates a new `SearchSpace` for the given `ir_instance`.
     pub fn new(
-        ir_instance: ir::Function<'a, ()>,
+        ir_instance: ir::Function<()>,
         mut actions: Vec<Action>,
     ) -> Result<Self, ()> {
         // Pre-allocate IDs for future lowerings.
@@ -55,7 +55,7 @@ impl<'a> SearchSpace<'a> {
     }
 
     /// Returns the underlying ir instance.
-    pub fn ir_instance(&self) -> &ir::Function<'a> {
+    pub fn ir_instance(&self) -> &ir::Function {
         &self.ir_instance
     }
 

--- a/telamon-capi/src/search_space.rs
+++ b/telamon-capi/src/search_space.rs
@@ -9,7 +9,7 @@ use telamon::search_space;
 /// Opaque type that abstracts away the lifetime parameter of
 /// `search_space::SearchSpace`.
 #[derive(Clone)]
-pub struct SearchSpace(pub(crate) search_space::SearchSpace<'static>);
+pub struct SearchSpace(pub(crate) search_space::SearchSpace);
 
 /// Creates a new search space from an IR function. The caller stays
 /// is responsible for freeing the instance and action pointers; the

--- a/telamon-gen/Cargo.toml
+++ b/telamon-gen/Cargo.toml
@@ -31,11 +31,7 @@ log = "0.4.1"
 proc-macro2 = "0.4.9"
 quote = "0.6.4"
 regex = "0.2.10"
-serde = "1.0.43"
-# cbindgen, used in telamon_capi which transitively depends on telamon_gen,
-# currently needs version 1.0.21 to work, so we use it here as well. See
-# https://github.com/eqrion/cbindgen/pull/159
-serde_derive = "=1.0.21"
+serde = {version = "1.0.43", features = ["derive"]}
 serde_json = "1.0.16"
 indexmap = { version = "1.0", features = ["serde-1"] }
 utils = {package = "telamon-utils", path = "../telamon-utils"}

--- a/telamon-gen/cc_tests/Cargo.toml
+++ b/telamon-gen/cc_tests/Cargo.toml
@@ -16,8 +16,7 @@ env_logger = "0.5.9"
 itertools = "0.8"
 log = "0.4.1"
 num = "0.2.0"
-serde = "1.0"
-serde_derive = "1.0"
+serde = {version ="1.0", features = ["derive", "rc"]}
 utils = {package = "telamon-utils", path = "../../telamon-utils"}
 
 [features]

--- a/telamon-gen/cc_tests/src/fail.rs
+++ b/telamon-gen/cc_tests/src/fail.rs
@@ -1,6 +1,8 @@
 //! Tests that failed at some point.
 
 mod fail0 {
+    use utils::generated_file;
+
     define_ir! {
         struct set_a;
         type subset_a[subset_b reverse set_a]: set_a;

--- a/telamon-gen/cc_tests/src/ir_gen.rs
+++ b/telamon-gen/cc_tests/src/ir_gen.rs
@@ -69,7 +69,7 @@ macro_rules! define_ir {
     // Defines the set ID.
     (@id_def trait $name:ident, $x:tt) => { define_ir!(@id_def struct $name, $x); };
     (@id_def struct $name:ident, $x:tt) => {
-        #[derive(Clone, Copy, Hash, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+        #[derive(Clone, Copy, Hash, Debug, PartialEq, Eq, PartialOrd, Ord, ::serde::Serialize, ::serde::Deserialize)]
         pub struct Id(pub usize);
     };
     (@id_def type $name:ident, $super:ident) => { pub use super::$super::Id as Id; };

--- a/telamon-gen/cc_tests/src/main.rs
+++ b/telamon-gen/cc_tests/src/main.rs
@@ -1,13 +1,9 @@
 #![allow(dead_code, unused_imports, clippy::all)]
-extern crate itertools;
+
+// Keep the extern crate here to automatically import the `generated_file` macro into all scopes.
+// Could be cleaned up at some point.
 #[macro_use]
 extern crate utils;
-#[macro_use]
-extern crate log;
-extern crate env_logger;
-extern crate num;
-#[macro_use]
-extern crate serde_derive;
 
 fn main() {
     panic!("use `cargo test` to run tests")

--- a/telamon-gen/src/ir/choice.rs
+++ b/telamon-gen/src/ir/choice.rs
@@ -1,7 +1,7 @@
 //! Describe decisions that must be specified.
 use crate::ir::{self, Adaptable};
 use itertools::{Either, Itertools};
-use serde_derive::Serialize;
+use serde::Serialize;
 use std;
 use utils::*;
 

--- a/telamon-gen/src/ir/mod.rs
+++ b/telamon-gen/src/ir/mod.rs
@@ -15,7 +15,7 @@ pub use self::choice::*;
 pub use self::filter::*;
 pub use self::set::*;
 
-use serde_derive::Serialize;
+use serde::Serialize;
 
 /// Describes the choices that constitute the IR.
 #[derive(Debug)]

--- a/telamon-gen/src/ir/set.rs
+++ b/telamon-gen/src/ir/set.rs
@@ -1,6 +1,6 @@
 use crate::ir::{self, Adaptable};
 use indexmap::IndexMap;
-use serde_derive::Serialize;
+use serde::Serialize;
 use std;
 use std::borrow::Borrow;
 use std::fmt;

--- a/telamon-gen/src/print/ast.rs
+++ b/telamon-gen/src/print/ast.rs
@@ -7,7 +7,6 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use quote::ToTokens;
 use serde::{Serialize, Serializer};
-use serde_derive;
 use std::fmt::{self, Display, Formatter};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use utils::*;
@@ -166,7 +165,7 @@ impl<'a> Context<'a> {
 ///
 /// Associated templates:
 /// * [choice/getter]: retrives the choice value from the store.
-#[derive(Debug, serde_derive::Serialize)]
+#[derive(Debug, Serialize)]
 pub struct ChoiceInstance<'a> {
     name: &'a str,
     arguments: Vec<(Variable<'a>, Set<'a>)>,
@@ -185,7 +184,7 @@ impl<'a> ChoiceInstance<'a> {
     }
 }
 
-#[derive(Debug, serde_derive::Serialize)]
+#[derive(Debug, Serialize)]
 pub struct SetConstraint<'a> {
     var: Variable<'a>,
     sets: Vec<Set<'a>>,
@@ -225,7 +224,7 @@ pub enum Conflict<'a> {
     },
 }
 
-#[derive(Clone, Debug, serde_derive::Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ConflictAst<'a> {
     Variable {
         conflict_var: Variable<'a>,
@@ -283,7 +282,7 @@ impl<'a> Conflict<'a> {
 }
 
 /// Builds a loop nest given a body.
-#[derive(Clone, Debug, serde_derive::Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct LoopNest<'a> {
     levels: Vec<(Variable<'a>, Set<'a>, Vec<ConflictAst<'a>>)>,
     triangular: bool,
@@ -386,7 +385,7 @@ impl<'a> Display for Variable<'a> {
 }
 
 /// The type of a value.
-#[derive(serde_derive::Serialize)]
+#[derive(Serialize)]
 pub enum ValueType {
     Enum(RcStr),
     Range,
@@ -439,7 +438,7 @@ pub fn new_objs_list(set: &ir::SetDef, new_objs: &str) -> Variable<'static> {
 }
 
 /// AST to print the reference to a set.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, serde_derive::Serialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize)]
 pub struct Set<'a> {
     def: SetDef<'a>,
     var: Option<Variable<'a>>,
@@ -470,7 +469,7 @@ impl<'a> Set<'a> {
 }
 
 /// AST for the set definition.
-#[derive(Debug, Clone, serde_derive::Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct SetDef<'a> {
     name: &'a str,
     keys: &'a IndexMap<ir::SetDefKey, String>,

--- a/telamon-gen/src/print/choice.rs
+++ b/telamon-gen/src/print/choice.rs
@@ -3,7 +3,7 @@ use crate::ir::{self, SetRef};
 use crate::print;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, ToTokens};
-use serde_derive::Serialize;
+use serde::Serialize;
 
 /// Prints the ids of the variables of a `ChoiceInstance`.
 pub fn ids(choice_instance: &ir::ChoiceInstance, ctx: &print::Context) -> TokenStream {

--- a/telamon-gen/src/print/filter.rs
+++ b/telamon-gen/src/print/filter.rs
@@ -7,7 +7,7 @@ use crate::print::value_set;
 use log::trace;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote;
-use serde_derive::Serialize;
+use serde::Serialize;
 use utils::unwrap;
 
 /// Ast for a filtering funtion.

--- a/telamon-gen/src/print/mod.rs
+++ b/telamon-gen/src/print/mod.rs
@@ -9,7 +9,7 @@ use crate::print::ast::Context;
 use crate::print::value::{Value, ValueIdent};
 use lazy_static::lazy_static;
 use log::debug;
-use serde_derive::Serialize;
+use serde::Serialize;
 
 /// Reset the state of the printer. This should only be used for testing purpose, when
 /// one whats to compare the outputs of the printer oer sevral runs.
@@ -63,7 +63,7 @@ macro_rules! render {
     ($($tmpl:ident)/+, $(< $($lifetime: tt),* >, )*
      $($name:ident: $ty: ty = $val: expr),*) => {
         {
-            #[derive(serde_derive::Serialize)]
+            #[derive(::serde::Serialize)]
             struct Data<$($($lifetime),*),*> { $($name: $ty),* };
             let data = Data { $($name: $val),* };
             let template = concat_sep!(".", $(stringify!($tmpl)),*);

--- a/telamon-gen/src/print/store.rs
+++ b/telamon-gen/src/print/store.rs
@@ -2,7 +2,7 @@
 use crate::print;
 use proc_macro2::{Ident, Span};
 use quote::ToTokens;
-use serde_derive::Serialize;
+use serde::Serialize;
 
 /// Returns the name of the getter method for `choice`. If `get_old` is true, the method
 /// will only take into account decisions that have been propagated.

--- a/telamon-gen/src/print/template/store.rs
+++ b/telamon-gen/src/print/template/store.rs
@@ -3,7 +3,7 @@
 {{/inline~}}
 
 /// Stores the domains of each variable.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DomainStore {
     {{#each choices}}
         {{name}}: Arc<FnvHashMap<{{>choice_ids this}}, {{>value_type.name value_type}}>>,

--- a/tests/cuda.rs
+++ b/tests/cuda.rs
@@ -15,7 +15,7 @@ fn unrolled_dims() {
     let executor = cuda::Executor::init();
     let context = cuda::Context::new(&executor);
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let size_64 = builder.cst_size(64);
     let d0 = builder.open_dim_ex(size_64, DimKind::UNROLL);
     let i0 = builder.mov(&d0);
@@ -30,7 +30,7 @@ fn block_thread_dims() {
     let executor = cuda::Executor::init();
     let context = cuda::Context::new(&executor);
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let size_64 = builder.cst_size(64);
     let d0 = builder.open_dim_ex(size_64.clone(), DimKind::BLOCK);
     let d1 = builder.open_dim_ex(size_64, DimKind::THREAD);
@@ -50,7 +50,7 @@ fn params() {
         builder.scalar("a", 42);
         builder.get()
     };
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     builder.mov(&"a");
     gen_best(&context, builder.get());
 }
@@ -77,7 +77,7 @@ fn cache_directive() {
         builder.array::<f32>("a", 1);
         builder.get()
     };
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let pattern = ir::AccessPattern::Unknown(None);
     builder.ld_ex(
         ir::Type::F(32),
@@ -96,7 +96,7 @@ fn thread_reduction_map() {
     let executor = cuda::Executor::init();
     let context = cuda::Context::new(&executor);
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let size_32 = builder.cst_size(32);
     let d0 = builder.open_dim_ex(size_32, DimKind::THREAD);
     let init = builder.mov(&0f32);
@@ -115,7 +115,7 @@ fn inst_order() {
     let executor = cuda::Executor::init();
     let context = cuda::Context::new(&executor);
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
 
     let size_32 = builder.cst_size(32);
     let d0 = builder.open_dim(size_32.clone());
@@ -144,7 +144,7 @@ fn induction_var_nested() {
         out = builder.array::<i32>("out", 1);
         builder.get()
     };
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let size_1 = builder.cst_size(1);
     let size_4 = builder.cst_size(4);
     let size_5 = builder.cst_size(5);
@@ -179,7 +179,7 @@ fn induction_var_simple() {
         out = builder.array::<i32>("out", 1);
         builder.get()
     };
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let size_3 = builder.cst_size(3);
     let size_4 = builder.cst_size(4);
     let d0 = builder.open_dim_ex(size_3, DimKind::LOOP);
@@ -214,7 +214,7 @@ fn global_vector_load() {
         .as_ref()
         .write(&(0..D0_LEN).map(|i| i as i32 + 10).collect_vec()[..]);
 
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     // Load B from global memory
     let d0_size = builder.cst_size(D0_LEN);
     let d0 = builder.open_dim_ex(d0_size, DimKind::VECTOR);
@@ -243,7 +243,7 @@ fn size_cast() {
         out = builder.array::<i64>("out", 1);
         builder.get()
     };
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let size_3 = builder.cst_size(3);
     let size_4 = builder.cst_size(4);
     let d0 = builder.open_dim_ex(size_3, DimKind::LOOP);
@@ -271,7 +271,7 @@ fn perf_model_0() {
         builder.get()
     };
 
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let size_16 = builder.cst_size(16);
     let n_tiled = n.to_ir_size(&builder);
 
@@ -296,7 +296,7 @@ fn merge_0() {
     let context = cuda::Context::new(&executor);
     let signature = empty_signature();
 
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let size_16 = builder.cst_size(16);
 
     let d0 = builder.open_dim_ex(size_16.clone(), DimKind::LOOP);
@@ -325,7 +325,7 @@ fn merge_1() {
     let context = cuda::Context::new(&executor);
     let signature = empty_signature();
 
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let size_16 = builder.cst_size(16);
 
     let d0 = builder.open_dim_ex(size_16.clone(), DimKind::LOOP);
@@ -351,7 +351,7 @@ fn dim_map_reduce_0() {
     let context = cuda::Context::new(&executor);
     let signature = empty_signature();
 
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let size_16 = builder.cst_size(16);
 
     let inst0 = builder.mov(&0f32);
@@ -377,7 +377,7 @@ fn dim_map_active() {
     let context = cuda::Context::new(&executor);
     let signature = empty_signature();
 
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let size_32 = builder.cst_size(32);
 
     let d0 = builder.open_dim_ex(size_32.clone(), DimKind::THREAD);
@@ -402,7 +402,7 @@ fn test0() {
     let context = cuda::Context::new(&executor);
     let signature = empty_signature();
 
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let size_32 = builder.cst_size(32);
 
     let d0 = builder.open_dim_ex(size_32.clone(), DimKind::THREAD);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -15,7 +15,7 @@ fn empty() {
     let signature = empty_signature();
     gen_best(
         &context,
-        helper::Builder::new(&signature, context.device()).get(),
+        helper::Builder::new(signature.into(), context.device()).get(),
     );
 }
 
@@ -30,7 +30,7 @@ fn two_add() {
         builder.get()
     };
     gen_best(&context, {
-        let mut builder = helper::Builder::new(&signature, context.device());
+        let mut builder = helper::Builder::new(signature.into(), context.device());
         builder.add(&"a", &2);
         builder.add(&std::f32::consts::PI, &1.0f32);
         builder.get()
@@ -43,11 +43,11 @@ fn inst_dim_order() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let dim0 = builder.open_dim(Size::new_const(64));
     let inst0 = builder.mov(&0i32);
     let pattern = ir::AccessPattern::Unknown(None);
-    let addr = builder.cast(&0i64, pattern.pointer_type(context.device()));
+    let addr = builder.cast(&0i64, pattern.pointer_type(&*context.device()));
     let inst1 = builder.st(&addr, &0i32, pattern);
     builder.close_dim(&dim0);
     let dim1 = builder.open_dim(Size::new_const(64));
@@ -84,7 +84,7 @@ fn inst_variable_order() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let src = builder.mov(&1f32);
     let var = builder.get_inst_variable(src);
     let dst = builder.mov(&var);
@@ -102,7 +102,7 @@ fn dim_map_variable_order() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
 
     let src_dim = builder.open_dim(ir::Size::new_const(16));
     let src = builder.mov(&1f32);
@@ -142,7 +142,7 @@ fn last_variable_order() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
 
     let dim = builder.open_dim(ir::Size::new_const(16));
     let src = builder.mov(&1f32);
@@ -168,7 +168,7 @@ fn nested_thread_dims() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let size4 = builder.cst_size(4);
     let d0 = builder.open_dim_ex(size4.clone(), DimKind::THREAD);
     let d1 = builder.open_dim_ex(size4.clone(), DimKind::THREAD);
@@ -203,7 +203,7 @@ fn max_thread_on_addinst() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     builder.open_dim_ex(Size::new_const(1024), DimKind::THREAD);
     let d1 = builder.open_dim(Size::new_const(2));
     builder.mov(&0i32);
@@ -221,7 +221,7 @@ fn max_thread_on_setkind() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let d0 = builder.open_dim(Size::new_const(1024));
     let d1 = builder.open_dim(Size::new_const(2));
     builder.mov(&0i32);
@@ -245,7 +245,7 @@ fn block_dims() {
         n = builder.max_size("n", 64);
         builder.get()
     };
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let d0 = builder.open_dim(Size::new_const(4));
     let inst = builder.mov(&0i32);
     let s1 = n.to_ir_size(&builder);
@@ -282,7 +282,7 @@ fn vector_dims() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let base_addr = builder.cast(&0i64, context.device().pointer_type(MemSpace::GLOBAL));
     let d0 = builder.open_dim(Size::new_const(4));
     // Test with one vectorizable instruction
@@ -322,7 +322,7 @@ fn unroll_dims() {
         n = builder.max_size("n", 64);
         builder.get()
     };
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let d0 = builder.open_dim(Size::new_const(64));
     let d1 = builder.open_dim(Size::new_const(4096));
     let s2 = n.to_ir_size(&builder);
@@ -341,7 +341,7 @@ fn reduce_dim_invariants() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let init = builder.cast(&0i64, context.device().pointer_type(MemSpace::GLOBAL));
     let d0 = builder.open_dim(Size::new_const(4));
     let pattern = ir::AccessPattern::Unknown(None);
@@ -378,7 +378,7 @@ fn rename_thread() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let d_n_1 = &builder.open_dim_ex(Size::new_const(8), DimKind::THREAD);
     builder.mov(&0i32);
     builder.mov(d_n_1);
@@ -391,7 +391,7 @@ fn dim_merge() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let d0 = builder.open_dim_ex(Size::new_const(4), DimKind::LOOP);
     builder.mov(&0i32);
     let d1 = builder.open_dim_ex(Size::new_const(4), DimKind::LOOP);
@@ -405,7 +405,7 @@ fn loop_fusion() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let d0 = builder.open_dim_ex(Size::new_const(4), DimKind::LOOP);
     let inst0 = builder.mov(&0i32);
     let d1 = builder.open_mapped_dim(&d0);
@@ -423,7 +423,7 @@ fn unrolled_loop_unfused_simple() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let d0 = builder.open_dim_ex(Size::new_const(4), DimKind::UNROLL);
     let inst0 = builder.mov(&0i32);
     let d1 = builder.open_mapped_dim(&d0);
@@ -441,7 +441,7 @@ fn temporary_memory_gen_simple() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let d0 = builder.open_dim_ex(Size::new_const(4), DimKind::LOOP);
     let inst0 = builder.mov(&0i32);
     let d1 = builder.open_mapped_dim(&d0);
@@ -459,7 +459,7 @@ fn unrolled_loop_unfused_reduction() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     let d0 = builder.open_dim_ex(ir::Size::new_const(4), DimKind::UNROLL);
     let inst0 = builder.mov(&0i32);
     builder.open_mapped_dim(&d0);
@@ -478,7 +478,7 @@ fn two_thread_dim_map() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     // Generate a variable in each thread.
     let dim0_0 = builder.open_dim_ex(ir::Size::new_const(32), DimKind::THREAD);
     let dim0_1 = builder.open_dim_ex(ir::Size::new_const(32), DimKind::THREAD);
@@ -500,7 +500,7 @@ fn double_dim_map() {
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
 
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
     // Load from a and b.
     let dim0_0 = builder.open_dim_ex(ir::Size::new_const(32), DimKind::THREAD);
     let dim0_1 = builder.open_dim_ex(ir::Size::new_const(32), DimKind::THREAD);
@@ -527,7 +527,7 @@ fn multi_dim_to_same_vector_level() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
 
     builder.open_dim_ex(ir::Size::new_const(2), DimKind::INNER_VECTOR);
     builder.open_dim_ex(ir::Size::new_const(4), DimKind::INNER_VECTOR);
@@ -548,7 +548,7 @@ fn two_level_vectorization() {
     let _ = env_logger::try_init();
     let context = fake::Context::<fake::Device>::default();
     let signature = empty_signature();
-    let mut builder = helper::Builder::new(&signature, context.device());
+    let mut builder = helper::Builder::new(signature.into(), context.device());
 
     let inner_vec = builder.open_dim_ex(ir::Size::new_const(2), DimKind::INNER_VECTOR);
     let outer_vec = builder.open_dim_ex(ir::Size::new_const(2), DimKind::OUTER_VECTOR);


### PR DESCRIPTION
This patch removes the lifetime in `ir::Function` due to holding
references to the signature, parameters, and device.  The references are
replaced with atomically reference-counted pointers instead.  Since
those internal structures are rarely copied (they are already behind
other `Arc`s which get themselves cloned, except when during lowering),
there should be virtually no performance difference, but it makes
various APIs nicer -- and limits the lifetime hell we would occasionally
find ourselves in.

The PR touches a large amount of files, but most of the changes in there
are fairly straightforward -- it's just removing lifetimes and
(sometimes) adding `Arc`s.