### PR TITLE
Allow creating explorer config from any file

### DIFF
--- a/kernels/benches/cuda_search.rs
+++ b/kernels/benches/cuda_search.rs
@@ -99,7 +99,7 @@ fn benchmark<'a, K, REF>(
     K: Kernel<'a>,
     REF: FnMut(&K::Parameters, &cuda::Context) -> f64,
 {
-    let mut config = Config::read_from_file();
+    let mut config = Config::from_settings_toml();
     config.timeout.get_or_insert(TIMEOUT);
     //config.distance_to_best.get_or_insert(20.);
 

--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use std::{self, error, fmt, str::FromStr};
 
 use config;
+use log::warn;
 use num_cpus;
 use serde::{Deserialize, Serialize};
 use utils::{tfrecord, unwrap};
@@ -60,24 +61,35 @@ impl Config {
         // option, which makes the parsing succeed even if there is
         // nothing to parse.
         unwrap!(config_parser.set_default::<Option<f64>>("timeout", None));
-        let config_path = std::path::Path::new("Settings.toml");
-        if config_path.exists() {
-            unwrap!(config_parser.merge(config::File::from(config_path)));
-        }
         config_parser
     }
 
-    /// Extract the configuration from the configuration file, if any.
-    pub fn read_from_file() -> Self {
-        unwrap!(Self::create_parser().try_into::<Self>())
+    /// Create a new configuration from the hardcoded `Settings.toml` configuration file if it
+    /// exists.
+    pub fn from_settings_toml() -> Self {
+        let settings_path = std::path::Path::new("Settings.toml");
+        if settings_path.exists() {
+            warn!("*** Loading config from Settings.toml ***");
+            warn!("*** Pay careful attention to the parameters used as they may differ from the defaults. ***");
+            unwrap!(Self::from_path(settings_path))
+        } else {
+            Self::default()
+        }
+    }
+
+    /// Extract the configuration from the given configuration file.
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, config::ConfigError> {
+        let mut parser = Self::create_parser();
+        parser.merge(config::File::from(path.as_ref()))?;
+        parser.try_into::<Self>()
     }
 
     /// Parse the configuration from a JSON string. Primary user is
     /// the Python API (through the C API).
-    pub fn from_json(json: &str) -> Self {
+    pub fn from_json(json: &str) -> Result<Self, config::ConfigError> {
         let mut parser = Self::create_parser();
-        unwrap!(parser.merge(config::File::from_str(json, config::FileFormat::Json)));
-        unwrap!(parser.try_into::<Self>())
+        parser.merge(config::File::from_str(json, config::FileFormat::Json))?;
+        parser.try_into::<Self>()
     }
 
     pub fn output_path<P: AsRef<Path>>(&self, path: P) -> io::Result<PathBuf> {

--- a/telamon-capi/src/lib.rs
+++ b/telamon-capi/src/lib.rs
@@ -142,7 +142,8 @@ pub unsafe extern "C" fn kernel_optimize(
             let slice = std::slice::from_raw_parts(config_data as *const u8, config_len);
             std::str::from_utf8(slice).expect("Invalid configuration string")
         };
-        Config::from_json(config_str)
+        // TODO: Should not unwrap here.
+        Config::from_json(config_str).unwrap()
     };
     match device {
         DeviceId::X86 => (*params).optimize_kernel(&config, &mut x86::Context::default()),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -17,7 +17,7 @@ pub fn empty_signature() -> ir::Signature {
 
 /// Find the best candidate for a function and outputs it.
 pub fn gen_best(context: &Context, space: SearchSpace) {
-    let mut config = explorer::Config::read_from_file();
+    let mut config = explorer::Config::from_settings_toml();
     config.num_workers = 1;
     let best = explorer::find_best(&config, context, vec![space], None).unwrap();
     context.device().gen_code(&best, &mut sink());


### PR DESCRIPTION
Previously explorer configuration could only be created from
`Settings.toml` files, or a json string.  This patch makes it so that
explorer configuration can be created by any file or json string as
needed by the caller.

In addition, we push errors to the creator of the `Config` instead of
unwrapping, and we output a warning message when automatically loading
from a `Settings.toml` since this is essentially context-dependent
defaults which can be confusing.