### PR TITLE
Use relative error in kernel error checking

### DIFF
--- a/kernels/src/kernel.rs
+++ b/kernels/src/kernel.rs
@@ -52,6 +52,7 @@ pub trait Kernel<'a>: Sized {
         signature: &'b ir::Signature,
         ctx: &'b dyn device::Context,
     ) -> Vec<Candidate<'b>>;
+
     /// Computes the expected output.
     fn get_expected_output(&self, _: &dyn device::Context) -> Self::ExpectedOutput;
 

--- a/kernels/src/lib.rs
+++ b/kernels/src/lib.rs
@@ -6,12 +6,16 @@ mod kernel;
 pub mod linalg;
 pub mod statistics;
 
+use std::fmt;
+
 pub use crate::kernel::{analyze_bounds, Kernel};
 
 use telamon::device::{self, ArgMap, Context};
 use telamon::helper::tensor::DimSize;
 use telamon::helper::{self, SignatureBuilder};
 use telamon::{explorer, model, search_space};
+
+use ::ndarray::{ArrayBase, Data, Dimension, FoldWhile, Zip};
 
 /// Creates a candidate from the search space and registers the tile sizes in it.
 fn build_candidate<'a>(
@@ -51,35 +55,187 @@ fn infer_tiling(
         .unwrap_or_else(|| helper::TilingPattern::infer_pattern(size as u32, max_sizes))
 }
 
-/// A scalar that can be used as the data type for tests.
-pub trait Scalar:
-    device::ScalarArgument
-    + ndarray::LinalgScalar
-    + ndarray::ScalarOperand
-    + PartialOrd
-    + std::ops::Neg<Output = Self>
+/// Returns `true` if two arrays are element-wise equal within a tolerance.
+///
+/// The tolerance values are defined by the absolute and relative offsets from the `Scalar` trait
+/// for the corresponding type.
+///
+/// The relative difference (`rtol` * abs(`b`)) and the absolute difference `atol` are added
+/// together and compared against the absolute difference between `a` and `b`.
+///
+/// # Panics
+///
+/// If broadcasting the arrays to the same shape is not possible.
+fn allclose<A, S, D, S2, E>(a: &ArrayBase<S, D>, b: &ArrayBase<S2, E>) -> bool
+where
+    A: Scalar,
+    S: Data<Elem = A>,
+    S2: Data<Elem = A>,
+    D: Dimension,
+    E: Dimension,
 {
-    /// Returns the amount of allowed error in tests.
-    fn epsilon() -> Self {
-        Self::zero()
-    }
+    !Zip::from(a)
+        .and_broadcast(b)
+        .fold_while((), |_, x, y| {
+            if (*x - *y).abs() < A::atol() + A::rtol() * y.abs() {
+                FoldWhile::Continue(())
+            } else {
+                FoldWhile::Done(())
+            }
+        })
+        .is_done()
+}
 
