### PR TITLE
Rename `DimMap::filter` into `DimMap::drain_filter`

### DIFF
--- a/src/ir/dim_map.rs
+++ b/src/ir/dim_map.rs
@@ -11,9 +11,9 @@ use utils::*;
 
 /// Represents a mapping between dimenions.
 #[derive(Clone, Debug)]
-// TODO(cleanup): once merge is handled exclusively from the domain, we can use
-// a `Vec` instead.
 pub struct DimMap {
+    // TODO(cleanup): once merge is handled exclusively from the domain, we can use
+    // a `Vec` instead.
     map: LinkedList<(ir::DimId, ir::DimId)>,
 }
 
@@ -85,7 +85,7 @@ impl DimMap {
     /// Renames a basic block into an other. Indicates if some mapping were
     /// removed.
     pub fn merge_dims(&mut self, lhs: ir::DimId, rhs: ir::DimId) -> bool {
-        self.filter(|&mut pair| pair == (lhs, rhs) || pair == (rhs, lhs))
+        self.drain_filter(|&mut pair| pair == (lhs, rhs) || pair == (rhs, lhs))
             .count()
             > 0
     }
@@ -95,8 +95,8 @@ impl DimMap {
         self.map.iter()
     }
 
-    /// Filters the DimMap.
-    pub fn filter<F>(&mut self, f: F) -> FilterList<(ir::DimId, ir::DimId), F>
+    /// Filters the DimMap, removing the filtered elements in-place.
+    pub fn drain_filter<F>(&mut self, f: F) -> FilterList<(ir::DimId, ir::DimId), F>
     where
         F: FnMut(&mut (ir::DimId, ir::DimId)) -> bool,
     {

--- a/src/ir/mem.rs
+++ b/src/ir/mem.rs
@@ -175,7 +175,7 @@ impl BlockMap {
         for &id in &self.layouts {
             let mut changed = false; // Ensure we only lower once.
             let block = &mut self.blocks[id];
-            for pair in block.maybe_mapped.filter(|&mut (lhs2, rhs2)| {
+            for pair in block.maybe_mapped.drain_filter(|&mut (lhs2, rhs2)| {
                 (lhs2 == lhs && rhs2 == rhs) || (lhs2 == rhs && rhs2 == lhs)
             }) {
                 block.mapped_dims.push(pair);


### PR DESCRIPTION
`DimMap::filter` is a confusing name: not only does it return an
iterator over the filtered elements, but it also removes them from the
`DimMap`.  This can make for very surprising behavior, since `.filter()`
(e.g. on an iterator) usually does not have side effects.

The behavior and intent is (almost) identical to the nightly
`drain_filter` on `Vec`, so let's use that name instead to be less
confusing and more explicit.