### PR TITLE
Remove x86 random correctness tests

### DIFF
--- a/kernels/tests/x86.rs
+++ b/kernels/tests/x86.rs
@@ -1,17 +1,6 @@
 use telamon_kernels::{linalg, Kernel};
 use telamon_x86 as x86;
 
-macro_rules! test_output {
-    ($name:ident, $kernel:ty, $num_tests:expr, $params:expr) => {
-        #[test]
-        fn $name() {
-            let _ = env_logger::try_init();
-            let mut context = x86::Context::default();
-            <$kernel>::test_correctness($params, $num_tests, &mut context);
-        }
-    };
-}
-
 macro_rules! test_dump {
     ($name:ident, $kernel:ty, $params:expr) => {
         #[test]
@@ -24,21 +13,6 @@ macro_rules! test_dump {
         }
     };
 }
-
-test_output!(correct_axpy, linalg::Axpy<f32>, 100, (1 << 16, true));
-test_output!(correct_mv, linalg::MatVec<f32>, 100, (1 << 4, 1 << 2, true));
-test_output!(
-    correct_gesummv,
-    linalg::Gesummv<f32>,
-    100,
-    (1 << 4, 1 << 4, true)
-);
-test_output!(
-    correct_matmul,
-    linalg::MatMul<f32>,
-    100,
-    linalg::MatMulP::new(16, 16, 16)
-);
 
 test_dump!(axpy, linalg::Axpy<f32>, (1 << 16, true));
 test_dump!(mv, linalg::MatVec<f32>, (1 << 4, 1 << 2, true));


### PR DESCRIPTION
This removes the x86 correctness tests.  We don't have a performance
model for x86, so those tests are (very) slow since we can easily end up
in incredibly bad configurations, and they don't test very meaningful
things (in the end; we only care about correctness of the best
performing code -- not in weird corner cases of the search space).  They
are also less useful than they were, since we now do correction checks
during search -- which is what matters in the end.

Note that this doesn't remove ability to perform the correctness check;
they are just not done during automated testing.  Also note that this
only concerns the random tests; the fixed tests (from `kernel_dump`) are
not removed by this patch.