### PR TITLE
Add choice groups for fusion and nesting of dimensions

### DIFF
--- a/src/explorer/choice.rs
+++ b/src/explorer/choice.rs
@@ -125,6 +125,25 @@ pub fn list<'a>(
                         )
                     }))
                 }
+
+                ChoiceGroup::DimFusion => {
+                    Box::new(fun.dims().enumerate().flat_map(move |(i, lhs)| {
+                        let lhs = lhs.stmt_id();
+                        let dims = fun.dims().take(i).map(|x| x.stmt_id());
+
+                        dims.chain(fun.insts().map(|x| x.stmt_id())).flat_map(
+                            move |rhs| {
+                                let available_orders = space.domain().get_order(lhs, rhs);
+
+                                gen_choice(
+                                    available_orders.bisect(Order::MERGED),
+                                    &|order| Action::Order(lhs, rhs, order),
+                                )
+                            },
+                        )
+                    }))
+                }
+
                 ChoiceGroup::MemSpace => {
                     Box::new(fun.mem_blocks().flat_map(move |block| {
                         let mem_spaces = space.domain().get_mem_space(block.mem_id());

--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -355,6 +355,11 @@ pub enum ChoiceGroup {
     /// fused (explicitly sets Order::MERGED or explicitly eliminates
     /// Order:MERGED)
     DimFusion,
+
+    /// Exposes choices from Order defining whether two dimension are
+    /// nested (explicitly sets Order::INNER, Order::OUTER or
+    /// eliminates these two orders)
+    DimNesting,
 }
 
 impl fmt::Display for ChoiceGroup {
@@ -372,6 +377,7 @@ impl fmt::Display for ChoiceGroup {
             Threads => "threads",
             ThreadSize => "thread_size",
             DimFusion => "dim_fusion",
+            DimNesting => "dim_nesting",
         })
     }
 }
@@ -405,6 +411,7 @@ impl FromStr for ChoiceGroup {
             "threads" => Threads,
             "thread_size" => ThreadSize,
             "dim_fusion" => DimFusion,
+            "dim_nesting" => DimNesting,
             _ => return Err(ParseChoiceGroupError(s.to_string())),
         })
     }

--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -350,6 +350,11 @@ pub enum ChoiceGroup {
     InstFlag,
     Threads,
     ThreadSize,
+
+    /// Exposes choices from Order defining whether two dimension are
+    /// fused (explicitly sets Order::MERGED or explicitly eliminates
+    /// Order:MERGED)
+    DimFusion,
 }
 
 impl fmt::Display for ChoiceGroup {
@@ -366,6 +371,7 @@ impl fmt::Display for ChoiceGroup {
             InstFlag => "inst_flag",
             Threads => "threads",
             ThreadSize => "thread_size",
+            DimFusion => "dim_fusion",
         })
     }
 }
@@ -398,6 +404,7 @@ impl FromStr for ChoiceGroup {
             "inst_flag" => InstFlag,
             "threads" => Threads,
             "thread_size" => ThreadSize,
+            "dim_fusion" => DimFusion,
             _ => return Err(ParseChoiceGroupError(s.to_string())),
         })
     }

--- a/telamon-gen/src/print/template/enum_def.rs
+++ b/telamon-gen/src/print/template/enum_def.rs
@@ -33,7 +33,7 @@ impl {type_name} {{
             .chain((*self & !other).into_option().into_iter())
     }}
 
-    fn into_option(self) -> Option<Self> {{
+    pub fn into_option(self) -> Option<Self> {{
         if self.is_failed() {{ None }} else {{ Some(self) }}
     }}
 


### PR DESCRIPTION
Add new two new choice groups `DimFusion` and `DimNesting` that allow for the separation of fusion and nesting choices from sequential ordering choices from `Order`.