### PR TITLE
Introduce a simpler API for building kernels

### DIFF
--- a/kernels/benches/cuda_bound.rs
+++ b/kernels/benches/cuda_bound.rs
@@ -1,4 +1,5 @@
 //! Benchmarks the accuracy of bounds on CUDA GPUs.
+use telamon::helper::MemInit;
 use telamon_cuda as cuda;
 use telamon_kernels::{analyze_bounds, linalg, Kernel};
 
@@ -25,7 +26,7 @@ where
     K: Kernel<'a>,
 {
     let mut context = cuda::Context::new(executor);
-    let bounds = K::test_bound(params, num_runs, true, &mut context);
+    let bounds = K::test_bound(params, num_runs, MemInit::RandomFill, &mut context);
     println!("bounds for kernel {}", K::name());
     analyze_bounds(bounds);
 }

--- a/kernels/benches/cuda_search.rs
+++ b/kernels/benches/cuda_search.rs
@@ -2,6 +2,7 @@
 use cuda_sys::cublas::*;
 use cuda_sys::cuda::*;
 use telamon::explorer::config::Config;
+use telamon::helper::MemInit;
 use telamon_cuda as cuda;
 use telamon_kernels::statistics::estimate_mean;
 use telamon_kernels::{linalg, Kernel};
@@ -95,8 +96,13 @@ fn benchmark<'a, K, REF>(
     //config.distance_to_best.get_or_insert(20.);
 
     let mut context = cuda::Context::new(executor);
-    let runtime =
-        K::benchmark(&config, params.clone(), NUM_CODE_RUNS, true, &mut context);
+    let runtime = K::benchmark(
+        &config,
+        params.clone(),
+        NUM_CODE_RUNS,
+        MemInit::RandomFill,
+        &mut context,
+    );
     for _ in 0..4 {
         reference(&params, &context);
     }

--- a/kernels/src/lib.rs
+++ b/kernels/src/lib.rs
@@ -8,7 +8,7 @@ pub mod statistics;
 
 use std::fmt;
 
-pub use crate::kernel::{analyze_bounds, Kernel};
+pub use crate::kernel::{analyze_bounds, Kernel, KernelBuilder};
 
 use telamon::device::{self, ArgMap, Context};
 use telamon::helper::tensor::DimSize;

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -7,7 +7,7 @@ pub mod tensor;
 
 pub use self::builder::Builder;
 pub use self::operand::{AutoOperand, Reduce, TmpArray};
-pub use self::signature::Builder as SignatureBuilder;
+pub use self::signature::{Builder as SignatureBuilder, MemInit};
 
 use crate::ir;
 use serde::{Deserialize, Serialize};

--- a/telamon-capi/src/lib.rs
+++ b/telamon-capi/src/lib.rs
@@ -14,7 +14,7 @@ pub mod search_space;
 use libc::{c_char, c_int, c_uint, size_t, uint32_t};
 use telamon::device;
 use telamon::explorer::config::Config;
-use telamon::helper::TilingPattern;
+use telamon::helper::{MemInit, TilingPattern};
 pub use telamon_kernels::{linalg, Kernel};
 use telamon_x86 as x86;
 
@@ -64,7 +64,7 @@ impl KernelParameters {
                     config,
                     params.clone(),
                     0,
-                    true,
+                    MemInit::RandomFill,
                     context,
                 );
             }


### PR DESCRIPTION
This patch introduces `KernelBuilder`, which is a tiny wrapper around
`SignatureBuilder` for building kernels, simplifying the creation of a
kernel, especially when creating the kernel outside the `Kernel` trait.

In addition, it makes the memory initialization strategy explicit using
an appropriate `MemInit` enum instead of using naked booleans.