### PR TITLE
Improve internal data structures pretty-printing

### DIFF
--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -4,7 +4,7 @@ use std::{self, fmt};
 use crate::codegen::{
     self, cfg, dimension, Cfg, Dimension, InductionLevel, InductionVar,
 };
-use crate::ir;
+use crate::ir::{self, IrDisplay};
 use crate::search_space::{self, DimKind, Domain, MemSpace, SearchSpace};
 use utils::unwrap;
 use utils::*;
@@ -147,6 +147,26 @@ impl<'a> Function<'a> {
     /// be computed in the provided order.
     pub fn init_induction_levels(&self) -> &[InductionLevel] {
         &self.init_induction_levels
+    }
+}
+
+impl<'a> fmt::Display for Function<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(
+            fmt,
+            "BLOCKS[{}]({}) THREADS[{}]({})",
+            self.block_dims.iter().map(|d| d.size()).format(", "),
+            self.block_dims
+                .iter()
+                .map(|d| d.dim_ids().format(" = "))
+                .format(", "),
+            self.thread_dims.iter().map(|d| d.size()).format(", "),
+            self.thread_dims
+                .iter()
+                .map(|d| d.dim_ids().format(" = "))
+                .format(", "),
+        )?;
+        write!(fmt, "{}", self.cfg().display(self.space.ir_instance()))
     }
 }
 
@@ -420,6 +440,11 @@ impl<'a> Instruction<'a> {
     /// Returns the operator computed by the instruction.
     pub fn operator(&self) -> &ir::Operator {
         self.instruction.operator()
+    }
+
+    /// Returns the IR instruction from which this codegen instruction was created.
+    pub fn ir_instruction(&self) -> &ir::Instruction {
+        self.instruction
     }
 
     /// Returns the dimensions on which to instantiate the instruction.

--- a/src/codegen/size.rs
+++ b/src/codegen/size.rs
@@ -2,6 +2,7 @@ use crate::ir;
 use crate::search_space::{NumSet, SearchSpace};
 use num;
 use std;
+use std::fmt;
 use utils::unwrap;
 
 /// The size of an iteration dimension. The size is of the form:
@@ -85,6 +86,30 @@ impl<'a, 'b> std::ops::MulAssign<&'b Size<'a>> for Size<'a> {
         self.dividend.extend(rhs.dividend.iter().cloned());
         self.divisor *= rhs.divisor;
         self.simplify();
+    }
+}
+
+impl<'a> fmt::Display for Size<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let mut pre = false;
+        if self.factor != 1 {
+            write!(fmt, "{}", self.factor)?;
+            pre = true;
+        }
+
+        for p in &self.dividend {
+            if pre {
+                write!(fmt, "*")?;
+            }
+            write!(fmt, "{}", p)?;
+            pre = true;
+        }
+
+        if self.divisor != 1 {
+            write!(fmt, "/{}", self.divisor)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/src/explorer/choice.rs
+++ b/src/explorer/choice.rs
@@ -38,6 +38,23 @@ impl fmt::Debug for ActionEx {
     }
 }
 
+impl ir::IrDisplay for ActionEx {
+    fn fmt(&self, fmt: &mut fmt::Formatter, function: &ir::Function) -> fmt::Result {
+        match self {
+            ActionEx::Action(action) => write!(fmt, "{}", action.display(function)),
+            ActionEx::LowerLayout {
+                mem,
+                st_dims,
+                ld_dims,
+            } => write!(
+                fmt,
+                "LowerLayout {{ mem: {:?}, st_dims: {:?}, ld_dims: {:?} }}",
+                mem, st_dims, ld_dims
+            ),
+        }
+    }
+}
+
 /// Represents a choice that splits a search space in multiple ones.
 // TODO(search_space): explore and lower loayouts directly from the regular actions.
 pub type Choice = Vec<ActionEx>;

--- a/src/helper/builder.rs
+++ b/src/helper/builder.rs
@@ -405,6 +405,10 @@ impl Builder {
             .into_iter()
             .flat_map(|(dim, size)| {
                 let mut size: ir::PartialSize = size.into();
+                // `dimensions()` returns the dimensions from inner-most to outer-most, but we want
+                // them from outer-most to inner-most for display.  Note that we don't otherwise
+                // depend on the order of the increments; they are only used as a DimId ->
+                // PartialSize mapping.
                 self.function
                     .logical_dim(dim.id())
                     .dimensions()
@@ -413,6 +417,9 @@ impl Builder {
                         size *= self.function.dim(dim).size();
                         (dim, increment)
                     })
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .rev()
             })
             .collect()
     }

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use std::{self, fmt};
 
 use crate::device::Device;
