### PR TITLE
Minor Fixes in mppa

### DIFF
--- a/backend/mppa/src/context.rs
+++ b/backend/mppa/src/context.rs
@@ -350,7 +350,7 @@ struct Code<'a> {
 
 impl<'a> fmt::Display for Code<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "<mppa kernel>");
+        write!(fmt, "<mppa kernel>")
     }
 }
 
@@ -360,6 +360,6 @@ impl<'a> KernelEvaluator for Code<'a> {
         let t0 = Instant::now();
         self.executor.execute_kernel(&mut self.kernel).unwrap();
         let d = t0.elapsed();
-        Some(d.subsec_nanos() as f64 + d.secs() as f64 * 1_000_000_000.)
+        Some(d.subsec_nanos() as f64 + d.as_secs() as f64 * 1_000_000_000.)
     }
 }


### PR DESCRIPTION
Two minor errors - a superfluous semi-column and a typo - were introduced by mistakes - and also the fact that we can't compile telamon-mppa on standard machines. 