### PR TITLE
Add `threads` and `thread_size` choices groups

### DIFF
--- a/backend/cuda/src/mem_model.rs
+++ b/backend/cuda/src/mem_model.rs
@@ -429,7 +429,7 @@ fn global_coalescing(
 ) -> (f64, f64, f64) {
     let thread_dims = sort_thread_dims(thread_dims, false, space, gpu);
     let offsets = wrap_access_offsets(&thread_dims, true, gpu);
-    trace!("{:?}", offsets);
+    trace!("global offsets: {:?}", offsets);
     let (mut l1_coalescing, mut l2_coalescing, mut replay) =
         offsets_global_coalescing(&offsets, gpu);
     if thread_dims
@@ -439,7 +439,7 @@ fn global_coalescing(
     {
         let offsets =
             wrap_access_offsets(&thread_dims[0..thread_dims.len() - 1], true, gpu);
-        trace!("{:?}", offsets);
+        trace!("global offsets (last inactive): {:?}", offsets);
         let (l1, l2, r) = offsets_global_coalescing(&offsets, gpu);
         l1_coalescing = f64::min(l1_coalescing, l1);
         l2_coalescing = f64::min(l2_coalescing, l2);

--- a/kernels/src/kernel.rs
+++ b/kernels/src/kernel.rs
@@ -194,13 +194,7 @@ pub trait Kernel<'a>: Sized + Sync {
 
         let implem = action_list.iter().fold(candidate, |cand, action| {
             cand.apply_decision(ctx, action.clone())
-                .unwrap_or_else(|()| {
-                    panic!(
-                        "In kernel {}, Could not apply action {:?}",
-                        Self::name(),
-                        action
-                    )
-                })
+                .unwrap_or_else(|err| panic!("In kernel {}: {}", Self::name(), err))
         });
 
         let device_fn = codegen::Function::build(&implem.space);

--- a/src/explorer/candidate.rs
+++ b/src/explorer/candidate.rs
@@ -1,6 +1,6 @@
 //! Exploration of the search space.
 use crate::device::Context;
-use crate::explorer::choice::ActionEx;
+use crate::explorer::choice::{ActionError, ActionEx};
 use crate::model::{bound, Bound};
 use crate::search_space::SearchSpace;
 
@@ -56,7 +56,7 @@ impl Candidate {
             .into_iter()
             .flat_map(|action| {
                 self.apply_decision(context, action)
-                    .map_err(|_| trace!("invalid action encountered"))
+                    .map_err(|err| trace!("invalid action encountered: {}", err))
                     .ok()
             })
             .collect_vec();
@@ -100,17 +100,9 @@ impl Candidate {
         &self,
         context: &dyn Context,
         action: ActionEx,
-    ) -> Result<Self, ()> {
+    ) -> Result<Self, ActionError> {
         debug!("applying action {:?}", action);
-        let mut space = self.space.clone();
-        match action {
-            ActionEx::Action(action) => space.apply_decisions(vec![action]),
-            ActionEx::LowerLayout {
-                mem,
-                ref st_dims,
-                ref ld_dims,
-            } => space.lower_layout(mem, st_dims, ld_dims),
-        }?;
+        let space = action.apply_to(self.space.clone())?;
         let bound = bound(&space, context);
         let delta = 1.0e-2 * self.bound.value();
         if bound.value() + delta < self.bound.value() {

--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -348,6 +348,8 @@ pub enum ChoiceGroup {
     Order,
     MemSpace,
     InstFlag,
+    Threads,
+    ThreadSize,
 }
 
 impl fmt::Display for ChoiceGroup {
@@ -362,6 +364,8 @@ impl fmt::Display for ChoiceGroup {
             Order => "order",
             MemSpace => "mem_space",
             InstFlag => "inst_flag",
+            Threads => "threads",
+            ThreadSize => "thread_size",
         })
     }
 }
@@ -392,6 +396,8 @@ impl FromStr for ChoiceGroup {
             "order" => Order,
             "mem_space" => MemSpace,
             "inst_flag" => InstFlag,
+            "threads" => Threads,
+            "thread_size" => ThreadSize,
             _ => return Err(ParseChoiceGroupError(s.to_string())),
         })
     }

--- a/telamon-gen/src/print/template/enum_def.rs
+++ b/telamon-gen/src/print/template/enum_def.rs
@@ -27,6 +27,16 @@ impl {type_name} {{
             .map(|x| {type_name} {{ bits: x }})
     }}
 
+    /// Partition the domain into the intersection with `other` and its complement.
+    pub fn bisect(&self, other: Self) -> impl Iterator<Item = Self> {{
+        (*self & other).into_option().into_iter()
+            .chain((*self & !other).into_option().into_iter())
+    }}
+
+    fn into_option(self) -> Option<Self> {{
+        if self.is_failed() {{ None }} else {{ Some(self) }}
+    }}
+
     /// Indicates if two choices will have the same value.
     pub fn eq(&self, other: Self) -> bool {{
         self.is_constrained() && *self == other


### PR DESCRIPTION
 - The `threads` group generate choices for determining if each
   dimension should be implemented as a thread or not.

 - The `thread_size` group fixes the sizes only of the dimensions which
   may be mapped to threads, which has a large impact on the mem_model
   analysis for access conflicts and replays.

Some quality of life changes are also included:

 - The custom `NestedIterator` implementation is removed, as it turns
   out the standard library already provides that construct through
   `.flatten()`

 - When applying an action fails, `ActionEx`-level APIs now return a
   proper error instead of `()`, which provides actually useful error
   messages.