### PR TITLE
[explorer] Dump actions.json for best candidates

### DIFF
--- a/src/explorer/monitor.rs
+++ b/src/explorer/monitor.rs
@@ -10,6 +10,7 @@ use futures::prelude::*;
 use futures::{executor, future, task, Async};
 use log::warn;
 use serde::{Deserialize, Serialize};
+use std::io::Write;
 use std::sync::{
     self,
     atomic::{AtomicBool, Ordering},
@@ -177,13 +178,20 @@ where
         };
         unwrap!(log_sender.send(log_message));
 
-        match config.output_path(format!("best_{}", status.num_evaluations)) {
-            Ok(output_path) => cand
-                .space
-                .dump_code(context, output_path)
-                .unwrap_or_else(|err| warn!("Error while dumping candidate: {}", err)),
-            Err(err) => warn!("Error while dumping candidate: {}", err),
-        }
+        config
+            .output_path(format!("best_{}", status.num_evaluations))
+            .and_then(|output_path| {
+                std::fs::create_dir_all(&output_path)?;
+
+                write!(
+                    std::fs::File::create(output_path.join("actions.json"))?,
+                    "{}",
+                    serde_json::to_string(&cand.actions).unwrap()
+                )?;
+
+                cand.space.dump_code(context, output_path.join("code"))
+            })
+            .unwrap_or_else(|err| warn!("Error while dumping candidate: {}", err));
 
         status.best_candidate = Some((cand, eval));
     }


### PR DESCRIPTION
Previously we were generating a `best_X.c` and `best_X.cfg` for each
best candidate, which doesn't allow to easily re-use the found
implementation e.g. in the debugger.  The `tlcli rebuild` command was
introduced for this purpose, and can extract a replay file from the
eventlog.

However, evenlogs these days tend to be quite large, and it may not be
desirable to keep them for runs which don't need specific performance
analysis.  Hence, this patch changes the mechanism for dumping best
candidates: now a directory `best_X` is created, with the generated code
in `code.c`; the loop tree in `code.cfg`; and the replay in
`actions.json` (not unlike the format used for errors, which also
contain extra files about the error).