### PR TITLE
Derive `Ord` and `PartialOrd` for actions

### DIFF
--- a/src/explorer/choice.rs
+++ b/src/explorer/choice.rs
@@ -245,7 +245,10 @@ fn lower_layout_choice(space: &SearchSpace, mem: ir::MemId) -> Vec<ActionEx> {
                 let dim_pair = remaining_dims.swap_remove(i);
                 let possible_sizes =
                     unwrap!(space.ir_instance().dim(dim_pair.0).possible_sizes());
-                let size = space.domain().get_size(dim_pair.0).min(possible_sizes);
+                let size = space
+                    .domain()
+                    .get_size(dim_pair.0)
+                    .min_value(possible_sizes);
                 let ordered_size = ordered_size * size;
                 ordered_dims.push(dim_pair);
                 to_process.push((ordered_dims, remaining_dims, ordered_size));

--- a/src/ir/dimension.rs
+++ b/src/ir/dimension.rs
@@ -237,7 +237,9 @@ impl<'a, L> Statement<'a, L> for Dimension<'a, L> {
 }
 
 /// Provides a unique identifier for logic dimensions.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Ord, PartialOrd,
+)]
 #[repr(transparent)]
 pub struct LogicalDimId(pub u32);
 

--- a/src/ir/mem.rs
+++ b/src/ir/mem.rs
@@ -9,7 +9,9 @@ use utils::*;
 // TODO(cleanup): move layouts into internal blocks.
 
 /// Uniquely identifies a block.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Ord, PartialOrd,
+)]
 #[repr(transparent)]
 pub struct MemId(pub u32);
 

--- a/src/model/size.rs
+++ b/src/model/size.rs
@@ -62,8 +62,8 @@ pub fn dim_bounds(dim: ir::DimId, space: &SearchSpace) -> Range {
     let size = space.domain().get_size(dim);
     let universe = unwrap!(space.ir_instance().dim(dim).possible_sizes());
     Range {
-        min: size.min(universe).into(),
-        max: size.max(universe).into(),
+        min: size.min_value(universe).into(),
+        max: size.max_value(universe).into(),
     }
 }
 