-use crate::ir::{self, Dimension, InstId, Instruction, Operator, Statement, StmtId};
+use crate::ir::{
+    self, Dimension, InstId, Instruction, IrDisplay, Operator, Statement, StmtId,
+};
 use crate::ir::{mem, AccessPattern, Operand, SparseVec};
 use crate::search_space::MemSpace;
 use itertools::Itertools;
@@ -725,5 +727,26 @@ impl Function {
     pub(crate) fn dim_not_merged(&mut self, lhs: ir::DimId, rhs: ir::DimId) {
         let to_lower = self.body.mem_blocks.not_merged(&self.body.dims[lhs], rhs);
         self.body.layouts_to_lower.extend(to_lower);
+    }
+}
+
+impl fmt::Display for Function {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(fmt, "Instructions:")?;
+        for inst in self.body.insts.iter() {
+            writeln!(fmt, "  {}", inst.display(self))?
+        }
+
+        writeln!(fmt, "Logical dimensions:")?;
+        for logical_dim in &self.body.logical_dims {
+            writeln!(fmt, "  {}", logical_dim)?;
+        }
+
+        writeln!(fmt, "Extra dimensions:")?;
+        for dim in self.body.dims.iter().filter(|d| d.logical_dim().is_none()) {
+            writeln!(fmt, "  {}", dim)?;
+        }
+
+        Ok(())
     }
 }

--- a/src/ir/induction_var.rs
+++ b/src/ir/induction_var.rs
@@ -1,4 +1,7 @@
+use std::fmt;
+
 use crate::ir;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use utils::*;
 
@@ -69,5 +72,15 @@ impl InductionVar<()> {
             dims: self.dims,
             base: self.base.freeze(cnt),
         }
+    }
+}
+impl<L> ir::IrDisplay<L> for InductionVar<L> {
+    fn fmt(&self, fmt: &mut fmt::Formatter, function: &ir::Function<L>) -> fmt::Result {
+        write!(
+            fmt,
+            "{}[{}]",
+            self.base.display(function),
+            self.dims.iter().map(|(id, _)| id).format(", ")
+        )
     }
 }

--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -5,6 +5,7 @@ use crate::ir::{
 use serde::{Deserialize, Serialize};
 use std::{self, fmt};
 
+use itertools::Itertools;
 use utils::*;
 
 /// Uniquely identifies an instruction.
@@ -250,5 +251,21 @@ impl<L> Statement<L> for Instruction<L> {
 impl<L> fmt::Display for Instruction<L> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "{:?}:  {}", self.id, self.operator)
+    }
+}
+
+impl<L> ir::IrDisplay<L> for Instruction<L> {
+    fn fmt(&self, fmt: &mut fmt::Formatter, function: &ir::Function<L>) -> fmt::Result {
+        write!(
+            fmt,
+            "{:?}[{}]: {}",
+            self.id,
+            self.iteration_dims()
+                .iter()
+                .sorted()
+                .into_iter()
+                .format(", "),
+            self.operator.display(function)
+        )
     }
 }

--- a/src/ir/operator.rs
+++ b/src/ir/operator.rs
@@ -343,6 +343,43 @@ impl<L> Operator<L> {
     }
 }
 
