### PR TITLE
Format floating point literals correctly in x86 and MPPA backends

### DIFF
--- a/backend/x86/src/lib.rs
+++ b/backend/x86/src/lib.rs
@@ -12,6 +12,7 @@ pub use crate::cpu::Cpu;
 
 use num::bigint::BigInt;
 use num::rational::Ratio;
+use num::traits::Float;
 use num::ToPrimitive;
 use telamon::codegen;
 use telamon::ir;
@@ -46,7 +47,23 @@ impl codegen::ValuePrinter for ValuePrinter {
     fn get_const_float(&self, val: &Ratio<BigInt>, len: u16) -> String {
         assert!(len <= 64);
         let f = unwrap!(val.numer().to_f64()) / unwrap!(val.denom().to_f64());
-        f.to_string()
+
+        // Print in C99 hexadecimal floating point representation
+        let (mantissa, exponent, sign) = f.integer_decode();
+        let signchar = if sign < 0 { "-" } else { "" };
+
+        // Assume that floats and doubles in the C implementation have
+        // 32 and 64 bits, respectively
+        let floating_suffix = match len {
+            32 => "f",
+            64 => "",
+            _ => panic!("Cannot print floating point value with {} bits", len),
+        };
+
+        format!(
+            "{}0x{:x}p{}{}",
+            signchar, mantissa, exponent, floating_suffix
+        )
     }
 
     fn get_const_int(&self, val: &BigInt, len: u16) -> String {


### PR DESCRIPTION
Currently, both the x86 and MPPA backend print floating point literals using
f64::to_string(). This causes two problems.

First, floating point values without decimal places are printed without a
trailing ".0", which lets the C compiler interpret them as integer
literals. This results in a warning for valid floating point values which are
outside of the range of an integer.

Second, this prevents the C compiler from emitting a warning for values that
should be represented as C floats, but which are out of range.

This patch adds proper suffixes to floating point literals, avoiding the
above-mentioned problems. For floating point types with an unusual number of
bits (i.e., neither 32 nor 64 bits), the formatting function panics.