### PR TITLE
Unify `futures` and `crossbeam` versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,10 @@ path = "telamon-gen"
 binary-heap-plus = "0.1.4"
 byteorder = "1"
 config = "0.8.0"
-crossbeam = "0.3.2"
+crossbeam = "0.7"
 env_logger = "0.5.9"
 failure = "0.1.1"
-futures-preview = "0.2"
+futures = "0.1.3"
 fnv = "1.0"
 getopts = "0.2.17"
 indexmap = "1.0"
@@ -71,7 +71,6 @@ flate2 = "1.0.2"
 dot = "0.1"
 csv = "1"
 utils = {package = "telamon-utils", path = "telamon-utils"}
-tokio-timer = { git = "https://github.com/ulysseB/tokio-timer.git" }
 telajax = {path = "telajax", optional = true}
 
 

--- a/src/explorer/monitor.rs
+++ b/src/explorer/monitor.rs
@@ -6,15 +6,17 @@ use crate::explorer::candidate::Candidate;
 use crate::explorer::config::Config;
 use crate::explorer::logger::LogMessage;
 use crate::explorer::store::Store;
-use futures::channel;
-use futures::executor::block_on;
 use futures::prelude::*;
+use futures::{executor, future, task, Async};
 use log::warn;
 use serde::{Deserialize, Serialize};
-use std;
-use std::sync;
+use std::sync::{
+    self,
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::time::{Duration, Instant};
-use tokio_timer::*;
+use std::{self, thread};
 use utils::unwrap;
 
 pub type MonitorMessage<'a, T> = (Candidate<'a>, f64, <T as Store<'a>>::PayLoad);
@@ -26,12 +28,6 @@ pub enum TerminationReason {
     MaxEvaluations,
     /// The timeout was reached.
     Timeout,
-}
-
-impl<T> From<TimeoutError<T>> for TerminationReason {
-    fn from(_: TimeoutError<T>) -> Self {
-        TerminationReason::Timeout
-    }
 }
 
 impl std::fmt::Display for TerminationReason {
@@ -68,7 +64,7 @@ pub fn monitor<'a, T, E>(
     config: &Config,
     context: &dyn Context,
     candidate_store: &T,
-    recv: channel::mpsc::Receiver<MonitorMessage<'a, T>>,
+    recv: futures::sync::mpsc::Receiver<MonitorMessage<'a, T>>,
     log_sender: sync::mpsc::SyncSender<LogMessage<E>>,
 ) -> Option<Candidate<'a>>
 where
@@ -77,27 +73,35 @@ where
     warn!("Monitor waiting for evaluation results");
     let t0 = Instant::now();
     let mut status = Status::default();
-    let res = if config.timeout.is_some() {
-        block_until_timeout(
-            config,
-            context,
-            recv,
-            t0,
-            candidate_store,
-            &log_sender,
-            &mut status,
-        )
-    } else {
-        block_unbounded(
-            config,
-            context,
-            recv,
-            t0,
-            candidate_store,
-            &log_sender,
-            &mut status,
-        )
+
+    let res = {
+        let log_sender_ref = &log_sender;
+        let status_mut = &mut status;
+        let mut future: Box<dyn Future<Item = _, Error = _>> =
+            Box::new(recv.map_err(|()| unreachable!()).for_each(move |message| {
+                handle_message(
+                    config,
+                    context,
+                    message,
+                    t0,
+                    candidate_store,
+                    log_sender_ref,
+                    status_mut,
+                )
+            }));
+
+        if let Some(timeout_mins) = config.timeout {
+            future = Box::new(
+                future
+                    .select(timeout(Duration::from_secs(timeout_mins * 60)))
+                    .map(|((), _)| ())
+                    .map_err(|(err, _)| err),
+            );
+        }
+
+        executor::spawn(future).wait_future()
     };
+
     let duration = t0.elapsed();
     let duration_secs =
         duration.as_secs() as f64 + f64::from(duration.subsec_nanos()) * 1e-9;
@@ -131,78 +135,6 @@ fn get_new_cut(config: &Config, eval: f64) -> f64 {
     } else {
         eval
     }
-}
-
-/// Given a receiver channel, constructs a future that returns whenever the
-/// tree has been fully explored.
-fn block_unbounded<'a, T, E>(
-    config: &Config,
-    context: &dyn Context,
-    receiver: channel::mpsc::Receiver<MonitorMessage<'a, T>>,
-    t0: Instant,
-    candidate_store: &T,
-    log_sender: &sync::mpsc::SyncSender<LogMessage<E>>,
-    status: &mut Status<'a>,
-) -> Result<(), TerminationReason>
-where
-    T: Store<'a>,
-{
-    block_on(
-        receiver
-            .map_err(|n| n.never_into())
-            .for_each(move |message| {
-                handle_message::<T, E>(
-                    config,
-                    context,
-                    message,
-                    t0,
-                    candidate_store,
-                    log_sender,
-                    status,
-                )
-            }),
-    )
-    .map(|_| ())
-}
-
-/// Given a receiver channel, builds a future that returns whenever the tree
-/// has been fully explored or the timeout has been reached
-fn block_until_timeout<'a, 'b, T, E>(
-    config: &'b Config,
-    context: &dyn Context,
-    receiver: channel::mpsc::Receiver<MonitorMessage<'a, T>>,
-    t0: Instant,
-    candidate_store: &'b T,
-    log_sender: &'b sync::mpsc::SyncSender<LogMessage<E>>,
-    status: &'b mut Status<'a>,
-) -> Result<(), TerminationReason>
-where
-    T: Store<'a>,
-{
-    let timer = configure_timer();
-    //TODO Find a clean way to get a timeout that never returns - or no timeout at
-    // all
-    let timeout = config.timeout.unwrap_or(10000);
-    let time = Duration::from_secs(timeout as u64 * 60);
-    block_on(
-        timer.timeout(
-            receiver
-                .map_err(|n| n.never_into())
-                .for_each(move |message| {
-                    handle_message::<T, E>(
-                        config,
-                        context,
-                        message,
-                        t0,
-                        candidate_store,
-                        log_sender,
-                        status,
-                    )
-                })
-                .map(|_| ()),
-            time,
-        ),
-    )
 }
 
 /// All work that has to be done on reception of a message, meaning updating