+impl<L> ir::IrDisplay<L> for Operator<L> {
+    fn fmt(&self, fmt: &mut fmt::Formatter, function: &ir::Function<L>) -> fmt::Result {
+        match self {
+            BinOp(op, lhs, rhs, _rnd) => write!(
+                fmt,
+                "{}({}, {})",
+                op,
+                lhs.display(function),
+                rhs.display(function)
+            ),
+            UnaryOp(op, arg) => write!(fmt, "{}({})", op, arg.display(function)),
+            Mul(lhs, rhs, _rnd, _t) => write!(
+                fmt,
+                "mul({}, {})",
+                lhs.display(function),
+                rhs.display(function)
+            ),
+            Mad(arg0, arg1, arg2, _rnd) => write!(
+                fmt,
+                "mad({}, {}, {})",
+                arg0.display(function),
+                arg1.display(function),
+                arg2.display(function)
+            ),
+            Ld(_t, arg, _ap) => write!(fmt, "load({})", arg.display(function)),
+            St(dst, src, _side_effects, _ap) => write!(
+                fmt,
+                "store({}, {})",
+                dst.display(function),
+                src.display(function)
+            ),
+            TmpLd(_t, mem) => write!(fmt, "load({})", mem),
+            TmpSt(src, mem) => write!(fmt, "store({}, {})", mem, src.display(function)),
+        }
+    }
+}
+
 impl Operator<()> {
     pub fn freeze(self, cnt: &mut ir::Counter) -> Operator {
         self.map_operands(|oper| oper.freeze(cnt))

--- a/src/ir/size.rs
+++ b/src/ir/size.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std;
+use std::fmt;
 use std::sync::Arc;
 
 use utils::*;
@@ -64,6 +65,27 @@ impl Default for Size {
             params: Vec::new(),
             max_val: 1,
         }
+    }
+}
+
+impl fmt::Display for Size {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let mut params = self.params.iter();
+        if self.factor != 1 {
+            write!(fmt, "{}", self.factor)?;
+        } else if let Some(param) = params.next() {
+            write!(fmt, "{}", param)?;
+        }
+
+        for param in params {
+            write!(fmt, "*{}", param.name)?;
+        }
+
+        if !self.params.is_empty() {
+            write!(fmt, " [<= {}]", self.max_val)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -152,6 +174,42 @@ impl Default for PartialSize {
             dim_factors: VecSet::default(),
             divisors: VecSet::default(),
         }
+    }
+}
+
+impl fmt::Display for PartialSize {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        use itertools::Itertools;
+
+        if self.static_factor != 1 {
+            write!(fmt, "{}", self.static_factor)?;
+            if !self.param_factors.is_empty() || !self.dim_factors.is_empty() {
+                write!(fmt, "*")?;
+            }
+        }
+
+        write!(
+            fmt,
+            "{}",
+            self.param_factors
+                .iter()
+                .map(|p| p.name.clone())
+                .chain(self.dim_factors.iter().map(|d| format!("{:?}", d)))
+                .format("*")
+        )?;
+
+        if !self.divisors.is_empty() {
+            write!(
+                fmt,
+                "/{}",
+                self.divisors
+                    .iter()
+                    .map(|d| format!("{:?}", *d))
+                    .format("/")
+            )?;
+        }
+
+        Ok(())
     }
 }
 

--- a/src/ir/statement.rs
+++ b/src/ir/statement.rs
@@ -26,6 +26,15 @@ impl fmt::Debug for StmtId {
     }
 }
 
