### PR TITLE
Don't update the cut if it is worse than before

### DIFF
--- a/src/explorer/mcts.rs
+++ b/src/explorer/mcts.rs
@@ -1266,7 +1266,14 @@ where
     type Event = Message;
 
     fn update_cut(&self, new_cut: f64) {
-        *self.cut.write().expect("cut: poisoned") = new_cut;
+        // If an initial cut was specified in the configuration file, `update_cut` will be called
+        // with the first implementation found, even if it is not better than the previous cut.
+        //
+        // When this happens, we should keep using the provided initial cut instead of blindly
+        // using the new cut.
+        let mut cut_mut = self.cut.write().expect("cut: poisoned");
+        *cut_mut = new_cut.min(*cut_mut);
+
         self.cut_epoch.fetch_add(1, Ordering::Relaxed);
 
         // TODO: trim the tree?


### PR DESCRIPTION
When using the `initial_cut` parameter (eg when reusing a cut found from
a previous search), we were updating the cut after a first valid
implementation is found.  Such an implementation would have a bound that
is less than the initial cut, but not necessarily (in fact, almost
never) an execution time lower than the initial cut -- thus we would in
fact make the cut worse by performing this update.

This patch instead changes it so that we only update the cut if it
improves it.

NB: An alternative fix for this issue would be to take the initial cut
into account in the monitor, but this means we would ignore
implementations that are not faster than the initial cut.  This would
limit the usefulness of the `initial_cut` parameter -- in particular, it
wouldn't be possible to use it to optimisticaly cut branches with an
aggressive cut for which we don't have an implementation.