### PR TITLE
Add kernels ResNetCell and TransformerCell

### DIFF
--- a/kernels/src/compose.rs
+++ b/kernels/src/compose.rs
@@ -195,6 +195,18 @@ pub fn tensor_map<'a, S: ScalarArgument>(
     VirtualTensor::new(res_instr, dims)
 }
 
+/// Divides each element of a virtual tensor `t` by a scalar
+/// operand `s`
+pub fn tensor_elementwise_div<'a, S: ScalarArgument>(
+    builder: &mut Builder,
+    t: &VirtualTensor<S>,
+    s: &dyn AutoOperand,
+) -> VirtualTensor<'a, S> {
+    tensor_map(builder, t, |tensor_operand, builder| {
+        builder.div(tensor_operand, s)
+    })
+}
+
 /// Multiplies each element of a virtual tensor `rhs` with a scalar
 /// operand `lhs`
 pub fn tensor_elementwise_mul<'a, S: ScalarArgument>(

--- a/kernels/src/compose.rs
+++ b/kernels/src/compose.rs
@@ -330,3 +330,18 @@ pub fn array_activate_inplace<S, D>(
         None => {}
     }
 }
+
+/// Applies the softmax function to an array `a` in place, i.e., each
+/// element `o_i` of the result has the value `o_i = exp(a_i) /
+/// sum(j = 0 to N, exp(a_j))`, where `a_i` is the i-th value of the
+/// input array `a` and `N` is the number of elements of `a`.
+pub fn array_softmax_inplace<S, D>(
+    a: &mut ndarray::Array<S, D>,
+) where
+    S: Scalar,
+    D: ndarray::Dimension,
+{
+    a.mapv_inplace(|c| S::exp(c));
+    let sum = a.scalar_sum();
+    a.mapv_inplace(|c| c / sum);
+}

--- a/kernels/src/compose.rs
+++ b/kernels/src/compose.rs
@@ -227,21 +227,46 @@ pub enum ActivationFunction {
     Sigmoid,
 }
 
-impl ActivationFunction {
-    /// Creates a new virtual tensor by applying the activation
-    /// function to each element of `t`
-    pub fn apply<S: Scalar>(
-        &self,
-        builder: &mut Builder,
-        t: &VirtualTensor<S>,
-    ) -> VirtualTensor<S> {
-        match self {
-            ActivationFunction::ReLU => tensor_elementwise_max(builder, t, &S::zero()),
-            ActivationFunction::Sigmoid => tensor_map(builder, t, |operand, builder| {
+/// Applies an optional activation function element-wise to the
+/// virtual tensor `a` and returns a new virtual tensor with the
+/// result. If no activation function has been specified, the instance
+/// itself is returned.
+pub fn tensor_activate<'a, S: Scalar>(
+    builder: &mut Builder,
+    t: VirtualTensor<'a, S>,
+    f: &Option<ActivationFunction>,
+) -> VirtualTensor<'a, S> {
+    match f {
+        Some(ActivationFunction::ReLU) => tensor_elementwise_max(builder, &t, &S::zero()),
+        Some(ActivationFunction::Sigmoid) => {
+            tensor_map(builder, &t, |operand, builder| {
                 let exp = builder.exp(operand);
                 let add = builder.add(&S::one(), &exp);
                 builder.div(&S::one(), &add)
-            }),
+            })
         }
+        None => t,
+    }
+}
+
+/// Applies an optional activation function element-wise and in place
+/// to the Array `a`. If no activation function has been specified,
+/// `a` is left unmodified.
+pub fn array_activate_inplace<S, D>(
+    a: &mut ndarray::Array<S, D>,
+    f: &Option<ActivationFunction>,
+) where
+    S: Scalar,
+    D: ndarray::Dimension,
+{
+    match f {
+        Some(ActivationFunction::ReLU) => {
+            a.mapv_inplace(|c| c.max(S::zero()));
+        }
+        Some(ActivationFunction::Sigmoid) => {
+            let one = S::one();
+            a.mapv_inplace(|c| one / (one + S::exp(c)));
+        }
+        None => {}
     }
 }

--- a/kernels/src/linalg.rs
+++ b/kernels/src/linalg.rs
@@ -2,13 +2,14 @@
 #![allow(clippy::many_single_char_names)]
 use std::sync::Arc;
 
-use crate::compose::{
-    array_activate_inplace, matrix_matrix_multiply, matrix_vector_multiply,
-    tensor_activate, tensor_add, tensor_elementwise_mul, tensor_mad, ActivationFunction,
-};
+pub use crate::compose;
 use crate::kernel::Kernel;
 use crate::{build_candidate, check_output, create_size, infer_tiling, Scalar};
 use ::ndarray::{Array1, Array2, Array3, ArrayD};
+use compose::{
+    array_activate_inplace, matrix_matrix_multiply, matrix_vector_multiply,
+    tensor_activate, tensor_add, tensor_elementwise_mul, tensor_mad, ActivationFunction,
+};
 use rand;
 use serde::{Deserialize, Serialize};
 use telamon::explorer::Candidate;

--- a/kernels/src/linalg.rs
+++ b/kernels/src/linalg.rs
@@ -3,8 +3,8 @@
 use std::sync::Arc;
 
 use crate::compose::{
-    matrix_matrix_multiply, matrix_vector_multiply, tensor_elementwise_mul, tensor_mad,
-    ActivationFunction,
+    array_activate_inplace, matrix_matrix_multiply, matrix_vector_multiply,
+    tensor_activate, tensor_add, tensor_elementwise_mul, tensor_mad, ActivationFunction,
 };
 use crate::kernel::Kernel;
 use crate::{build_candidate, check_output, create_size, infer_tiling, Scalar};
@@ -388,12 +388,9 @@ impl<'a, S: Scalar> Kernel<'a> for FusedMM<'a, S> {
 
         let ab = matrix_matrix_multiply(&mut builder, &a, &b);
 
-        if let Some(activation_fun) = &self.params.activation_fun {
-            let res = activation_fun.apply::<S>(&mut builder, &ab);
-            res.store(&self.c, &mut builder);
-        } else {
-            ab.store(&self.c, &mut builder);
-        }
+        let res = tensor_activate(&mut builder, ab, &self.params.activation_fun);
+
+        res.store(&self.c, &mut builder);
 
         vec![build_candidate(builder.get(), ctx)]
     }
