### PR TITLE
Minor rewriting and renaming of NameMap

### DIFF
--- a/backend/cuda/src/gpu.rs
+++ b/backend/cuda/src/gpu.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "real_gpu")]
 use crate::characterize;
 use crate::mem_model::{self, MemInfo};
-use crate::{CudaPrinter, Executor};
+use crate::{printer::CudaPrinter, Executor};
 use serde::{Deserialize, Serialize};
 use std::io::Write;
 use telamon::codegen::Function;

--- a/backend/cuda/src/lib.rs
+++ b/backend/cuda/src/lib.rs
@@ -58,14 +58,14 @@ impl ValuePrinter {
 }
 
 impl codegen::ValuePrinter for ValuePrinter {
-    fn get_const_float(val: &Ratio<BigInt>, len: u16) -> String {
+    fn get_const_float(&self, val: &Ratio<BigInt>, len: u16) -> String {
         assert!(len <= 64);
         let f = unwrap!(val.numer().to_f64()) / unwrap!(val.denom().to_f64());
         let binary = unsafe { std::mem::transmute::<f64, u64>(f) };
         format!("0D{:016X}", binary)
     }
 
-    fn get_const_int(val: &BigInt, len: u16) -> String {
+    fn get_const_int(&self, val: &BigInt, len: u16) -> String {
         assert!(len <= 64);
         format!("{}", unwrap!(val.to_i64()))
     }

--- a/backend/cuda/src/lib.rs
+++ b/backend/cuda/src/lib.rs
@@ -26,7 +26,6 @@ pub use self::api::{DeviceAttribute, PerfCounter, PerfCounterSet};
 pub use self::context::Context;
 pub use self::gpu::{Gpu, InstDesc};
 pub use self::kernel::Kernel;
-pub use self::printer::CudaPrinter;
 
 use num::bigint::BigInt;
 use num::rational::Ratio;
@@ -36,12 +35,12 @@ use telamon::ir;
 use utils::*;
 
 #[derive(Default)]
-struct Namer {
+pub(crate) struct ValuePrinter {
     num_var: FnvHashMap<ir::Type, usize>,
     num_sizes: usize,
 }
 
-impl Namer {
+impl ValuePrinter {
     /// Generate a variable name prefix from a type.
     fn gen_prefix(t: ir::Type) -> &'static str {
         match t {
@@ -58,25 +57,25 @@ impl Namer {
     }
 }
 
-impl codegen::Namer for Namer {
-    fn name(&mut self, t: ir::Type) -> String {
-        let prefix = Namer::gen_prefix(t);
-        let entry = self.num_var.entry(t).or_insert(0);
-        let name = format!("%{}{}", prefix, *entry);
-        *entry += 1;
-        name
-    }
-
-    fn name_float(&self, val: &Ratio<BigInt>, len: u16) -> String {
+impl codegen::ValuePrinter for ValuePrinter {
+    fn get_const_float(val: &Ratio<BigInt>, len: u16) -> String {
         assert!(len <= 64);
         let f = unwrap!(val.numer().to_f64()) / unwrap!(val.denom().to_f64());
         let binary = unsafe { std::mem::transmute::<f64, u64>(f) };
         format!("0D{:016X}", binary)
     }
 
-    fn name_int(&self, val: &BigInt, len: u16) -> String {
+    fn get_const_int(val: &BigInt, len: u16) -> String {
         assert!(len <= 64);
         format!("{}", unwrap!(val.to_i64()))
+    }
+
+    fn name(&mut self, t: ir::Type) -> String {
+        let prefix = ValuePrinter::gen_prefix(t);
+        let entry = self.num_var.entry(t).or_insert(0);
+        let name = format!("%{}{}", prefix, *entry);
+        *entry += 1;
+        name
     }
 
     fn name_param(&mut self, p: codegen::ParamValKey) -> String {

--- a/backend/cuda/src/printer.rs
+++ b/backend/cuda/src/printer.rs
@@ -368,7 +368,7 @@ impl CudaPrinter {
 }
 
 impl InstPrinter for CudaPrinter {
-    type VP = ValuePrinter;
+    type ValuePrinter = ValuePrinter;
 
     /// Print result = op1 op op2
     fn print_binop(

--- a/backend/mppa/src/context.rs
+++ b/backend/mppa/src/context.rs
@@ -1,6 +1,6 @@
 //! MPPA evaluation context.
 use crate::printer::MppaPrinter;
-use crate::{mppa, Namer};
+use crate::{mppa, ValuePrinter};
 use crossbeam;
 use crossbeam::queue::ArrayQueue;
 use itertools::Itertools;
@@ -131,8 +131,8 @@ impl Context {
     /// Compiles and sets the arguments of a kernel.
     fn setup_kernel(&self, fun: &Function) -> (telajax::Kernel, Vec<KernelArg>) {
         let id = ATOMIC_KERNEL_ID.fetch_add(1, Ordering::SeqCst);
-        let mut namer = Namer::default();
-        let mut name_map = NameMap::new(fun, &mut namer);
+        let mut value_printer = ValuePrinter::default();
+        let mut name_map = NameMap::new(fun, &mut value_printer);
         let mut printer = MppaPrinter::default();
 
         let kernel_code = printer.wrapper_function(fun, &mut name_map, id);
@@ -168,7 +168,7 @@ impl Context {
     fn get_wrapper(
         &self,
         fun: &Function,
-        name_map: &mut NameMap<Namer>,
+        name_map: &mut NameMap<ValuePrinter>,
         id: usize,
     ) -> Arc<telajax::Wrapper> {
         let mut printer = MppaPrinter::default();
@@ -188,7 +188,7 @@ impl Context {
     fn process_kernel_argument(
         &self,
         fun: &Function,
-        name_map: &mut NameMap<Namer>,
+        name_map: &mut NameMap<ValuePrinter>,
     ) -> (Vec<usize>, Vec<KernelArg>) {
         fun.device_code_args()
             .map(|p| match p {

--- a/backend/mppa/src/lib.rs
+++ b/backend/mppa/src/lib.rs
@@ -56,13 +56,13 @@ impl ValuePrinter {
 }
 
 impl codegen::ValuePrinter for ValuePrinter {
-    fn get_const_float(val: &Ratio<BigInt>, len: u16) -> String {
+    fn get_const_float(&self, val: &Ratio<BigInt>, len: u16) -> String {
         assert!(len <= 64);
         let f = unwrap!(val.numer().to_f64()) / unwrap!(val.denom().to_f64());
         f.to_string()
     }
 
-    fn get_const_int(val: &BigInt, len: u16) -> String {
+    fn get_const_int(&self, val: &BigInt, len: u16) -> String {
         assert!(len <= 64);
         format!("{}", unwrap!(val.to_i64()))
     }

--- a/backend/mppa/src/lib.rs
+++ b/backend/mppa/src/lib.rs
@@ -10,7 +10,6 @@ mod printer;
 
 pub use crate::context::Context;
 pub use crate::mppa::Mppa;
-pub use crate::printer::MppaPrinter;
 
 use num::bigint::BigInt;
 use num::rational::Ratio;
@@ -19,13 +18,13 @@ use telamon::{codegen, ir};
 use utils::*;
 
 #[derive(Default)]
-pub struct Namer {
+pub struct ValuePrinter {
     num_var: FnvHashMap<ir::Type, usize>,
     num_sizes: usize,
     num_glob_ptr: usize,
 }
 
-impl Namer {
+impl ValuePrinter {
     pub fn gen_prefix(t: ir::Type) -> &'static str {
         match t {
             ir::Type::I(1) => "p",
@@ -56,9 +55,20 @@ impl Namer {
     }
 }
 
-impl codegen::Namer for Namer {
+impl codegen::ValuePrinter for ValuePrinter {
+    fn get_const_float(val: &Ratio<BigInt>, len: u16) -> String {
+        assert!(len <= 64);
+        let f = unwrap!(val.numer().to_f64()) / unwrap!(val.denom().to_f64());
+        f.to_string()
+    }
+
+    fn get_const_int(val: &BigInt, len: u16) -> String {
+        assert!(len <= 64);
+        format!("{}", unwrap!(val.to_i64()))
+    }
+
     fn name(&mut self, t: ir::Type) -> String {
-        let prefix = Namer::gen_prefix(t);
+        let prefix = ValuePrinter::gen_prefix(t);
         match t {
             ir::Type::PtrTo(..) => {
                 let name = format!("{}{}", prefix, self.num_glob_ptr);
@@ -72,17 +82,6 @@ impl codegen::Namer for Namer {
                 name
             }
         }
-    }
-
-    fn name_float(&self, val: &Ratio<BigInt>, len: u16) -> String {
-        assert!(len <= 64);
-        let f = unwrap!(val.numer().to_f64()) / unwrap!(val.denom().to_f64());
-        f.to_string()
-    }
-
-    fn name_int(&self, val: &BigInt, len: u16) -> String {
-        assert!(len <= 64);
-        format!("{}", unwrap!(val.to_i64()))
     }
 
     fn name_param(&mut self, p: codegen::ParamValKey) -> String {

--- a/backend/mppa/src/printer.rs
+++ b/backend/mppa/src/printer.rs
@@ -461,7 +461,7 @@ impl MppaPrinter {
 }
 
 impl InstPrinter for MppaPrinter {
-    type VP = ValuePrinter;
+    type ValuePrinter = ValuePrinter;
 
     fn print_binop(
         &mut self,

--- a/backend/mppa/src/printer.rs
+++ b/backend/mppa/src/printer.rs
@@ -1,4 +1,4 @@
-use crate::Namer;
+use crate::ValuePrinter;
 use itertools::Itertools;
 use std::borrow::Cow;
 use std::fmt::Write as WriteFmt;
@@ -15,7 +15,11 @@ pub struct MppaPrinter {
 
 impl MppaPrinter {
     /// Declares all parameters of the function with the appropriate type
-    fn param_decl(&mut self, param: &ParamVal, name_map: &NameMap<Namer>) -> String {
+    fn param_decl(
+        &mut self,
+        param: &ParamVal,
+        name_map: &NameMap<ValuePrinter>,
+    ) -> String {
         let name = name_map.name_param(param.key());
         match param {
             ParamVal::External(_, par_type) => {
@@ -28,16 +32,16 @@ impl MppaPrinter {
         }
     }
 
-    /// Declared all variables that have been required from the namer
-    fn var_decls(&mut self, name_map: &NameMap<Namer>) -> String {
-        let namer = name_map.namer();
+    /// Declared all variables that have been required from the value_printer
+    fn var_decls(&mut self, name_map: &NameMap<ValuePrinter>) -> String {
+        let value_printer = name_map.value_printer();
         let print_decl = |(&t, &n)| {
             // Type is never supposed to be PtrTo here as we handle ptr types in a different way
             if let ir::Type::PtrTo(..) = t {
                 unreachable!("Type PtrTo are never inserted in this map");
             }
-            let prefix = Namer::gen_prefix(t);
-            let mut s = format!("{} ", Namer::get_string(t));
+            let prefix = ValuePrinter::gen_prefix(t);
+            let mut s = format!("{} ", ValuePrinter::get_string(t));
             s.push_str(
                 &(0..n)
                     .map(|i| format!("{}{}", prefix, i))
@@ -47,18 +51,18 @@ impl MppaPrinter {
             s.push_str(";\n  ");
             s
         };
-        let other_var_decl = namer
+        let other_var_decl = value_printer
             .num_var
             .iter()
             .map(print_decl)
             .collect_vec()
             .join("\n  ");
-        if namer.num_glob_ptr == 0 {
+        if value_printer.num_glob_ptr == 0 {
             other_var_decl
         } else {
             format!(
                 "intptr_t {};\n{}",
-                &(0..namer.num_glob_ptr)
+                &(0..value_printer.num_glob_ptr)
                     .map(|i| format!("ptr{}", i))
                     .collect_vec()
                     .join(", "),
@@ -71,7 +75,7 @@ impl MppaPrinter {
     fn decl_par_indexes(
         &mut self,
         function: &Function,
-        name_map: &NameMap<Namer>,
+        name_map: &NameMap<ValuePrinter>,
     ) -> String {
         assert!(function.block_dims().is_empty());
         let mut decls = vec![];
@@ -90,7 +94,7 @@ impl MppaPrinter {
     pub fn function<'a: 'b, 'b>(
         &mut self,
         function: &'b Function<'a>,
-        name_map: &mut NameMap<'b, '_, Namer>,
+        name_map: &mut NameMap<'b, '_, ValuePrinter>,
     ) -> String {
         let param_decls = function
             .device_code_args()
@@ -329,7 +333,11 @@ impl MppaPrinter {
 
     /// Turns the argument of wrapper into an array of void pointers
     /// Necessary to call pthread with it
-    fn build_ptr_struct(&self, func: &Function, name_map: &NameMap<Namer>) -> String {
+    fn build_ptr_struct(
+        &self,
+        func: &Function,
+        name_map: &NameMap<ValuePrinter>,
+    ) -> String {
         func.device_code_args()
             .enumerate()
             .map(|(i, arg)| {
@@ -347,7 +355,7 @@ impl MppaPrinter {
     pub fn wrapper_function<'a: 'b, 'b>(
         &mut self,
         func: &'b Function<'a>,
-        name_map: &mut NameMap<'b, '_, Namer>,
+        name_map: &mut NameMap<'b, '_, ValuePrinter>,
         id: usize,
     ) -> String {
         let fun_str = self.function(func, name_map);
@@ -410,7 +418,7 @@ impl MppaPrinter {
     pub fn print_ocl_wrapper(
         &mut self,
         fun: &Function,
-        name_map: &mut NameMap<Namer>,
+        name_map: &mut NameMap<ValuePrinter>,
         id: usize,
     ) -> String {
         let arg_names = fun
@@ -452,10 +460,8 @@ impl MppaPrinter {
     }
 }
 
-impl Printer<Namer> for MppaPrinter {
-    fn get_int(n: u32) -> String {
-        format!("{}", n)
-    }
+impl InstPrinter for MppaPrinter {
+    type VP = ValuePrinter;
 
     fn print_binop(
         &mut self,
@@ -603,20 +609,20 @@ impl Printer<Namer> for MppaPrinter {
     fn name_operand<'a>(
         vector_dims: &[Vec<Dimension>; 2],
         op: &ir::Operand,
-        namer: &'a NameMap<Namer>,
+        name_map: &'a NameMap<ValuePrinter>,
     ) -> Cow<'a, str> {
         assert!(vector_dims[0].is_empty());
         assert!(vector_dims[1].is_empty());
-        namer.name_op(op)
+        name_map.name_op(op)
     }
 
     fn name_inst<'a>(
         vector_dims: &[Vec<Dimension>; 2],
         inst: ir::InstId,
-        namer: &'a NameMap<Namer>,
+        name_map: &'a NameMap<ValuePrinter>,
     ) -> Cow<'a, str> {
         assert!(vector_dims[0].is_empty());
         assert!(vector_dims[1].is_empty());
-        namer.name_inst(inst).into()
+        name_map.name_inst(inst).into()
     }
 }

--- a/backend/x86/src/lib.rs
+++ b/backend/x86/src/lib.rs
@@ -43,13 +43,13 @@ impl ValuePrinter {
 }
 
 impl codegen::ValuePrinter for ValuePrinter {
-    fn get_const_float(val: &Ratio<BigInt>, len: u16) -> String {
+    fn get_const_float(&self, val: &Ratio<BigInt>, len: u16) -> String {
         assert!(len <= 64);
         let f = unwrap!(val.numer().to_f64()) / unwrap!(val.denom().to_f64());
         f.to_string()
     }
 
-    fn get_const_int(val: &BigInt, len: u16) -> String {
+    fn get_const_int(&self, val: &BigInt, len: u16) -> String {
         assert!(len <= 64);
         format!("{}", unwrap!(val.to_i64()))
     }

--- a/backend/x86/src/lib.rs
+++ b/backend/x86/src/lib.rs
@@ -9,7 +9,6 @@ mod printer;
 
 pub use crate::context::Context;
 pub use crate::cpu::Cpu;
-pub use crate::printer::X86printer;
 
 use num::bigint::BigInt;
 use num::rational::Ratio;
@@ -19,13 +18,13 @@ use telamon::ir;
 use utils::*;
 
 #[derive(Default)]
-struct Namer {
+pub(crate) struct ValuePrinter {
     num_var: FnvHashMap<ir::Type, usize>,
     num_sizes: usize,
     num_glob_ptr: usize,
 }
 
-impl Namer {
+impl ValuePrinter {
     /// Generate a variable name prefix from a type.
     fn gen_prefix(t: ir::Type) -> &'static str {
         match t {
@@ -43,9 +42,20 @@ impl Namer {
     }
 }
 
-impl codegen::Namer for Namer {
+impl codegen::ValuePrinter for ValuePrinter {
+    fn get_const_float(val: &Ratio<BigInt>, len: u16) -> String {
+        assert!(len <= 64);
+        let f = unwrap!(val.numer().to_f64()) / unwrap!(val.denom().to_f64());
+        f.to_string()
+    }
+
+    fn get_const_int(val: &BigInt, len: u16) -> String {
+        assert!(len <= 64);
+        format!("{}", unwrap!(val.to_i64()))
+    }
+
     fn name(&mut self, t: ir::Type) -> String {
-        let prefix = Namer::gen_prefix(t);
+        let prefix = ValuePrinter::gen_prefix(t);
         match t {
             ir::Type::PtrTo(..) => {
                 let name = format!("{}{}", prefix, self.num_glob_ptr);
@@ -59,17 +69,6 @@ impl codegen::Namer for Namer {
                 name
             }
         }
-    }
-
-    fn name_float(&self, val: &Ratio<BigInt>, len: u16) -> String {
-        assert!(len <= 64);
-        let f = unwrap!(val.numer().to_f64()) / unwrap!(val.denom().to_f64());
-        f.to_string()
-    }
-
-    fn name_int(&self, val: &BigInt, len: u16) -> String {
-        assert!(len <= 64);
-        format!("{}", unwrap!(val.to_i64()))
     }
 
     fn name_param(&mut self, p: codegen::ParamValKey) -> String {

--- a/backend/x86/src/printer.rs
+++ b/backend/x86/src/printer.rs
@@ -370,7 +370,7 @@ impl X86printer {
 }
 
 impl InstPrinter for X86printer {
-    type VP = ValuePrinter;
+    type ValuePrinter = ValuePrinter;
 
     fn print_binop(
         &mut self,

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -10,8 +10,8 @@ mod variable;
 pub use self::cfg::Cfg;
 pub use self::dimension::{Dimension, InductionLevel, InductionVar};
 pub use self::function::*;
-pub use self::name_map::{NameMap, Namer, Operand};
-pub use self::printer::{MulMode, Printer};
+pub use self::name_map::{NameMap, Operand, ValuePrinter};
+pub use self::printer::{InstPrinter, MulMode};
 pub use self::size::Size;
 pub use self::variable::Variable;
 

--- a/src/codegen/name_map.rs
+++ b/src/codegen/name_map.rs
@@ -524,11 +524,11 @@ mod tests {
             self.name(ir::Type::I(0))
         }
 
-        fn get_const_float(_: &Ratio<BigInt>, _: u16) -> String {
+        fn get_const_float(&self, _: &Ratio<BigInt>, _: u16) -> String {
             "1.0".to_owned()
         }
 
-        fn get_const_int(_: &BigInt, _: u16) -> String {
+        fn get_const_int(&self, _: &BigInt, _: u16) -> String {
             "1".to_owned()
         }
     }


### PR DESCRIPTION
Title is quite explicit. Namer has been renamed ValuePrinter, Printer is now InstPrinter. name_inst becomes get_const_inst and no longer takes self (we don't need a trait object anymore). Backends have been rewritten accordingly. ValuePrinter is now an associated type of InstPrinter (Printer was generic over Namer before). As a result, X86Printer, CudaPrinter and MppaPrinter are no longer public. An alternative would have been to make each concrete implementation of ValuePrinter public, but I don't see the point of doing that. The possibility of further splitting ValuePrinter in ConstPrinter and Namer has been discussed but postponed as it does not offer any obvious immediate advantage.