### PR TITLE
Add ability to restart the search

### DIFF
--- a/src/explorer/config.rs
+++ b/src/explorer/config.rs
@@ -46,6 +46,10 @@ pub struct Config {
     /// certain range above the best Therefore, if cut_under is 20%, we can discard any
     /// candidate whose bound is above 80% of the current best.
     pub distance_to_best: Option<f64>,
+    /// Restart the search every n evaluations.
+    ///
+    /// Only supported by the MCTS search algorithm.
+    pub restart_every_n_evals: Option<usize>,
     /// Exploration algorithm to use. Needs to be last for TOML serialization, because it is a table.
     pub algorithm: SearchAlgorithm,
 }
@@ -129,6 +133,7 @@ impl Default for Config {
             timeout: None,
             max_evaluations: None,
             distance_to_best: None,
+            restart_every_n_evals: None,
         }
     }
 }

--- a/src/explorer/store.rs
+++ b/src/explorer/store.rs
@@ -29,4 +29,6 @@ pub trait Store: Sync {
     fn explore(&self, context: &dyn Context) -> Option<(Candidate, Self::PayLoad)>;
     /// Displays statistics about the candidate store.
     fn print_stats(&self) {}
+    /// Resets the store to restart evaluation.
+    fn restart(&self) {}
 }


### PR DESCRIPTION
This adds the ability for the MCTS search algorithm to perform a (soft)
restart.  The soft restart erases information related to the evaluation
statistics (such as average runtime or top-k best runs).

Some information carries over across restarts, most notably:

 - The current cut
 - Nodes which were found dead through backtracking
 - Performance model bounds

The results of constraint propagation are not kept; however, the
structure of the tree ensures that we won't perform contraint
propagation if the result has already failed (or was cut due to the
performance model) in a previous restart.