+impl fmt::Display for StmtId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            StmtId::Inst(inst_id) => fmt::Display::fmt(inst_id, f),
+            StmtId::Dim(dim_id) => fmt::Display::fmt(dim_id, f),
+        }
+    }
+}
+
 impl From<ir::InstId> for StmtId {
     fn from(id: ir::InstId) -> Self {
         StmtId::Inst(id)

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -114,7 +114,10 @@ pub fn bound(space: &SearchSpace, context: &dyn Context) -> Bound {
         &[],
         &ir::PartialSize::default(),
     );
-    trace!("global pressure {:?}", global_pressure);
+    trace!(
+        "global pressure {}",
+        global_pressure.display(&*context.device())
+    );
     let device_rates = context.device().total_rates();
     let throughput_bound = global_pressure.bound(BottleneckLevel::Global, &device_rates);
     // Return the biggest bound.

--- a/src/search_space/mod.rs
+++ b/src/search_space/mod.rs
@@ -99,8 +99,8 @@ impl SearchSpace {
         // Dump the "control flow graph"
         write!(
             std::fs::File::create(path.as_ref().with_extension("cfg"))?,
-            "{:#?}",
-            code.cfg()
+            "{}",
+            code,
         )?;
 
         // Dump the source code

--- a/telamon-gen/cc_tests/src/ir_gen.rs
+++ b/telamon-gen/cc_tests/src/ir_gen.rs
@@ -71,6 +71,12 @@ macro_rules! define_ir {
     (@id_def struct $name:ident, $x:tt) => {
         #[derive(Clone, Copy, Hash, Debug, PartialEq, Eq, PartialOrd, Ord, ::serde::Serialize, ::serde::Deserialize)]
         pub struct Id(pub usize);
+
+        impl ::std::fmt::Display for Id {
+            fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                write!(fmt, "{:?}", self)
+            }
+        }
     };
     (@id_def type $name:ident, $super:ident) => { pub use super::$super::Id as Id; };
     (@id_def type $name:ident, @) => { compile_error!("type sets must have a superset"); };

--- a/telamon-gen/src/print/runtime/range.rs
+++ b/telamon-gen/src/print/runtime/range.rs
@@ -5,6 +5,8 @@ use quote::quote;
 /// Returns the tokens defining `Range` and `HalfRange`.
 pub fn get() -> TokenStream {
     quote! {
+        use std::fmt;
+
         /// Abstracts integer choices by a range.
         #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Ord, PartialOrd)]
         #[repr(C)]
@@ -125,6 +127,18 @@ pub fn get() -> TokenStream {
             }
         }
 
+        impl fmt::Display for Range {
+            fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                if self.max == std::u32::MAX {
+                    write!(fmt, "{}..", self.min)
+                } else if self.min > self.max {
+                    write!(fmt, "{{}}")
+                } else {
+                    write!(fmt, "{}..={}", self.min, self.max)
+                }
+            }
+        }
+
         /// Abstracts integer choices by a range, but only store `min`.
         #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Ord, PartialOrd)]
         #[repr(C)]
@@ -217,6 +231,12 @@ pub fn get() -> TokenStream {
 
             fn new_eq<D: NumSet>(_: &(), eq: D, eq_universe: &D::Universe) -> Self {
                 HalfRange { min: eq.min_value(eq_universe) }
+            }
+        }
+
+        impl fmt::Display for HalfRange {
+            fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                write!(fmt, "{}..", self.min)
             }
         }
     }

--- a/telamon-gen/src/print/template/actions.rs
+++ b/telamon-gen/src/print/template/actions.rs
@@ -10,6 +10,81 @@ pub enum Action {
     {{/each~}}
 }
 
+/// Helper struct for printing actions with `format!` and `{}`.
+///
+/// Actions contains IDs which references a [`Function`], and thus can't be properly displayed
+/// without extra information (the objects referred to by the IDs).  This struct embeds a reference
+/// to the [`Function`], which allows it to implement the [`Display`] trait for actions.
+///
+/// [`Display`]: std::fmt::Display
+/// [`Function`]: crate::ir::Function
+pub struct DisplayAction<'a> {
+    action: &'a Action,
+    ir_instance: &'a ir::Function,
+}
+
+impl<'a> std::fmt::Debug for DisplayAction<'a> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self.action, fmt)
+    }
+}
+
+impl<'a> std::fmt::Display for DisplayAction<'a> {
+    #[allow(unused_variables)]
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            fmt, "{:?} = {}",
+            Choice::from(*self.action),
+            self.action.display_domain(self.ir_instance))
+    }
+}
+
+/// Helper struct for printing the domain of an action with `format!` and `{}`.
+///
+/// This is similar to [`DisplayAction`] but only displays the domain associated with the action,
+/// not the choice.
+pub struct DisplayActionDomain<'a> {
+    action: &'a Action,
+    ir_instance: &'a ir::Function,
+}
+
+impl<'a> std::fmt::Debug for DisplayActionDomain<'a> {
+    #[allow(unused_variables)]
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let DisplayActionDomain { action, ir_instance } = self;
+        match **action {
+            {{~#each choices}}
+            Action::{{to_type_name name}}({{>choice.arg_names}}domain) => {
+                std::fmt::Debug::fmt(&domain, fmt)
+            },
+            {{~/each}}
+        }
+    }
+}
+
+impl<'a> std::fmt::Display for DisplayActionDomain<'a> {
+    #[allow(unused_variables)]
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let DisplayActionDomain { action, ir_instance } = self;
+        match **action {
+            {{~#each choices}}
+            Action::{{to_type_name name}}({{>choice.arg_names}}domain) => {
+                {{~#ifeq choice_def "Integer"}}
+                write!(fmt, "{}", {
+                    {{~#each arguments}}
+                    let {{this.[0]}} = {{>set.item_getter this.[1] id=this.[0]}};
+                    {{~/each}}
+                    domain.display({{>value_type.univers value_type}})
+                })
+                {{~else}}
+                write!(fmt, "{}", domain)
+                {{~/ifeq}}
+            },
+            {{~/each}}
+        }
+    }
+}
+
 impl Action {
     /// Returns the action performing the complementary decision.
     #[allow(unused_variables)]
@@ -23,6 +98,28 @@ impl Action {
                 ){{~/if}},
             {{~/each}}
         }
+    }
+
+    /// Returns an object that implements [`Display`] for printing the action with its associated
+    /// function.
+    ///
+    /// This is needed because actions only contain IDs referring to objects stored on the
+    /// [`Function`] and hence can't be displayed properly without the [`Function`].
+    ///
+    /// [`Display`]: std::fmt::Display
+    /// [`Function`]: crate::ir::Function
+    pub fn display<'a>(&'a self, ir_instance: &'a ir::Function) -> DisplayAction<'a> {
+        DisplayAction { action: self, ir_instance }
+    }
+
+    /// Returns an object that implements [`Display`] for printing an action's domain.
+    ///
+    /// This is useful to manipulate something that represents an action's domain for display or
+    /// debugging, since the domains have different types for different actions.
+    ///
+    /// [`Display`]: std::fmt::Display
+    pub fn display_domain<'a>(&'a self, ir_instance: &'a ir::Function) -> DisplayActionDomain<'a> {
+        DisplayActionDomain { action: self, ir_instance }
     }
 }
 

--- a/telamon-gen/src/print/template/choices.rs
+++ b/telamon-gen/src/print/template/choices.rs
@@ -19,3 +19,22 @@ impl From<Action> for Choice {
         }
     }
 }
+
+impl std::fmt::Display for Choice {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            {{~#each choices}}
+            Choice::{{to_type_name name}}({{>choice.arg_names}}) => {
+                fmt.write_str("{{to_type_name name}}(")?;
+                {{~#each arguments}}
+                write!(fmt, "{}", {{this.[0]}})?;
+                {{~#unless @last}}
+                fmt.write_str(", ")?;
+                {{~/unless}}
+                {{~/each}}
+                fmt.write_str(")")
+            },
+            {{~/each}}
+        }
+    }
+}

--- a/telamon-gen/src/print/template/enum_def.rs
+++ b/telamon-gen/src/print/template/enum_def.rs
@@ -115,3 +115,18 @@ impl std::fmt::Debug for {type_name} {{
         }}
     }}
 }}
+
+impl std::fmt::Display for {type_name} {{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {{
+        let mut values = vec![];
+        {printers}
+        f.write_str("{{")?;
+        if !values.is_empty() {{
+            write!(f, "{{}}", values[0])?;
+            for value in &values[1..] {{
+                write!(f, ", {{}}", value)?;
+            }}
+        }}
+        f.write_str("}}")
+    }}
+}}


### PR DESCRIPTION
This patch improves the display of various internal Telamon structures.
Notably:

 - Actions are displayed in the format `DimKind(%2) = {BLOCK, LOOP}` and
   `DimKind(%2) = {BLOCK}` instead of `DimKind(%2, BLOCK | LOOP)` and
   `DimKind(%2, BLOCK)`.  This is closer to the formal definitions, and
   better defined since there is a clear separation between the choice
   and domain.

 - Numeric domains (i.e. sizes) are displayed using their actual values
   instead of their index in the bitset vector.  For instance, if a size
   has possible values {2, 4, 16}, before we would display each of those
   values as `NS { 1 }`, `NS { 2 }` and `NS { 4 }` respectively -- now
   we properly display `{2}`, `{4}` and `{16}`.

 - `codegen::Cfg` objects are now printed using full instruction
   information and should contain enough data to fully understand the
   code behavior without external information (eg dimension mappings).

 - `codegen::Function` can now be printed, which will print the `Cfg`
   but also additional information such as the size of block and thread
   dimensions.

 - Most of the `ir` types have a more precise `Display` information
   without relying too much on objects IDs, which tries to strike a
   balance between verbosity and usefulness.

   Most of those types need an ir::Function to be properly displayed,
   since they need to resolve IDs to get the required information.  We
   use a new trait, `ir::IrDisplay`, which is similar to `fmt::Display`
   but requires an additional reference to an `ir::Function` to be
   passed in.  To integrate with the usual Rust formatting pipelines, a
   `.display()` method is provided, taking as argument the reference to
   the `ir::Function`, and returing a wrapper object which passes it
   back to `ir::IrDisplay::fmt` when displayed.  This allows the
   following pattern:

   ```rust
   let obj = ...; // Some object implementing IrDisplay
   let fun = ...; // An ir::Function instance
   println!("{}", obj.display(&fun));
   ```