@@ -403,20 +400,9 @@ impl<'a, S: Scalar> Kernel<'a> for FusedMM<'a, S> {
         let b_shape = (self.params.k as usize, self.params.n as usize);
         let a = unwrap!(self.a.read_to_host(context).into_shape(a_shape));
         let b = unwrap!(self.b.read_to_host(context).into_shape(b_shape));
+
         let mut res = a.dot(&b);
-
-        match self.params.activation_fun {
-            Some(ActivationFunction::ReLU) => {
-                res.mapv_inplace(|c| c.max(S::zero()));
-            }
-
-            Some(ActivationFunction::Sigmoid) => {
-                let one = S::one();
-                res.mapv_inplace(|c| one / (one + S::exp(c)));
-            }
-
-            None => {}
-        };
+        array_activate_inplace(&mut res, &self.params.activation_fun);
 
         res
     }
@@ -777,12 +763,8 @@ impl<'a, S: Scalar> Kernel<'a> for Fused2MM<'a, S> {
         let aabc = matrix_matrix_multiply(&mut builder, &aab, &c);
         let aabcpbd = tensor_mad(&mut builder, &d, &"beta", &aabc);
 
-        if let Some(activation_fun) = &self.params.activation_fun {
-            let res = activation_fun.apply::<S>(&mut builder, &aabcpbd);
-            res.store(&self.e, &mut builder);
-        } else {
-            aabcpbd.store(&self.e, &mut builder);
-        }
+        let res = tensor_activate(&mut builder, aabcpbd, &self.params.activation_fun);
+        res.store(&self.e, &mut builder);
 
         let candidate = build_candidate(builder.get(), ctx);
 
@@ -805,18 +787,7 @@ impl<'a, S: Scalar> Kernel<'a> for Fused2MM<'a, S> {
         let bd = d.mapv(|x| x * S::from(self.params.beta).unwrap());
         let mut aabcpbd = aabc + bd;
 
-        match self.params.activation_fun {
-            Some(ActivationFunction::ReLU) => {
-                aabcpbd.mapv_inplace(|c| c.max(S::zero()));
-            }
-
-            Some(ActivationFunction::Sigmoid) => {
-                let one = S::one();
-                aabcpbd.mapv_inplace(|c| one / (one + S::exp(c)));
-            }
-
-            None => {}
-        };
+        array_activate_inplace(&mut aabcpbd, &self.params.activation_fun);
 
         aabcpbd
     }

--- a/src/helper/tensor.rs
+++ b/src/helper/tensor.rs
@@ -237,7 +237,12 @@ where
                 (l.eval(context) as usize, (s.eval(context) / s_len) as usize)
             })
             .unzip();