@@ -276,11 +208,63 @@ where
     Ok(())
 }
 
-/// Builds and returns a timer that suits our needs - that is, which timeout
-/// can be set to at least a few tens of hours
-fn configure_timer() -> Timer {
-    let builder = wheel();
-    let builder = builder.tick_duration(Duration::new(10, 0));
-    let builder = builder.num_slots(usize::pow(2, 16));
-    builder.build()
+struct TimeoutWorker {
+    running: Arc<AtomicBool>,
+    thread: thread::Thread,
+}
+
+impl Drop for TimeoutWorker {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Relaxed);
+        self.thread.unpark();
+    }
+}
+
+/// Creates a new future which will return with a `TerminationReason::Timeout` error after the
+/// `duration` has elapsed.
+///
+/// This creates a background thread which sleeps for the requested amount of time, then notifies
+/// the future to be polled and return with an error.
+fn timeout(duration: Duration) -> impl Future<Item = (), Error = TerminationReason> {
+    let start_time = std::time::Instant::now();
+
+    let mut worker = None;
+    future::poll_fn(move || {
+        if start_time.elapsed() > duration {
+            Err(TerminationReason::Timeout)
+        } else {
+            // If we were polled before the timeout exceeded, we need to setup a worker thread
+            // which will notify the task when the timeout expires.  If we don't, the futures
+            // runtime may never poll on our future again (un-notified polls after the first one
+            // are allowed, but not guaranteed), in which case we would never actually time out.
+            if worker.is_none() {
+                let running = Arc::new(AtomicBool::new(true));
+                let task = task::current();
+                let thread_running = Arc::clone(&running);
+                let thread = thread::Builder::new()
+                    .name("Telamon - Timeout".to_string())
+                    .spawn(move || loop {
+                        if !thread_running.load(Ordering::Relaxed) {
+                            break;
+                        }
+
+                        let elapsed = start_time.elapsed();
+                        if elapsed < duration {
+                            // Use park_timeout instead of sleep here so that we can be woken up and
+                            // exit when the `TimeoutWorker` goes out of scope.
+                            thread::park_timeout(duration - elapsed);
+                        } else {
+                            task.notify();
+                        }
+                    })
+                    .unwrap()
+                    .thread()
+                    .clone();
+
+                worker = Some(TimeoutWorker { running, thread });
+            }
+
+            Ok(Async::NotReady)
+        }
+    })
 }


### PR DESCRIPTION
This patch makes us use the same version of `futures` and `crossbeam`
between the different crates, and avoids using the yanked 0.2 version of
futures.  Note that `tokio` is incompatible with `futures` 0.2.

It also removes the dependency on our custom patched `tokio-timer`.
Instead, we use a very simple implementation of a timeout using a
background thread which sleeps until the timeout it reached.  This is
very similar to what `tokio-timer` does under the hood -- except that
`tokio-timer` is orders of magnitude more complex because it is designed
to be able to dispatch a lot of timers at once and shares the background
thread between them.  It also uses some more precise mechanisms in
addition to `sleep` -- but we don't care about all those features: we
only ever have a single timeout in the system and a simple sleeping
thread does the job.