### PR TITLE
Proper into_num_set() default impl

### DIFF
--- a/telamon-gen/src/print/runtime/integer_domain.rs
+++ b/telamon-gen/src/print/runtime/integer_domain.rs
@@ -24,7 +24,7 @@ pub fn get() -> TokenStream {
                 let start = new_universe.binary_search(&self.min_value(self_universe))
                     .unwrap_or_else(|x| x);
                 let len = new_universe.binary_search(&self.max_value(self_universe))
-                    .unwrap_or_else(|x| x) - start;
+                    .unwrap_or_else(|x| x) - start + 1;
                 let enabled_values = ((1 << len) - 1) << start;
                 NumericSet { enabled_values }
             }


### PR DESCRIPTION
The default implementation for into_num_set() was erroneously ignoring
the last available value.  In particular it would transform a singleton
set into the empty set.  This makes it so that the last value is
properly accounted for.