-        let len = unwrap!(sizes.iter().zip_eq(&strides).map(|(&l, &s)| l * s).max());
+        let len = sizes
+            .iter()
+            .zip_eq(&strides)
+            .map(|(&l, &s)| l * s)
+            .max()
+            .unwrap_or(1);
         raw.split_off(len);
         unwrap!(ndarray::ArrayBase::from_shape_vec(
             sizes.strides(strides),

--- a/telamon-cli/Cargo.toml
+++ b/telamon-cli/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 structopt = "0.2"
 cuda-sys = { version = "0.1", optional = true }
+cudnn = { version = "1.3", optional = true }
 libc = { version = "0.2", optional = true }
 env_logger = "0.5"
 log = "0.4"
@@ -27,5 +28,5 @@ telamon-x86 = { path = "../backend/x86", optional = true }
 
 [features]
 default = ["cuda"]
-cuda = ["telamon-cuda/real_gpu", "cuda-sys", "libc"]
+cuda = ["telamon-cuda/real_gpu", "cuda-sys", "cudnn", "libc"]
 x86 = ["telamon-x86"]

--- a/telamon-cli/src/bin/cuda_search/main.rs
+++ b/telamon-cli/src/bin/cuda_search/main.rs
@@ -191,6 +191,12 @@ fn main() {
                     idx,
                 )
                 .run(&config, &executor, &reference),
+                ResNetCellBottomHalf { m, n, k, activation_fun } => Benchmark::<'_, linalg::ResNetCellBottomHalf<'_, f32>>::new(
+                    linalg::ResNetCellBottomHalfP::new(m, n, k, activation_fun),
+                    format!("ResNetCellBottomHalf_{}_{}_{}_{}", m, n, k, telamon_kernels::linalg::compose::ActivationFunction::opt_to_display(&activation_fun)),
+                    idx,
+                )
+                .run(&config, &executor, &reference),
                 TransformerCell { m, n, p, r } => Benchmark::<'_, linalg::TransformerCell<'_, f32>>::new(
                     linalg::TransformerCellP::new(m, n, p, r),
                     format!("TransformerCell_{}_{}_{}_{}", m, n, p, r),

--- a/telamon-cli/src/bin/cuda_search/main.rs
+++ b/telamon-cli/src/bin/cuda_search/main.rs
@@ -185,6 +185,12 @@ fn main() {
                     idx,
                 )
                 .run(&config, &executor, &reference),
+                ResNetCellTopHalf { m, n, k, activation_fun } => Benchmark::<'_, linalg::ResNetCellTopHalf<'_, f32>>::new(
+                    linalg::ResNetCellTopHalfP::new(m, n, k, activation_fun),
+                    format!("ResNetCellTopHalf_{}_{}_{}_{}", m, n, k, telamon_kernels::linalg::compose::ActivationFunction::opt_to_display(&activation_fun)),
+                    idx,
+                )
+                .run(&config, &executor, &reference),
                 TransformerCell { m, n, p, r } => Benchmark::<'_, linalg::TransformerCell<'_, f32>>::new(
                     linalg::TransformerCellP::new(m, n, p, r),
                     format!("TransformerCell_{}_{}_{}_{}", m, n, p, r),

--- a/telamon-cli/src/bin/cuda_search/main.rs
+++ b/telamon-cli/src/bin/cuda_search/main.rs
@@ -191,6 +191,12 @@ fn main() {
                     idx,
                 )
                 .run(&config, &executor, &reference),
+                TransformerCellTopHalf { m, n, p } => Benchmark::<'_, linalg::TransformerCellTopHalf<'_, f32>>::new(
+                    linalg::TransformerCellTopHalfP::new(m, n, p),
+                    format!("TransformerCellTopHalf_{}_{}_{}", m, n, p),
+                    idx,
+                )
+                .run(&config, &executor, &reference),
             }
         }
     }

--- a/telamon-cli/src/bin/cuda_search/main.rs
+++ b/telamon-cli/src/bin/cuda_search/main.rs
@@ -197,6 +197,12 @@ fn main() {
                     idx,
                 )
                 .run(&config, &executor, &reference),
+                TransformerCellBottomHalf { m, n, r } => Benchmark::<'_, linalg::TransformerCellBottomHalf<'_, f32>>::new(
+                    linalg::TransformerCellBottomHalfP::new(m, n, r),
+                    format!("TransformerCellBottomHalf_{}_{}_{}", m, n, r),
+                    idx,
+                )
+                .run(&config, &executor, &reference),
             }
         }
     }

--- a/telamon-cli/src/bin/cuda_search/main.rs
+++ b/telamon-cli/src/bin/cuda_search/main.rs
@@ -185,6 +185,12 @@ fn main() {
                     idx,
                 )
                 .run(&config, &executor, &reference),
+                TransformerCell { m, n, p, r } => Benchmark::<'_, linalg::TransformerCell<'_, f32>>::new(
+                    linalg::TransformerCellP::new(m, n, p, r),
+                    format!("TransformerCell_{}_{}_{}_{}", m, n, p, r),
+                    idx,
+                )
+                .run(&config, &executor, &reference),
             }
         }
     }

--- a/telamon-cli/src/bin/cuda_search/main.rs
+++ b/telamon-cli/src/bin/cuda_search/main.rs
@@ -179,6 +179,12 @@ fn main() {
                     idx,
                 )
                 .run(&config, &executor, &reference),
+                ResNetCell { m, n, k, activation_fun } => Benchmark::<'_, linalg::ResNetCell<'_, f32>>::new(
+                    linalg::ResNetCellP::new(m, n, k).activation_fun(activation_fun),
+                    format!("ResNetCell_{}_{}_{}_{}", m, n, k, telamon_kernels::linalg::compose::ActivationFunction::opt_to_display(&activation_fun)),
+                    idx,
+                )
+                .run(&config, &executor, &reference),
             }
         }
     }


### PR DESCRIPTION
This series of commits adds two new ML kernels `ResNetCell` and `TransformerCell`. Additionally, for each of these kernels, two further kernels are added that result result from splitting the original kernel in two stages (`ResNetCellTopHalf`, `ResNetCellBottomHalf`, `TransformerCellTopHalf`, and `TransformerCellTopHalf`).