### PR TITLE
[explorer] Write end-of-search information to watch.log

### DIFF
--- a/src/explorer/logger.rs
+++ b/src/explorer/logger.rs
@@ -17,7 +17,11 @@ pub enum LogMessage<E> {
         cpt: usize,
         timestamp: Duration,
     },
-    Finished(monitor::TerminationReason),
+    Finished {
+        reason: monitor::TerminationReason,
+        timestamp: Duration,
+        num_evaluations: usize,
+    },
 }
 
 #[derive(Debug, Fail)]
@@ -66,12 +70,32 @@ pub fn log<E: Send + Serialize>(
             } => {
                 log_monitor(score, cpt, timestamp, &mut write_buffer);
             }
-            LogMessage::Finished(reason) => {
-                writeln!(write_buffer, "search stopped because {}", reason)?;
+            LogMessage::Finished {
+                reason,
+                timestamp,
+                num_evaluations,
+            } => {
+                let t_s = timestamp.as_secs();
+                let n_seconds = t_s % 60;
+                let n_minutes = (t_s / 60) % 60;
+                let n_hours = t_s / 3600;
+                writeln!(
+                    write_buffer,
+                    "search stopped after {}h {}m {}s and {} evaluations \
+                     (avg {} evaluations/s)",
+                    n_hours,
+                    n_minutes,
+                    n_seconds,
+                    num_evaluations,
+                    num_evaluations as f64 / (timestamp.as_nanos() as f64 * 1e-9),
+                )?;
+                writeln!(write_buffer, "{}", reason)?;
             }
         }
+        // Flush after writing a message to ensure the log file does not end up empty in case of a
+        // crash.
+        write_buffer.flush()?;
     }
-    write_buffer.flush()?;
     record_writer
         .into_inner()
         .map_err(io::Error::from)?

--- a/src/explorer/monitor.rs
+++ b/src/explorer/monitor.rs
@@ -116,7 +116,11 @@ where
         Err(reason) => {
             warn!("exploration stopped because {}", reason);
             candidate_store.stop_exploration();
-            unwrap!(log_sender.send(LogMessage::Finished(reason)));
+            unwrap!(log_sender.send(LogMessage::Finished {
+                reason,
+                timestamp: duration,
+                num_evaluations: status.num_evaluations
+            }));
         }
     }
     status.best_candidate.map(|x| x.0)


### PR DESCRIPTION
Currently the information about how long the search took and how many
evaluations were made in total is only written to stdout, and not
persisted.  This patch also writes it to the log file, so that it stays
available after the fact.