-    /// Indicates if the scalar can be considered as zero in the context of error
-    /// checking.
-    fn is_err_ok(self) -> bool {
-        self > Self::epsilon() || -self > Self::epsilon()
+/// Information about an incorrect output from a kernel.
+///
+/// This is meant to be used as an error in a `Result`, and will print the corresponding to the
+/// maximum and average errors when displayed.
+#[derive(Debug)]
+struct IncorrectOutputError<S> {
+    max_absolute_error: S,
+    sum_absolute_error: S,
+    max_relative_error: S,
+    sum_relative_error: S,
+    num_above_threshold: usize,
+    total_size: usize,
+}
+
+impl<S: Scalar> Default for IncorrectOutputError<S> {
+    fn default() -> Self {
+        IncorrectOutputError {
+            max_absolute_error: S::zero(),
+            sum_absolute_error: S::zero(),
+            max_relative_error: S::zero(),
+            sum_relative_error: S::zero(),
+            num_above_threshold: 0,
+            total_size: 0,
+        }
     }
 }
 
+impl<S: Scalar> std::error::Error for IncorrectOutputError<S> {}
+
+impl<S: Scalar> IncorrectOutputError<S> {
+    fn max_absolute_error(&self) -> S {
+        self.max_absolute_error
+    }
+
+    fn avg_absolute_error(&self) -> S {
+        self.sum_absolute_error / S::from(self.total_size).unwrap()
+    }
+
+    fn max_relative_error(&self) -> S {
+        self.max_relative_error
+    }
+
+    fn avg_relative_error(&self) -> S {
+        self.sum_relative_error / S::from(self.total_size).unwrap()
+    }
+
+    fn fraction_above_threshold(&self) -> S {
+        S::from(self.num_above_threshold).unwrap() / S::from(self.total_size).unwrap()
+    }
+}
+
+impl<S> fmt::Display for IncorrectOutputError<S>
+where
+    S: Scalar,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "error max ± {:.4e} ({:.2}%), avg ± {:.4e} ({:.2}%), with {}/{} ({:.2}%) values above threshold",
+            self.max_absolute_error(),
+            self.max_relative_error() * S::from(100).unwrap(),
+            self.avg_absolute_error(),
+            self.avg_relative_error() * S::from(100).unwrap(),
+            self.num_above_threshold,
+            self.total_size,
+            self.fraction_above_threshold() * S::from(100).unwrap(),
+        )
+    }
+}
+
+fn check_output<A, S, D, S2, E>(
+    actual: &ArrayBase<S, D>,
+    expected: &ArrayBase<S2, E>,
+) -> Result<(), IncorrectOutputError<A>>
+where
+    A: Scalar,
+    S: Data<Elem = A>,
+    S2: Data<Elem = A>,
+    D: Dimension,
+    E: Dimension,
+{
+    if allclose(actual, expected) {
+        Ok(())
+    } else {
+        Err(Zip::from(actual)
+            .and_broadcast(expected)
+            .fold_while(
+                IncorrectOutputError::default(),
+                |output_diff, actual, expected| {
+                    let absolute_error = (*actual - *expected).abs();
+                    let relative_error = absolute_error / expected.abs();
+                    FoldWhile::Continue(IncorrectOutputError {
+                        max_absolute_error: if absolute_error
+                            > output_diff.max_absolute_error
+                        {
+                            absolute_error
+                        } else {
+                            output_diff.max_absolute_error
+                        },
+                        sum_absolute_error: output_diff.sum_absolute_error
+                            + absolute_error,
+                        max_relative_error: if relative_error
+                            > output_diff.max_relative_error
+                        {
+                            relative_error
+                        } else {
+                            output_diff.max_relative_error
+                        },
+                        sum_relative_error: output_diff.sum_relative_error
+                            + relative_error,
+                        num_above_threshold: output_diff.num_above_threshold
+                            + if absolute_error < A::atol() + A::rtol() * expected.abs() {
+                                0
+                            } else {
+                                1
+                            },
+                        total_size: output_diff.total_size + 1,
+                    })
+                },
+            )
+            .into_inner())
+    }
+}
+
+/// A scalar that can be used as the data type for tests.
+pub trait Scalar: device::ScalarArgument + ndarray::NdFloat {
+    /// Absolute tolerance for errors.
+    fn atol() -> Self;
+
+    /// Relative tolerance for errors.
+    fn rtol() -> Self;
+}
+
 impl Scalar for f32 {
-    fn epsilon() -> Self {
-        10e-6
+    fn atol() -> Self {
+        1e-8
+    }
+
+    fn rtol() -> Self {
+        1e-5
     }
 }
 
 impl Scalar for f64 {
-    fn epsilon() -> Self {
-        10e-6
+    fn atol() -> Self {
+        1e-8
+    }
+
+    fn rtol() -> Self {
+        1e-5
     }
 }
 


### PR DESCRIPTION
Currently we are checking kernel output using a single threshold of
`1e-5` on the absolute error.  However, for large kernels, this is not
appropriate: errors accumulate on large sums, and can overflow the
threshold even for correct computations.

Instead, this patch makes it so that we check correctness using a
combination of an absolute and relative threshold.  This alleviates the
problem since large sums will have higher absolute values[1] and hence
will allow for more leeway thanks to the relative threshold term.

The implementation is similar to the NumPy `np.allclose` function, that
is, we add the absolute and relative tolerance and compare with the
absolute difference.  The absolute and relative tolerance are 1e-8 and
1e-5 respectively, following again the default values from
`np.allclose`.

At the same time, the patch also changes the error displayed in case of
correctness errors:  instead of dumping sometimes large tensors in
a textual form, it now prints summary statistics of the absolute and
relative errors, as well as the proportion of elements failing the
`allclose` check.

Note that those two issues are related to now checking correctness of
full kernels during evaluation: where previously we were only checking
correctness on small toy examples in tests, we are now checking
correctness on large tensors -- which makes the error messages way too
large (we search axpy with sizes of 2^26 -- one single error message was
gigabytes long!), and also introduces the additional precision issues.

Additionally, one should note that, due to the transformations we
currently support, there should not be any error at all (in fact, if one
looks closely, the errors for all correct Telamon kernels are always
the same).  In particular, we do not reorder the arithmetic operations.
The error that we observe should thus be attributed to (a) optimizations in
the reference implementations we compare against compared to the naive
version and possibly (b) the use of fused multiply-add instructions on
some platforms.

 1: Except where loss of significance occurs, typically.  But since we
    only generate positive random floats this shouldn't be an issue for
    us in practice; if it is, we can revisit the approach and e.g. scale the
    error depending on the kernel sizes.  The advantage of using a
    relative error is that it doesn't require any inner knowledge of the
    kernel semantics and provide a generally acceptable check.

kernels/:
 - src/lib.rs:  Add new error-checking functions
 - src/linalg.rs:  Use the new error-checking functions
 - src/kernel.rs:  Add missing space.