### PR TITLE
Move collect_direct_reduce_dims to a method

### DIFF
--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -87,6 +87,20 @@ impl<L> Instruction<L> {
         self.operator.operands()
     }
 
+    /// Iterate over the dimensions that appear in `Reduce` operands for this instruction.
+    pub fn iter_reduced_dims<'a>(&'a self) -> impl Iterator<Item = ir::DimId> + 'a {
+        self.operator.operands().into_iter().flat_map(|operand| {
+            match operand {
+                Operand::Reduce(_, _, _, reduce_dims) => {
+                    Some(reduce_dims.into_iter().cloned())
+                }
+                _ => None,
+            }
+            .into_iter()
+            .flatten()
+        })
+    }
+
     /// Returns the type of the variable produced by an instruction.
     pub fn t(&self) -> Option<Type> {
         self.operator.t()


### PR DESCRIPTION
This patch moves the `collect_direct_reduce_dims` from `search_space` to
a method of the `ir::Operand` for ease of use and reduction of
(conceptual) inter-dependencies between modules.