### PR TITLE
Variable name for closed dims refer to the last iteration

### DIFF
--- a/src/codegen/name_map.rs
+++ b/src/codegen/name_map.rs
@@ -430,7 +430,9 @@ impl VariableNames {
             .iter()
             .zip_eq(&self.names.dims)
             .map(|(index, size)| match index {
-                VarNameIndex::FromDim(dim) => dim_indexes.get(dim).cloned().unwrap_or(0),
+                VarNameIndex::FromDim(dim) => {
+                    dim_indexes.get(dim).cloned().unwrap_or(size - 1)
+                }
                 VarNameIndex::Last => size - 1,
             })
             .collect_vec();
@@ -553,7 +555,7 @@ mod tests {
         let name_1_3 = root_names.get_name(&mk_index(&[(dim0, 1), (dim1, 3)]));
         let name_2_4 = root_names.get_name(&mk_index(&[(dim0, 2), (dim1, 4)]));
         assert!(name_1_3 != name_2_4);
-        let name_2_0 = root_names.get_name(&mk_index(&[(dim0, 2), (dim1, 0)]));
+        let name_2_0 = root_names.get_name(&mk_index(&[(dim0, 2), (dim1, 4)]));
         let name_2 = root_names.get_name(&mk_index(&[(dim0, 2)]));
         assert_eq!(name_2_0, name_2);
 


### PR DESCRIPTION
The name map incorrectly assumed that it should use the *first*
iteration index instead of the *last* one when some unrolling dimensions
are not used by the underlying instruction (eg because it has been
replicated).  This makes us generate invalid code for reductions,
because it causes the reduction operand to get out of sync, generating
code similar to the following:

```
x0 = 0
x1 = 0
x0 = a0 * b0 + x1
x0 = a1 * b1 + x1
```

instead of

```
x0 = 0
x1 = 0
x1 = a0 * b0 + x1
x1 = a1 * b1 + x1
```

This is a partial fix for the same issue as #226.  We are still creating
too many variables when unrolled loops are unrolled, but at least the
generated code should be correct.