### PR TITLE
Add a telamon-cli package with CLI utilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ members = [
     "telamon-utils",
     "telamon-gen/cc_tests",
     "telamon-capi",
+    "telamon-cli",
 ]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,7 @@ members = [
     "telamon-gen/cc_tests",
     "telamon-capi",
 ]
+
+[profile.release]
+lto = false
+debug = true

--- a/kernels/benches/cuda_search.rs
+++ b/kernels/benches/cuda_search.rs
@@ -90,7 +90,7 @@ const NUM_CODE_RUNS: usize = 40;
 /// Search timeout in minutes.
 const TIMEOUT: u64 = 240;
 
-/// Benchamrks a kernel against a reference implementation.
+/// Benchmarks a kernel against a reference implementation.
 fn benchmark<'a, K, REF>(
     params: K::Parameters,
     executor: &'a cuda::Executor,

--- a/kernels/src/kernel.rs
+++ b/kernels/src/kernel.rs
@@ -384,7 +384,7 @@ pub trait Kernel<'a>: Sized + Sync {
     }
 }
 
-/// Descend along a path in the search tree and stores the bounds encountered on the way.
+/// Descends along a path in the search tree and stores the bounds encountered on the way.
 fn descend_check_bounds(
     candidates: &[Candidate],
     context: &dyn device::Context,

--- a/telamon-cli/Cargo.toml
+++ b/telamon-cli/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+authors = ["Basile Clement <basile.clement@ens.fr>"]
+name = "telamon-cli"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+structopt = "0.2"
+cuda-sys = { version = "0.1", optional = true }
+libc = { version = "0.2", optional = true }
+env_logger = "0.5"
+log = "0.4"
+serde_json = "1.0"
+tui = "0.5"
+futures = "0.1"
+termion = "1.5"
+crossbeam = "0.7"
+bincode = "1.0"
+streaming-stats = "0.2"
+num_cpus = "1.8.0"
+
+telamon = { path = "../" }
+telamon-cuda = { path = "../backend/cuda", optional = true }
+telamon-kernels = { path = "../kernels" }
+telamon-utils = { path = "../telamon-utils" }
+telamon-x86 = { path = "../backend/x86", optional = true }
+
+[features]
+default = ["cuda"]
+cuda = ["telamon-cuda/real_gpu", "cuda-sys", "libc"]
+x86 = ["telamon-x86"]

--- a/telamon-cli/src/bin/cuda_search/main.rs
+++ b/telamon-cli/src/bin/cuda_search/main.rs
@@ -1,0 +1,185 @@
+//! Benchmarks the exploration on CUDA gpus.
+use std::io::{self, Write};
+
+use telamon::device::{ArgMap, Context};
+use telamon::explorer::config::Config;
+use telamon::helper::MemInit;
+use telamon_cli::{
+    Bench, CommonOpt, ContextBuilder, CublasHandle, KernelParam, Reference,
+};
+use telamon_kernels::statistics::estimate_mean;
+use telamon_kernels::{linalg, Kernel};
+
+use structopt::StructOpt;
+
+/// The number of times to run the generated code to evaluate its performance.
+const NUM_CODE_RUNS: usize = 40;
+/// Search timeout in minutes.
+const TIMEOUT: u64 = 240;
+
+/// Benchmarks a kernel against a reference implementation.
+fn benchmark<'a, K, REF, CB>(
+    mut config: Config,
+    params: K::Parameters,
+    executor: CB,
+    reference: &REF,
+) where
+    K: Kernel<'a>,
+    CB: ContextBuilder<'a>,
+    REF: Reference<'a, K, Context = CB::Context>,
+{
+    config.timeout.get_or_insert(TIMEOUT);
+
+    let mut context = executor.build_context();
+    let runtime = K::benchmark(
+        &config,
+        params.clone(),
+        NUM_CODE_RUNS,
+        MemInit::RandomFill,
+        &mut context,
+    );
+    let ref_runtime = Bench::default()
+        .warmup(4)
+        .runs(NUM_CODE_RUNS)
+        .benchmark_fn(|| reference.eval_reference(&params, &context));
+    let mut f =
+        std::fs::File::create(config.output_path("benchmark.txt").unwrap()).unwrap();
+    writeln!(f, "runtimes: {:?}", runtime).unwrap();
+    let mean = estimate_mean(runtime, 0.95, "ns");
+    let ref_mean = estimate_mean(ref_runtime, 0.95, "ns");
+    writeln!(
+        f,
+        "{}: {}, reference: {}, speedup: {:.2}",
+        K::name(),
+        mean,
+        ref_mean,
+        ref_mean.value / mean.value
+    )
+    .unwrap();
+}
+
+#[derive(StructOpt)]
+struct Opt {
+    #[structopt(flatten)]
+    common: CommonOpt,
+
+    #[structopt(short = "r", long = "repeat", default_value = "10")]
+    repeat: usize,
+
+    #[structopt(short = "k", long = "kernel")]
+    kernels: Vec<KernelParam>,
+}
+
+trait BenchRun<'a, B, R> {
+    fn run(self, config: &Config, builder: B, reference: &R);
+}
+
+struct Benchmark<'a, K>
+where
+    K: Kernel<'a>,
+{
+    params: K::Parameters,
+    name: String,
+    iteration: usize,
+}
+
+impl<'a, K> Benchmark<'a, K>
+where
+    K: Kernel<'a>,
+{
+    fn new(params: K::Parameters, name: String, iteration: usize) -> Self {
+        Benchmark {
+            params,
+            name,
+            iteration,
+        }
+    }
+
+    fn output_dir(&self) -> String {
+        format!("{}/{}", self.name, self.iteration)
+    }
+}
+
+impl<'a, K, B, R> BenchRun<'a, B, R> for Benchmark<'a, K>
+where
+    K: Kernel<'a>,
+    B: ContextBuilder<'a>,
+    R: Reference<'a, K, Context = B::Context>,
+{
+    fn run(self, config: &Config, builder: B, reference: &R) {
+        let mut config = config.clone();
+        config.output_dir = std::path::Path::new(&config.output_dir)
+            .join(self.output_dir())
+            .to_str()
+            .unwrap()
+            .to_string();
+        benchmark::<K, _, _>(config.clone(), self.params, builder, reference)
+    }
+}
+
+macro_rules! benchmark {
+    (Sgemm($m:expr, $n:expr, $k:expr)[$iter:expr]) => {{
+        self::Benchmark::<'_, linalg::FusedMM<'_, f32>>::new(
+            linalg::FusedMMP::new($m, $n, $k),
+            format!("Sgemm_{}_{}_{}", $m, $n, $k),
+            $iter,
+        )
+    }};
+
+    (BatchMM($b:expr, $m:expr, $n:expr, $k:expr)[$iter:expr]) => {{
+        self::Benchmark::<'_, linalg::BatchMM<'_, f32>>::new(
+            linalg::BatchMMP::new($b, $m, $n, $k),
+            format!("BatchMM_{}_{}_{}_{}", $b, $m, $n, $k),
+            $iter,
+        )
+    }};
+}
+
+fn main() {
+    env_logger::init();
+    let args = Opt::from_args();
+
+    let executor = telamon_cuda::Executor::init();
+    let reference = CublasHandle::new();
+
+    let config = args.common.config().unwrap();
+
+    for idx in 0..args.repeat {
+        for kernel in &args.kernels {
+            use KernelParam::*;
+
+            match *kernel {
+                Axpy { n } => Benchmark::<'_, linalg::Axpy<f32>>::new(
+                    (n, true),
+                    format!("Axpy_{}", n),
+                    idx,
+                )
+                .run(&config, &executor, &reference),
+                MatVec { m, n } => Benchmark::<'_, linalg::MatVec<f32>>::new(
+                    (m, n, true),
+                    format!("Sgemv_{}_{}", m, n),
+                    idx,
+                )
+                .run(&config, &executor, &reference),
+                Gesummv { m, n } => Benchmark::<'_, linalg::Gesummv<f32>>::new(
+                    (m, n, true),
+                    format!("Gesummv_{}_{}", m, n),
+                    idx,
+                )
+                .run(&config, &executor, &reference),
+                Gemm { m, n, k } => Benchmark::<'_, linalg::FusedMM<'_, f32>>::new(
+                    linalg::FusedMMP::new(m, n, k),
+                    format!("Sgemm_{}_{}_{}", m, n, k),
+                    idx,
+                )
+                .run(&config, &executor, &reference),
+                BatchMM { b, m, n, k } => Benchmark::<'_, linalg::BatchMM<'_, f32>>::new(
+                    linalg::BatchMMP::new(b, m, n, k),
+                    format!("BatchMM_{}_{}_{}_{}", b, m, n, k),
+                    idx,
+                )
+                .run(&config, &executor, &reference),
+            }
+        }
+    }
+}