--- a/telamon-gen/cc_tests/src/main.rs
+++ b/telamon-gen/cc_tests/src/main.rs
@@ -99,18 +99,18 @@ mod single_enum {
         assert_eq!(all.lcm(universe), 120);
 
         // Test comparison operators.
-        assert!(all.lt(universe, Range::new_eq(&(), 9, &()), &()));
-        assert!(!all.lt(universe, Range::new_eq(&(), 8, &()), &()));
-        assert!(all.gt(universe, Range::new_eq(&(), 0, &()), &()));
-        assert!(!all.gt(universe, Range::new_eq(&(), 1, &()), &()));
-        assert!(all.leq(universe, Range::new_eq(&(), 8, &()), &()));
-        assert!(!all.leq(universe, Range::new_eq(&(), 7, &()), &()));
-        assert!(all.geq(universe, Range::new_eq(&(), 1, &()), &()));
-        assert!(!all.geq(universe, Range::new_eq(&(), 2, &()), &()));
-        assert!(all.neq(universe, &[6, 7][..], &()));
-        assert!(!all.neq(universe, &[4, 7][..], &()));
+        assert!(all.is_lt(universe, Range::new_eq(&(), 9, &()), &()));
+        assert!(!all.is_lt(universe, Range::new_eq(&(), 8, &()), &()));
+        assert!(all.is_gt(universe, Range::new_eq(&(), 0, &()), &()));
+        assert!(!all.is_gt(universe, Range::new_eq(&(), 1, &()), &()));
+        assert!(all.is_leq(universe, Range::new_eq(&(), 8, &()), &()));
+        assert!(!all.is_leq(universe, Range::new_eq(&(), 7, &()), &()));
+        assert!(all.is_geq(universe, Range::new_eq(&(), 1, &()), &()));
+        assert!(!all.is_geq(universe, Range::new_eq(&(), 2, &()), &()));
+        assert!(all.is_neq(universe, &[6, 7][..], &()));
+        assert!(!all.is_neq(universe, &[4, 7][..], &()));
         let uni2_minus_uni1 = NumericSet::new_eq(universe2, &[2, 9][..], &());
-        assert!(all.neq(universe, uni2_minus_uni1, universe2));
+        assert!(all.is_neq(universe, uni2_minus_uni1, universe2));
 
         // Test constructors.
         assert_eq!(

--- a/telamon-gen/src/print/filter.rs
+++ b/telamon-gen/src/print/filter.rs
@@ -239,12 +239,12 @@ fn comparison(
 impl quote::ToTokens for ir::CmpOp {
     fn to_tokens(&self, stream: &mut TokenStream) {
         let name = match self {
-            ir::CmpOp::Eq => "eq",
-            ir::CmpOp::Neq => "neq",
-            ir::CmpOp::Lt => "lt",
-            ir::CmpOp::Gt => "gt",
-            ir::CmpOp::Leq => "leq",
-            ir::CmpOp::Geq => "geq",
+            ir::CmpOp::Eq => "is_eq",
+            ir::CmpOp::Neq => "is_neq",
+            ir::CmpOp::Lt => "is_lt",
+            ir::CmpOp::Gt => "is_gt",
+            ir::CmpOp::Leq => "is_leq",
+            ir::CmpOp::Geq => "is_geq",
         };
         // TODO(span): get the real span from the lexer
         Ident::new(name, Span::call_site()).to_tokens(stream);

--- a/telamon-gen/src/print/runtime/integer_domain.rs
+++ b/telamon-gen/src/print/runtime/integer_domain.rs
@@ -10,9 +10,9 @@ pub fn get() -> TokenStream {
             type Universe: ?Sized;
 
             /// Returns the maximum value in the domain.
-            fn min(&self, universe: &Self::Universe) -> u32;
+            fn min_value(&self, universe: &Self::Universe) -> u32;
             /// Returns the minimum value in the domain.
-            fn max(&self, universe: &Self::Universe) -> u32;
+            fn max_value(&self, universe: &Self::Universe) -> u32;
 
             /// Converts the domain into a numeric set with the given domain. Values that
             /// are not in `new_universe` are skipped.
@@ -21,9 +21,9 @@ pub fn get() -> TokenStream {
                 self_universe: &Self::Universe,
                 new_universe: &[u32]
             ) -> NumericSet {
-                let start = new_universe.binary_search(&self.min(self_universe))
+                let start = new_universe.binary_search(&self.min_value(self_universe))
                     .unwrap_or_else(|x| x);
-                let len = new_universe.binary_search(&self.max(self_universe))
+                let len = new_universe.binary_search(&self.max_value(self_universe))
                     .unwrap_or_else(|x| x) - start;
                 let enabled_values = ((1 << len) - 1) << start;
                 NumericSet { enabled_values }
@@ -31,40 +31,40 @@ pub fn get() -> TokenStream {
 
             /// Returns the value of the domain, if it is constrained.
             fn as_constrained(&self, universe: &Self::Universe) -> Option<u32> {
-                let value = self.min(universe);
-                if value == self.max(universe) { Some(value) } else { None }
+                let value = self.min_value(universe);
+                if value == self.max_value(universe) { Some(value) } else { None }
             }
 
-            fn lt<D: NumSet>(&self, universe: &Self::Universe,
+            fn is_lt<D: NumSet>(&self, universe: &Self::Universe,
                              other: D, other_universe: &D::Universe) -> bool {
-                self.max(universe) < other.min(other_universe)
+                self.max_value(universe) < other.min_value(other_universe)
             }
 
-            fn gt<D: NumSet>(&self, universe: &Self::Universe,
+            fn is_gt<D: NumSet>(&self, universe: &Self::Universe,
                              other: D, other_universe: &D::Universe) -> bool {
-                self.min(universe) > other.max(other_universe)
+                self.min_value(universe) > other.max_value(other_universe)
             }
 
-            fn leq<D: NumSet>(&self, universe: &Self::Universe,
+            fn is_leq<D: NumSet>(&self, universe: &Self::Universe,
                               other: D, other_universe: &D::Universe) -> bool {
-                self.max(universe) <= other.min(other_universe)
+                self.max_value(universe) <= other.min_value(other_universe)
             }
 
-            fn geq<D: NumSet>(&self, universe: &Self::Universe,
+            fn is_geq<D: NumSet>(&self, universe: &Self::Universe,
                               other: D, other_universe: &D::Universe) -> bool {
-                self.min(universe) >= other.max(other_universe)
+                self.min_value(universe) >= other.max_value(other_universe)
             }
 
-            fn eq<D: NumSet>(&self, universe: &Self::Universe,
+            fn is_eq<D: NumSet>(&self, universe: &Self::Universe,
                              other: D, other_universe: &D::Universe) -> bool {
-                self.min(universe) == other.max(other_universe) &&
-                    self.max(universe) == other.min(other_universe)
+                self.min_value(universe) == other.max_value(other_universe) &&
+                    self.max_value(universe) == other.min_value(other_universe)
             }
 
-            fn neq<D: NumSet>(&self, universe: &Self::Universe,
+            fn is_neq<D: NumSet>(&self, universe: &Self::Universe,
                               other: D, other_universe: &D::Universe) -> bool {
-                self.min(universe) > other.max(other_universe) ||
-                    self.max(universe) < other.min(other_universe)
+                self.min_value(universe) > other.max_value(other_universe) ||
+                    self.max_value(universe) < other.min_value(other_universe)
             }
         }
 
@@ -93,19 +93,19 @@ pub fn get() -> TokenStream {
         impl NumSet for u32 {
             type Universe = ();
 
-            fn min(&self, _: &()) -> u32 { *self }
+            fn min_value(&self, _: &()) -> u32 { *self }
 
-            fn max(&self, _: &()) -> u32 { *self }
+            fn max_value(&self, _: &()) -> u32 { *self }
         }
 
         impl<'a> NumSet for &'a [u32] {
             type Universe = ();
 
-            fn min(&self, _: &()) -> u32 {
+            fn min_value(&self, _: &()) -> u32 {
                 if self.is_empty() { 1 } else { self[0] }
             }
 
-            fn max(&self, _: &()) -> u32 {
+            fn max_value(&self, _: &()) -> u32 {
                 if self.is_empty() { 0 } else { self[self.len()-1] }
             }
 

--- a/telamon-gen/src/print/runtime/range.rs
+++ b/telamon-gen/src/print/runtime/range.rs
@@ -6,7 +6,7 @@ use quote::quote;
 pub fn get() -> TokenStream {
     quote! {
         /// Abstracts integer choices by a range.
-        #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+        #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Ord, PartialOrd)]
         #[repr(C)]
         pub struct Range {
             pub min: u32,
@@ -93,40 +93,40 @@ pub fn get() -> TokenStream {
         impl NumSet for Range {
             type Universe = ();
 
-            fn min(&self, _: &()) -> u32 { self.min }
+            fn min_value(&self, _: &()) -> u32 { self.min }
 
-            fn max(&self, _: &()) -> u32 { self.max }
+            fn max_value(&self, _: &()) -> u32 { self.max }
         }
 
         impl NumDomain for Range {
             fn new_gt<D: NumSet>(_: &(), min: D, min_universe: &D::Universe) -> Self {
-                let min = min.min(min_universe).saturating_add(1);
+                let min = min.min_value(min_universe).saturating_add(1);
                 Range { min, .. Range::ALL }
             }
 
             fn new_lt<D: NumSet>(_: &(), max: D, max_universe: &D::Universe) -> Self {
-                let max = max.max(max_universe).saturating_sub(1);
+                let max = max.max_value(max_universe).saturating_sub(1);
                 Range { max, .. Range::ALL }
             }
 
             fn new_geq<D: NumSet>(_: &(), min: D, min_universe: &D::Universe) -> Self {
-                Range { min: min.min(min_universe), .. Range::ALL }
+                Range { min: min.min_value(min_universe), .. Range::ALL }
             }
 
             fn new_leq<D: NumSet>(_: &(), max: D, max_universe: &D::Universe) -> Self {
-                Range { max: max.max(max_universe), .. Range::ALL }
+                Range { max: max.max_value(max_universe), .. Range::ALL }
             }
 
             fn new_eq<D: NumSet>(_: &(), eq: D, eq_universe: &D::Universe) -> Self {
                 Range {
-                    max: eq.max(eq_universe),
-                    min: eq.min(eq_universe),
+                    max: eq.max_value(eq_universe),
+                    min: eq.min_value(eq_universe),
                 }
             }
         }
 
         /// Abstracts integer choices by a range, but only store `min`.
-        #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+        #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Ord, PartialOrd)]
         #[repr(C)]
         pub struct HalfRange { pub min: u32 }
 
@@ -192,14 +192,14 @@ pub fn get() -> TokenStream {
         impl NumSet for HalfRange {
             type Universe = ();
 
-            fn min(&self, _: &()) -> u32 { self.min }
+            fn min_value(&self, _: &()) -> u32 { self.min }
 
-            fn max(&self, _: &()) -> u32 { std::u32::MAX }
+            fn max_value(&self, _: &()) -> u32 { std::u32::MAX }
         }
 
         impl NumDomain for HalfRange {
             fn new_gt<D: NumSet>(_: &(), min: D, min_universe: &D::Universe) -> Self {
-                let min = min.min(min_universe).saturating_add(1);
+                let min = min.min_value(min_universe).saturating_add(1);
                 HalfRange { min }
             }
 
@@ -208,7 +208,7 @@ pub fn get() -> TokenStream {
             }
 
             fn new_geq<D: NumSet>(_: &(), min: D, min_universe: &D::Universe) -> Self {
-                HalfRange { min: min.min(min_universe) }
+                HalfRange { min: min.min_value(min_universe) }
             }
 
             fn new_leq<D: NumSet>(_: &(), _: D, _: &D::Universe) -> Self {
@@ -216,7 +216,7 @@ pub fn get() -> TokenStream {
             }
 
             fn new_eq<D: NumSet>(_: &(), eq: D, eq_universe: &D::Universe) -> Self {
-                HalfRange { min: eq.min(eq_universe) }
+                HalfRange { min: eq.min_value(eq_universe) }
             }
         }
     }

--- a/telamon-gen/src/print/template/actions.rs
+++ b/telamon-gen/src/print/template/actions.rs
@@ -1,5 +1,5 @@
 /// A decision to apply to the domain.
-#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy, Serialize, Deserialize, Ord, PartialOrd)]
 #[repr(C)]
 pub enum Action {
     {{~#each choices}}

--- a/telamon-gen/src/print/template/choices.rs
+++ b/telamon-gen/src/print/template/choices.rs
@@ -1,4 +1,4 @@
-#[derive(PartialEq, Eq, Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Serialize, Deserialize, Hash, Ord, PartialOrd)]
 #[repr(C)]
 pub enum Choice {
     {{~#each choices}}

--- a/telamon-gen/src/print/template/enum_def.rs
+++ b/telamon-gen/src/print/template/enum_def.rs
@@ -1,5 +1,5 @@
 {doc_comment}
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
 #[repr(C)]
 pub struct {type_name} {{ bits: {bits_type} }}
 

--- a/telamon-gen/src/print/value.rs
+++ b/telamon-gen/src/print/value.rs
@@ -84,14 +84,14 @@ impl Value {
     /// Returns the minimum of an integer domain.
     pub fn get_min(&self, ctx: &print::Context) -> Self {
         let universe = universe(self.value_type(), ctx);
-        let tokens = quote::quote!(NumSet::min(&#self, #universe));
+        let tokens = quote::quote!(NumSet::min_value(&#self, #universe));
         Value::new(tokens, ir::ValueType::Constant)
     }
 
     /// Returns the maximum of an integer domain.
     pub fn get_max(&self, ctx: &print::Context) -> Self {
         let universe = universe(self.value_type(), ctx);
-        let tokens = quote::quote!(NumSet::max(&#self, #universe));
+        let tokens = quote::quote!(NumSet::max_value(&#self, #universe));
         Value::new(tokens, ir::ValueType::Constant)
     }
 }


### PR DESCRIPTION
This patch derives the `Ord` and `PartialOrd` trait for actions,
allowing them to be ordered and sorted (typically for display).  Since
we already use `min`, `max`, `lt`, etc. functions on the bit enums for
our own custom traits, there were confusion with the native `Ord` and
`PartialOrd` methods, so the custom ones are renamed.