--- a/telamon-cli/src/bin/tlcli.rs
+++ b/telamon-cli/src/bin/tlcli.rs
@@ -1,0 +1,458 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::sync::{atomic, Arc, Mutex};
+
+use serde_json;
+use structopt::StructOpt;
+
+use telamon::device;
+use telamon::explorer::{
+    self,
+    choice::{ActionEx as Action, Choice},
+    config,
+    eventlog::EventLog,
+    mcts, Candidate,
+};
+use telamon::ir::IrDisplay;
+use telamon::model::{bound, Bound};
+use telamon::offline_analysis::tree::CandidateTree;
+use telamon::search_space::SearchSpace;
+
+use telamon_cli::{KernelParam, ReplayPath};
+
+/// Compute the bound for a given candidate.
+#[derive(StructOpt)]
+struct ComputeBound {
+    /// Kernel specification to use.
+    #[structopt(short = "k", long = "kernel")]
+    kernel: KernelParam,
+
+    /// Path to a saved replay file to load before computing the bound.
+    #[structopt(parse(from_os_str), short = "r", long = "replay")]
+    replay: Option<ReplayPath>,
+}
+
+impl ComputeBound {
+    fn run(&self, _args: &Opt) -> io::Result<()> {
+        let executor = telamon_cuda::Executor::init();
+        let mut context = telamon_cuda::Context::new(&executor);
+        let (mut candidates, context) = self.kernel.build(&mut context);
+        assert!(candidates.len() == 1);
+        let mut candidate = candidates.swap_remove(0).space;
+
+        // Apply replay if there is some
+        if let Some(replay) = &self.replay {
+            for action in &replay.load()? {
+                candidate = action
+                    .apply_to(candidate)
+                    .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+            }
+        }
+
+        let start = std::time::Instant::now();
+        let bound = bound(&candidate, context);
+        let duration = start.elapsed();
+        println!("Bound is {:?} (computed in {:?})", bound, duration);
+
+        Ok(())
+    }
+}
+
+/// Compute bounds.csv
+#[derive(StructOpt)]
+struct Bounds {
+    #[structopt(long = "order")]
+    order: Option<config::ChoiceOrdering>,
+
+    #[structopt(long = "kernel")]
+    kernel: KernelParam,
+
+    #[structopt(long = "num-runs", default_value = "500")]
+    num_runs: usize,
+}
+
+/// Ignore candidates with a too big bound in tests.
+const CUT: f64 = 2e8f64;
+
+impl Bounds {
+    fn next_choice(&self, space: &SearchSpace) -> Option<Choice> {
+        if let Some(order) = &self.order {
+            explorer::choice::list(order, space).next()
+        } else {
+            explorer::choice::default_list(space).next()
+        }
+    }
+
+    /// Descends along a path in the search tree and stores the bounds encountered on the way.
+    fn random_descent(
+        &self,
+        candidates: &[Candidate],
+        context: &dyn device::Context,
+    ) -> Option<(Candidate, Vec<Bound>)> {
+        let order = explorer::config::NewNodeOrder::Random;
+        let mut candidates = Cow::Borrowed(candidates);
+        let mut bounds = Vec::new();
+        loop {
+            let idx = if let Some(idx) = order.pick_candidate(&candidates, CUT) {
+                idx
+            } else {
+                break None;
+            };
+            bounds.push(candidates[idx].bound.clone());
+            let choice_opt = self.next_choice(&candidates[idx].space);
+            if let Some(choice) = choice_opt {
+                let new_nodes = candidates[idx]
+                    .apply_choice(context, choice)
+                    .into_iter()
+                    .filter(|x| x.bound.value() < CUT)
+                    .collect::<Vec<_>>();
+                candidates = std::borrow::Cow::Owned(new_nodes);
+            } else {
+                break Some((
+                    match candidates {
+                        Cow::Borrowed(candidates) => candidates[idx].clone(),
+                        Cow::Owned(mut candidates) => candidates.swap_remove(idx),
+                    },
+                    bounds,
+                ));
+            }
+        }
+    }
+
+    fn test_bound<F>(
+        &self,
+        candidates: Vec<Candidate>,
+        context: &dyn device::Context,
+        body_fn: F,
+    ) where
+        F: Fn((f64, Vec<f64>)) + Sync,
+    {
+        let num_tested = atomic::AtomicUsize::new(0);
+        let stabilizer = &context.stabilizer();
+        context.async_eval(
+            num_cpus::get(),
+            device::EvalMode::TestBound,
+            &|evaluator| loop {
+                if num_tested.fetch_add(1, atomic::Ordering::SeqCst) >= self.num_runs {
+                    if num_tested.fetch_sub(1, atomic::Ordering::SeqCst) > self.num_runs {
+                        break;
+                    }
+                }
+
+                if let Some((leaf, mut bounds)) =
+                    self.random_descent(&candidates, context)
+                {
+                    evaluator.add_kernel(leaf, {
+                        let body_fn = &body_fn;
+                        move |leaf, kernel| {
+                            let bound = leaf.bound.clone();
+                            let runtime = stabilizer
+                                .wrap(kernel)
+                                .bound(Some(bound.value()))
+                                .evaluate()
+                                .unwrap();
+                            bounds.push(bound);
+                            body_fn((
+                                runtime,
+                                bounds.into_iter().map(|bound| bound.value()).collect(),
+                            ))
+                        }
+                    });
+                } else {
+                    num_tested.fetch_sub(1, atomic::Ordering::SeqCst);
+                }
+            },
+        );
+    }
+
+    fn run(&self, _args: &Opt) -> io::Result<()> {
+        let executor = telamon_cuda::Executor::init();
+        let mut context = telamon_cuda::Context::new(&executor);
+        let (candidates, context) = self.kernel.build(&mut context);
+        let stdout = std::io::stdout();
+        self.test_bound(candidates, context, |(runtime, bounds)| {
+            let mut handle = stdout.lock();
+            write!(handle, "{},{}", self.kernel, runtime).unwrap();
+            for bound in bounds {
+                write!(handle, ",{}", bound).unwrap();
+            }
+            write!(handle, "\n").unwrap();
+        });
+
+        Ok(())
+    }
+}
+
+/// Rebuild a specific list of actions from an event log.
+///
+/// This generates a .json replay file which can be used by the debugger, as well as by various
+/// other utilities (eg the `compute_bound` subcommand).
+#[derive(StructOpt)]
+struct Rebuild {
+    /// Path to the eventlog to rebuild from
+    #[structopt(
+        parse(from_os_str),
+        short = "i",
+        long = "input",
+        default_value = "eventlog.tfrecord.gz"
+    )]
+    eventlog: PathBuf,
+
+    /// Identifier of the candidate node to rebuild.  This corresponds to the ID indicated in
+    /// `watch.log`.
+    id: usize,
+}
+
+impl Rebuild {
+    fn find_candidate(&self) -> io::Result<(mcts::NodeId, f64, Vec<Action>)> {
+        let mut nevals = 0;
+        let mut tree = CandidateTree::new();
+
+        for record_bytes in EventLog::open(&self.eventlog)?.records() {
+            match bincode::deserialize(&record_bytes?)
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?
+            {
+                mcts::Message::Node {
+                    id,
+                    parent,
+                    mut children,
+                    bound,
+                    discovery_time,
+                } => tree.extend(id, discovery_time, parent, bound, &mut children),
+                mcts::Message::Trace { .. } => (),
+                mcts::Message::Evaluation { id, value, .. } => {
+                    if let Some(value) = value {
+                        if nevals == self.id {
+                            return Ok((id, value, tree.get_node(id).actions()));
+                        }
+
+                        nevals += 1;
+                    }
+                }
+            }
+        }
+
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            "Unable to find candidate",
+        ))
+    }
+
+    fn run(&self, _args: &Opt) -> io::Result<()> {
+        let (id, score, actions) = self.find_candidate()?;
+
+        println!("Found candidate {} (score: {})", id, score);
+        println!("{}", serde_json::to_string_pretty(&actions)?);
+
+        Ok(())
+    }
+}
+
+/// Compute statistics on an eventlog
+#[derive(StructOpt)]
+struct Stats {
+    /// Path to the eventlog to compute stats for
+    #[structopt(
+        parse(from_os_str),
+        short = "i",
+        long = "input",
+        default_value = "eventlog.tfrecord.gz"
+    )]
+    eventlog: PathBuf,
+
+    /// Maximum number of implementations to consider
+    #[structopt(long = "limit")]
+    limit: Option<usize>,
+}
+
+impl Stats {
+    fn run(&self, _args: &Opt) -> io::Result<()> {
+        let (mut nimpl, mut impld) = (0, 0u64);
+
+        #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+        enum Cause {
+            Constraints,
+            PerfModel,
+            Backtrack,
+        };
+
+        impl From<mcts::CauseOfDeath> for Cause {
+            fn from(cause: mcts::CauseOfDeath) -> Self {
+                match cause {
+                    mcts::CauseOfDeath::Constraints => Cause::Constraints,
+                    mcts::CauseOfDeath::PerfModel { .. } => Cause::PerfModel,
+                    mcts::CauseOfDeath::Backtrack => Cause::Backtrack,
+                }
+            }
+        }
+
+        let mut deadinfo = HashMap::new();
+
+        let mut evalns = self.limit.map(Vec::with_capacity).unwrap_or_default();
+        let mut tree = CandidateTree::new();
+
+        for record_bytes in EventLog::open(&self.eventlog)?.records() {
+            match bincode::deserialize(&record_bytes?)
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?
+            {
+                mcts::Message::Node {
+                    id,
+                    parent,
+                    mut children,
+                    bound,
+                    discovery_time,
+                } => tree.extend(id, discovery_time, parent, bound, &mut children),
+                mcts::Message::Trace { events, .. } => {
+                    let mut cause = None;
+                    let mut len = 0;
+                    let mut node = tree.get_root();
+                    let mut has_size = false;
+
+                    for event in &events {
+                        match event.value {
+                            mcts::Event::SelectNode(id) => {
+                                node = tree.get_node(id);
+                            }
+                            mcts::Event::SelectChild(index, ..) => {
+                                node = node
+                                    .child(index.into())
+                                    .unwrap_or_else(|| panic!("no child"));
+                                match node.action().unwrap_or_else(|| panic!("no action"))
+                                {
+                                    Action::Action(
+                                        telamon::search_space::Action::Size(..),
+                                    ) => has_size = true,
+                                    _ => (),
+                                }
+                                len += 1;
+                            }
+                            mcts::Event::KillChild(index, cause_) => {
+                                let info = deadinfo
+                                    .entry((Cause::from(cause_), has_size))
+                                    .or_insert((0u64, 0u32));
+                                info.0 += len + 1;
+                                info.1 += 1;
+                            }
+                            mcts::Event::Kill(cause_) => {
+                                assert!(cause.is_none());
+
+                                cause = Some(Cause::from(cause_));
+                            }
+                            mcts::Event::Implementation => {
+                                assert!(cause.is_none());
+
+                                impld += len;
+                                nimpl += 1;
+                            }
+                            mcts::Event::Expand => (),
+                        }
+                    }
+
+                    if let Some(cause) = cause {
+                        let info =
+                            deadinfo.entry((cause, has_size)).or_insert((0u64, 0u32));
+                        info.0 += len;
+                        info.1 += 1;
+                    }
+                }
+                mcts::Message::Evaluation { value, .. } => {
+                    if let Some(value) = value {
+                        evalns.push(value.log(10.));
+                    }
+                }
+            }
+
+            if self.limit.map(|limit| nimpl >= limit).unwrap_or(false) {
+                break;
+            }
+        }
+
+        let stats = stats::OnlineStats::from_slice(&evalns);
+        println!(
+            "Average log10 runtime: {:.2} (± {:.2})",
+            stats.mean(),
+            stats.stddev(),
+        );
+
+        println!(
+            "Implementations: {} (avg depth: {})",
+            nimpl,
+            impld as f64 / nimpl as f64
+        );
+
+        let ((ddepth, ndead), (ddepth_size, ndead_size)) = deadinfo.iter().fold(
+            ((0, 0), (0, 0)),
+            |((ddepth, ndead), (ddepth_size, ndead_size)),
+             ((_, has_size), (depth, num))| {
+                if *has_size {
+                    ((ddepth, ndead), (ddepth_size + depth, ndead_size + num))
+                } else {
+                    ((ddepth + depth, ndead + num), (ddepth_size, ndead_size))
+                }
+            },
+        );
+
+        println!(
+            "Deadends: {} (avg depth: {})",
+            ndead + ndead_size,
+            (ddepth + ddepth_size) as f64 / (ndead + ndead_size) as f64
+        );
+
+        for ((cause, has_size), (cdepth, cnum)) in deadinfo.into_iter() {
+            println!(
+                "  - {:?} ({}): {} (avg depth: {})",
+                cause,
+                if has_size {
+                    " (with size)"
+                } else {
+                    " (without size)"
+                },
+                cnum,
+                cdepth as f64 / cnum as f64
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt)]
+enum Command {
+    #[structopt(name = "rebuild")]
+    Rebuild(Rebuild),
+
+    #[structopt(name = "bounds")]
+    Bounds(Bounds),
+
+    #[structopt(name = "stats")]
+    Stats(Stats),
+
+    #[structopt(name = "bound")]
+    Bound(ComputeBound),
+}
+
+#[derive(StructOpt)]
+#[structopt(name = "telamon")]
+struct Opt {
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+fn main() {
+    let args = Opt::from_args();
+    env_logger::init();
+
+    let result = match &args.command {
+        Command::Rebuild(rebuild) => rebuild.run(&args),
+        Command::Bounds(bounds) => bounds.run(&args),
+        Command::Stats(stats) => stats.run(&args),
+        Command::Bound(bound) => bound.run(&args),
+    };
+
+    match result {
+        Ok(()) => (),
+        Err(err) => panic!("An error occured: {}", err),
+    }
+}

--- a/telamon-cli/src/lib.rs
+++ b/telamon-cli/src/lib.rs
@@ -1,0 +1,594 @@
+use std::error::Error;
+use std::ffi::OsStr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::{fmt, fs, io};
+
+use structopt::StructOpt;
+
+use telamon::device::{ArgMap, Context};
+use telamon::explorer::{choice::ActionEx as Action, config::Config, Candidate};
+use telamon_kernels::{linalg, Kernel, KernelBuilder};
+
+#[derive(StructOpt)]
+pub struct CommonOpt {
+    /// Path to the configuration file to use.
+    ///
+    /// Configuration file must be in TOML format.
+    #[structopt(parse(from_os_str), long = "config")]
+    config_path: Option<PathBuf>,
+}
+
+impl CommonOpt {
+    pub fn config(&self) -> io::Result<Config> {
+        if let Some(config_path) = &self.config_path {
+            Config::from_path(config_path)
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+        } else {
+            Ok(Config::default())
+        }
+    }
+}
+
+pub trait ContextBuilder<'a> {
+    type Context: ArgMap<'a>;
+
+    fn build_context(&self) -> Self::Context;
+}
+
+#[cfg(feature = "cuda")]
+impl<'a> ContextBuilder<'a> for &'a telamon_cuda::Executor {
+    type Context = telamon_cuda::Context<'a>;
+
+    fn build_context(&self) -> Self::Context {
+        telamon_cuda::Context::new(self)
+    }
+}
+
+pub trait Reference<'a, K>
+where
+    K: Kernel<'a>,
+{
+    type Context: Context + 'a;
+
+    fn eval_reference(&self, params: &K::Parameters, context: &Self::Context) -> f64;
+}
+
+#[derive(Debug, Clone)]
+pub struct Bench {
+    warmup: usize,
+    runs: usize,
+}
+
+impl Default for Bench {
+    fn default() -> Self {
+        Bench {
+            warmup: 4,
+            runs: 40,
+        }
+    }
+}
+
+impl Bench {
+    pub fn warmup(mut self, warmup: usize) -> Self {
+        self.warmup = warmup;
+        self
+    }
+
+    pub fn runs(mut self, runs: usize) -> Self {
+        self.runs = runs;
+        self
+    }
+
+    pub fn benchmark_fn<F>(&self, f: F) -> Vec<f64>
+    where
+        F: Fn() -> f64,
+    {
+        for _ in 0..self.warmup {
+            f();
+        }
+
+        (0..self.runs).map(|_| f()).collect()
+    }
+}
+
+#[cfg(feature = "cuda")]
+mod cuda_reference {
+    use cuda_sys::cublas::*;
+    use cuda_sys::cuda::*;
+    use telamon_cuda as cuda;
+    use telamon_kernels::linalg;
+
+    use super::Reference;
+
+    /// Checks the cublas status and panics if an error occured.
+    fn check_cublas(status: cublasStatus_t) {
+        if status != cublasStatus_t::SUCCESS {
+            panic!("error in cublas: {:?}", status);
+        }
+    }
+
+    /// Checks a cuda status and panics if an error occured.
+    fn check_cuda(status: CUresult) {
+        if status != cudaError_t::CUDA_SUCCESS {
+            panic!("error in cuda: {:?}", status)
+        }
+    }
+
+    pub struct CublasHandle(cublasHandle_t);
+
+    impl CublasHandle {
+        /// Initialize a new handle.
+        pub fn new() -> Self {
+            unsafe {
+                let mut handle = std::mem::uninitialized();
+                check_cublas(cublasCreate_v2(&mut handle));
+                CublasHandle(handle)
+            }
+        }
+    }
+
+    impl Drop for CublasHandle {
+        fn drop(&mut self) {
+            unsafe {
+                check_cublas(cublasDestroy_v2(self.0));
+            }
+        }
+    }
+
+    /// Evaluates the runtime of a cuda function with events.
+    unsafe fn time_cuda<F: FnOnce()>(f: F) -> f64 {
+        let mut start = std::mem::uninitialized();
+        let mut stop = std::mem::uninitialized();
+        check_cuda(cuEventCreate(
+            &mut start,
+            CUevent_flags_enum::CU_EVENT_DEFAULT as _,
+        ));
+        check_cuda(cuEventCreate(
+            &mut stop,
+            CUevent_flags_enum::CU_EVENT_DEFAULT as _,
+        ));
+        check_cuda(cuCtxSynchronize());
+        check_cuda(cuEventRecord(start, std::ptr::null_mut()));
+        f();
+        check_cuda(cuEventRecord(stop, std::ptr::null_mut()));
+        check_cuda(cuEventSynchronize(stop));
+        let mut time = 0f32;
+        check_cuda(cuEventElapsedTime(&mut time, start, stop));
+        check_cuda(cuEventDestroy_v2(start));
+        check_cuda(cuEventDestroy_v2(stop));
+        time as f64 * 1.0e6f64
+    }
+
+    unsafe fn get_array<T>(name: &str, context: &cuda::Context) -> *mut T {
+        let ptr: *const *mut T = std::mem::transmute(context.get_param(name).raw_ptr());
+        *ptr
+    }
+
+    const CUBLAS_N: cublasOperation_t = cublasOperation_t_CUBLAS_OP_N;
+    const CUBLAS_T: cublasOperation_t = cublasOperation_t_CUBLAS_OP_T;
+
+    /// Reference implementation for the `Axpy` kernel.
+    fn saxpy_reference(
+        handle: &CublasHandle,
+        &(n, _): &(i32, bool),
+        context: &cuda::Context,
+    ) -> f64 {
+        let n = n as libc::c_int;
+        let alpha = context.get_param("alpha").raw_ptr() as *const f32;
+        unsafe {
+            let x = get_array("x", context);
+            let y = get_array("y", context);
+            time_cuda(|| check_cublas(cublasSaxpy_v2(handle.0, n, alpha, x, 1, y, 1)))
+        }
+    }
+
+    /// Reference implementation for the matrix-vector multiplication.
+    fn matvec_reference(
+        handle: &CublasHandle,
+        &(m, n, _): &(i32, i32, bool),
+        context: &cuda::Context,
+    ) -> f64 {
+        let m = m as libc::c_int;
+        let n = n as libc::c_int;
+        unsafe {
+            let x = get_array("x", context);
+            let a = get_array("a", context);
+            let y = get_array("y", context);
+            time_cuda(|| {
+                let op = cublasOperation_t_CUBLAS_OP_T;
+                check_cublas(cublasSgemv_v2(
+                    handle.0, op, n, m, &2., a, n, x, 1, &3., y, 1,
+                ))
+            })
+        }
+    }
+
+    /// Reference implementation for the matrix-matrix multiplication.
+    fn matmul_reference(
+        handle: &CublasHandle,
+        params: &linalg::FusedMMP,
+        context: &cuda::Context,
+    ) -> f64 {
+        let m = params.m as libc::c_int;
+        let n = params.n as libc::c_int;
+        let k = params.k as libc::c_int;
+        assert!(params.a_stride == 1);
+        unsafe {
+            let a = get_array("a", context);
+            let b = get_array("b", context);
+            let c = get_array("c", context);
+            let (op_a, lda) = if params.transpose_a {
+                (CUBLAS_T, m)
+            } else {
+                (CUBLAS_N, k)
+            };
+            let (op_b, ldb) = if params.transpose_b {
+                (CUBLAS_T, k)
+            } else {
+                (CUBLAS_N, n)
+            };
+            time_cuda(|| {
+                check_cublas(cublasSgemm_v2(
+                    handle.0, op_b, op_a, n, m, k, &2., b, ldb, a, lda, &3., c, n,
+                ));
+            })
+        }
+    }
+
+    /// Reference implementation for the matrix-matrix multiplication.
+    fn batchmm_reference(
+        handle: &CublasHandle,
+        params: &linalg::BatchMMP,
+        context: &cuda::Context,
+    ) -> f64 {
+        let m = params.m as libc::c_int;
+        let n = params.n as libc::c_int;
+        let k = params.k as libc::c_int;
+        let batch = params.batch as libc::c_int;
+        unsafe {
+            let a = get_array("a", context);
+            let b = get_array("b", context);
+            let c = get_array("c", context);
+            let (op_a, lda) = if params.transpose_a {
+                (CUBLAS_T, m)
+            } else {
+                (CUBLAS_N, k)
+            };
+            let (op_b, ldb) = if params.transpose_b {
+                (CUBLAS_T, k)
+            } else {
+                (CUBLAS_N, n)
+            };
+            let stride_a = (m * k) as libc::c_long;
+            let stride_b = if params.batch_b { n * k } else { 0 } as libc::c_long;
+            let stride_c = (m * n) as libc::c_long;
+            time_cuda(|| {
+                check_cublas(cublasSgemmStridedBatched(
+                    handle.0, op_b, op_a, n, m, k, &2., b, ldb, stride_b, a, lda,
+                    stride_a, &3., c, n, stride_c, batch,
+                ));
+            })
+        }
+    }
+
+    /// Reference implementation for `Gesummv`.
+    fn gesummv_reference(
+        handle: &CublasHandle,
+        &(m, n, _): &(i32, i32, bool),
+        context: &cuda::Context,
+    ) -> f64 {
+        let m = m as libc::c_int;
+        let n = n as libc::c_int;
+        unsafe {
+            let a = get_array("a", context);
+            let b = get_array("b", context);
+            let x = get_array("x", context);
+            let y = get_array("y", context);
+            time_cuda(|| {
+                let op = cublasOperation_t_CUBLAS_OP_T;
+                check_cublas(cublasSgemv_v2(
+                    handle.0, op, n, m, &3.1, a, n, x, 1, &0., y, 1,
+                ));
+                check_cublas(cublasSgemv_v2(
+                    handle.0, op, n, m, &4.1, b, n, x, 1, &1., y, 1,
+                ));
+            })
+        }
+    }
+
+    impl<'a> Reference<'a, linalg::Axpy<'a, f32>> for CublasHandle {
+        type Context = cuda::Context<'a>;
+
+        fn eval_reference(&self, params: &(i32, bool), context: &Self::Context) -> f64 {
+            saxpy_reference(self, params, context)
+        }
+    }
+
+    impl<'a> Reference<'a, linalg::MatVec<'a, f32>> for CublasHandle {
+        type Context = cuda::Context<'a>;
+
+        fn eval_reference(
+            &self,
+            params: &(i32, i32, bool),
+            context: &Self::Context,
+        ) -> f64 {
+            matvec_reference(self, params, context)
+        }
+    }
+
+    impl<'a> Reference<'a, linalg::FusedMM<'a, f32>> for CublasHandle {
+        type Context = cuda::Context<'a>;
+
+        fn eval_reference(
+            &self,
+            params: &linalg::FusedMMP,
+            context: &Self::Context,
+        ) -> f64 {
+            matmul_reference(self, params, context)
+        }
+    }
+
+    impl<'a> Reference<'a, linalg::BatchMM<'a, f32>> for CublasHandle {
+        type Context = cuda::Context<'a>;
+
+        fn eval_reference(
+            &self,
+            params: &linalg::BatchMMP,
+            context: &Self::Context,
+        ) -> f64 {
+            batchmm_reference(self, params, context)
+        }
+    }
+
+    impl<'a> Reference<'a, linalg::Gesummv<'a, f32>> for CublasHandle {
+        type Context = cuda::Context<'a>;
+
+        fn eval_reference(
+            &self,
+            params: &(i32, i32, bool),
+            context: &Self::Context,
+        ) -> f64 {
+            gesummv_reference(self, params, context)
+        }
+    }
+}
+
+#[cfg(feature = "cuda")]
+pub use cuda_reference::CublasHandle;
+
+/// Helper enum to create the supported kernel parameters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KernelParam {
+    Axpy { n: i32 },
+    MatVec { m: i32, n: i32 },
+    Gesummv { m: i32, n: i32 },
+    Gemm { m: i32, n: i32, k: i32 },
+    BatchMM { b: i32, m: i32, n: i32, k: i32 },
+}
+
+impl KernelParam {
+    /// Build the kernel in a given context, and return a list of candidates.
+    pub fn build<'a, 'b, C>(&self, context: &'b mut C) -> (Vec<Candidate>, &'b C)
+    where
+        C: Context + ArgMap<'a>,
+        'a: 'b,
+    {
+        fn build<'a, 'b, K, C>(
+            params: K::Parameters,
+            context: &'b mut C,
+        ) -> (Vec<Candidate>, &'b C)
+        where
+            K: Kernel<'a> + 'b,
+            C: Context + ArgMap<'a>,
+        {
+            let (signature, kernel, context) =
+                KernelBuilder::default().build::<K, C>(params, context);
+            let signature = Arc::new(signature);
+            (kernel.build_body(signature, context), context)
+        }
+
+        match *self {
+            KernelParam::Axpy { n } => {
+                build::<'_, '_, linalg::Axpy<'_, f32>, C>((n, true), context)
+            }
+            KernelParam::MatVec { m, n } => {
+                build::<'_, '_, linalg::MatVec<'_, f32>, C>((m, n, true), context)
+            }
+            KernelParam::Gesummv { m, n } => {
+                build::<'_, '_, linalg::Gesummv<'_, f32>, C>((m, n, true), context)
+            }
+            KernelParam::Gemm { m, n, k } => {
+                build::<'_, '_, linalg::FusedMM<'_, f32>, C>(
+                    linalg::FusedMMP::new(m, n, k),
+                    context,
+                )
+            }
+            KernelParam::BatchMM { b, m, n, k } => {
+                build::<'_, '_, linalg::BatchMM<'_, f32>, C>(
+                    linalg::BatchMMP::new(b, m, n, k),
+                    context,
+                )
+            }
+        }
+    }
+}
+
+impl fmt::Display for KernelParam {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            KernelParam::Axpy { n } => write!(fmt, "axpy_{}", n),
+            KernelParam::MatVec { m, n } => write!(fmt, "matvec_{}_{}", m, n),
+            KernelParam::Gesummv { m, n } => write!(fmt, "gesummv_{}_{}", m, n),
+            KernelParam::Gemm { m, n, k } => write!(fmt, "matmul_{}_{}_{}", m, n, k),
+            KernelParam::BatchMM { b, m, n, k } => {
+                write!(fmt, "batchmm_{}_{}_{}_{}", b, m, n, k)
+            }
+        }
+    }
+}
+
+/// An error which can be returned when parsing a kernel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseKernelError {
+    kind: KernelErrorKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KernelErrorKind {
+    /// Value being parsed is empty.
+    ///
+    /// This variant will be constructed when parsing an empty string.
+    Empty,
+
+    /// Invalid kernel name provided.
+    InvalidName,
+
+    /// Kernel name is too short and a parameter was missing
+    MissingParameter,
+
+    /// Kernel name is too long and has extra parameters.
+    UnexpectedParameter,
+
+    /// A non-integer value was found where an integer value was expected.
+    IntError(std::num::ParseIntError),
+}
+
+impl ParseKernelError {
+    /// Outputs the detailed cause of parsing a kernel failing
+    pub fn kind(&self) -> &KernelErrorKind {
+        &self.kind
+    }
+}
+
+impl fmt::Display for ParseKernelError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            KernelErrorKind::Empty => {
+                fmt.write_str("cannot parse kernel from empty string")
+            }
+            KernelErrorKind::InvalidName => fmt.write_str("invalid kernel name"),
+            KernelErrorKind::MissingParameter => {
+                fmt.write_str("missing kernel parameter")
+            }
+            KernelErrorKind::UnexpectedParameter => {
+                fmt.write_str("extraneous unexpected kernel parameter")
+            }
+            KernelErrorKind::IntError(error) => fmt::Display::fmt(error, fmt),
+        }
+    }
+}
+
+impl Error for ParseKernelError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match &self.kind {
+            KernelErrorKind::IntError(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::num::ParseIntError> for ParseKernelError {
+    fn from(error: std::num::ParseIntError) -> ParseKernelError {
+        ParseKernelError {
+            kind: KernelErrorKind::IntError(error),
+        }
+    }
+}
+
+impl std::str::FromStr for KernelParam {
+    type Err = ParseKernelError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use KernelParam::*;
+
+        fn parse_i32(s: &str) -> Result<i32, std::num::ParseIntError> {
+            if let Some(pos) = s.find("p") {
+                let (base, exp) = s.split_at(pos);
+                Ok(base.parse::<i32>()?.pow(exp[1..].parse::<u32>()?))
+            } else {
+                s.parse::<i32>()
+            }
+        }
+
+        fn next_part<'a, I>(parts: &mut I) -> Result<&'a str, ParseKernelError>
+        where
+            I: Iterator<Item = &'a str>,
+        {
+            parts.next().ok_or(ParseKernelError {
+                kind: KernelErrorKind::MissingParameter,
+            })
+        }
+
+        let mut parts = s.split('_');
+        let name = next_part(&mut parts)?;
+
+        let result = match name {
+            "axpy" => {
+                let n = parse_i32(next_part(&mut parts)?)?;
+                Axpy { n }
+            }
+            "matvec" => {
+                let m = parse_i32(next_part(&mut parts)?)?;
+                let n = parse_i32(next_part(&mut parts)?)?;
+                MatVec { m, n }
+            }
+            "gesummv" => {
+                let m = parse_i32(next_part(&mut parts)?)?;
+                let n = parse_i32(next_part(&mut parts)?)?;
+                Gesummv { m, n }
+            }
+            "matmul" => {
+                let m = parse_i32(next_part(&mut parts)?)?;
+                let n = parse_i32(next_part(&mut parts)?)?;
+                let k = parse_i32(next_part(&mut parts)?)?;
+                Gemm { m, n, k }
+            }
+            "batchmm" => {
+                let b = parse_i32(next_part(&mut parts)?)?;
+                let m = parse_i32(next_part(&mut parts)?)?;
+                let n = parse_i32(next_part(&mut parts)?)?;
+                let k = parse_i32(next_part(&mut parts)?)?;
+                BatchMM { b, m, n, k }
+            }
+            _ => {
+                return Err(ParseKernelError {
+                    kind: KernelErrorKind::InvalidName,
+                })
+            }
+        };
+
+        if parts.next().is_some() {
+            Err(ParseKernelError {
+                kind: KernelErrorKind::UnexpectedParameter,
+            })
+        } else {
+            Ok(result)
+        }
+    }
+}
+
+/// Path to a replay file.
+///
+/// Replay files are .json files containing a serialized representation of actions to apply.  They
+/// can be generated by the debugger or the replay tests.
+///
+/// This is a thin wrapper around a `PathBuf` which provides convenience functions to load the
+/// actual actions.
+#[derive(Debug)]
+pub struct ReplayPath(PathBuf);
+
+impl From<&'_ OsStr> for ReplayPath {
+    fn from(os_str: &'_ OsStr) -> ReplayPath {
+        ReplayPath(os_str.into())
+    }
+}
+
+impl ReplayPath {
+    /// Load the replay and returns the corresponding actions.
+    ///
+    /// If no replay path was provided, an empty vector is returned.
+    pub fn load(&self) -> io::Result<Vec<Action>> {
+        Ok(serde_json::from_reader(fs::File::open(&self.0)?)?)
+    }
+}


### PR DESCRIPTION
The telamon-cli package currently provides two executables:

 - A `cuda_search` executable which runs the search for a given kernel
   and configuration

 - A `tlcli` swiss knife executable which allows doing a bunch of handy
   and common tasks such as extracting lists of actions from event log,
   displaying eventlog statistics, replaying a list of action, etc.
   Those are scripts I had lying around that I find useful, and as such
   worth it to share.

(Yes, those should be binaries in the main `telamon` package.  They are
not because (a) it would require recompiling the main `telamon` package
each time, which is way too slow and (b) they depend on the kernels.
Yes, this should be fixed; but it requires a non negligible amount of
refactoring -- so in the meantime let's use a separate crate)