### PR TITLE
[tlcli] Introduce a platform-independent kernel builder

### DIFF
--- a/telamon-cli/Cargo.toml
+++ b/telamon-cli/Cargo.toml
@@ -18,6 +18,7 @@ crossbeam = "0.7"
 bincode = "1.0"
 streaming-stats = "0.2"
 num_cpus = "1.8.0"
+itertools = "0.8"
 
 telamon = { path = "../" }
 telamon-cuda = { path = "../backend/cuda", optional = true }

--- a/telamon-cli/src/bin/cuda_search/main.rs
+++ b/telamon-cli/src/bin/cuda_search/main.rs
@@ -1,62 +1,11 @@
 //! Benchmarks the exploration on CUDA gpus.
-use std::io::{self, Write};
+use std::io::Write;
 
-use telamon::device::{ArgMap, Context};
-use telamon::explorer::config::Config;
-use telamon::helper::MemInit;
-use telamon_cli::{
-    Bench, CommonOpt, ContextBuilder, CublasHandle, KernelParam, Reference,
-};
+use telamon::{codegen, explorer};
+use telamon_cli::{Bench, CommonOpt, KernelParam, Platform};
 use telamon_kernels::statistics::estimate_mean;
-use telamon_kernels::{linalg, Kernel};
 
 use structopt::StructOpt;
-
-/// The number of times to run the generated code to evaluate its performance.
-const NUM_CODE_RUNS: usize = 40;
-/// Search timeout in minutes.
-const TIMEOUT: u64 = 240;
-
-/// Benchmarks a kernel against a reference implementation.
-fn benchmark<'a, K, REF, CB>(
-    mut config: Config,
-    params: K::Parameters,
-    executor: CB,
-    reference: &REF,
-) where
-    K: Kernel<'a>,
-    CB: ContextBuilder<'a>,
-    REF: Reference<'a, K, Context = CB::Context>,
-{
-    config.timeout.get_or_insert(TIMEOUT);
-
-    let mut context = executor.build_context();
-    let runtime = K::benchmark(
-        &config,
-        params.clone(),
-        NUM_CODE_RUNS,
-        MemInit::RandomFill,
-        &mut context,
-    );
-    let ref_runtime = Bench::default()
-        .warmup(4)
-        .runs(NUM_CODE_RUNS)
-        .benchmark_fn(|| reference.eval_reference(&params, &context));
-    let mut f =
-        std::fs::File::create(config.output_path("benchmark.txt").unwrap()).unwrap();
-    writeln!(f, "runtimes: {:?}", runtime).unwrap();
-    let mean = estimate_mean(runtime, 0.95, "ns");
-    let ref_mean = estimate_mean(ref_runtime, 0.95, "ns");
-    writeln!(
-        f,
-        "{}: {}, reference: {}, speedup: {:.2}",
-        K::name(),
-        mean,
-        ref_mean,
-        ref_mean.value / mean.value
-    )
-    .unwrap();
-}
 
 #[derive(StructOpt)]
 struct Opt {
@@ -68,118 +17,65 @@ struct Opt {
 
     #[structopt(short = "k", long = "kernel")]
     kernels: Vec<KernelParam>,
-}
 
-trait BenchRun<'a, B, R> {
-    fn run(self, config: &Config, builder: B, reference: &R);
-}
+    #[structopt(long = "platform", default_value = "cuda")]
+    platform: Platform,
 
-struct Benchmark<'a, K>
-where
-    K: Kernel<'a>,
-{
-    params: K::Parameters,
-    name: String,
-    iteration: usize,
-}
-
-impl<'a, K> Benchmark<'a, K>
-where
-    K: Kernel<'a>,
-{
-    fn new(params: K::Parameters, name: String, iteration: usize) -> Self {
-        Benchmark {
-            params,
-            name,
-            iteration,
-        }
-    }
-
-    fn output_dir(&self) -> String {
-        format!("{}/{}", self.name, self.iteration)
-    }
-}
-
-impl<'a, K, B, R> BenchRun<'a, B, R> for Benchmark<'a, K>
-where
-    K: Kernel<'a>,
-    B: ContextBuilder<'a>,
-    R: Reference<'a, K, Context = B::Context>,
-{
-    fn run(self, config: &Config, builder: B, reference: &R) {
-        let mut config = config.clone();
-        config.output_dir = std::path::Path::new(&config.output_dir)
-            .join(self.output_dir())
-            .to_str()
-            .unwrap()
-            .to_string();
-        benchmark::<K, _, _>(config.clone(), self.params, builder, reference)
-    }
-}
-
-macro_rules! benchmark {
-    (Sgemm($m:expr, $n:expr, $k:expr)[$iter:expr]) => {{
-        self::Benchmark::<'_, linalg::FusedMM<'_, f32>>::new(
-            linalg::FusedMMP::new($m, $n, $k),
-            format!("Sgemm_{}_{}_{}", $m, $n, $k),
-            $iter,
-        )
-    }};
-
-    (BatchMM($b:expr, $m:expr, $n:expr, $k:expr)[$iter:expr]) => {{
-        self::Benchmark::<'_, linalg::BatchMM<'_, f32>>::new(
-            linalg::BatchMMP::new($b, $m, $n, $k),
-            format!("BatchMM_{}_{}_{}_{}", $b, $m, $n, $k),
-            $iter,
-        )
-    }};
+    /// Number of times to run the generated code to evaluate its performance.
+    #[structopt(long = "num-code-runs", default_value = "40")]
+    num_code_runs: usize,
 }
 
 fn main() {
     env_logger::init();
     let args = Opt::from_args();
 
-    let executor = telamon_cuda::Executor::init();
-    let reference = CublasHandle::new();
-
-    let config = args.common.config().unwrap();
+    let builder = args.platform.to_builder();
+    let mut config = args.common.config().unwrap().clone();
+    let output_base = std::path::Path::new(&config.output_dir).to_owned();
 
     for idx in 0..args.repeat {
         for kernel in &args.kernels {
-            use KernelParam::*;
+            config.output_dir = output_base
+                .join(kernel.to_string())
+                .join(idx.to_string())
+                .to_str()
+                .unwrap()
+                .to_string();
 
-            match *kernel {
-                Axpy { n } => Benchmark::<'_, linalg::Axpy<f32>>::new(
-                    (n, true),
-                    format!("Axpy_{}", n),
-                    idx,
-                )
-                .run(&config, &executor, &reference),
-                MatVec { m, n } => Benchmark::<'_, linalg::MatVec<f32>>::new(
-                    (m, n, true),
-                    format!("Sgemv_{}_{}", m, n),
-                    idx,
-                )
-                .run(&config, &executor, &reference),
-                Gesummv { m, n } => Benchmark::<'_, linalg::Gesummv<f32>>::new(
-                    (m, n, true),
-                    format!("Gesummv_{}_{}", m, n),
-                    idx,
-                )
-                .run(&config, &executor, &reference),
-                Gemm { m, n, k } => Benchmark::<'_, linalg::FusedMM<'_, f32>>::new(
-                    linalg::FusedMMP::new(m, n, k),
-                    format!("Sgemm_{}_{}_{}", m, n, k),
-                    idx,
-                )
-                .run(&config, &executor, &reference),
-                BatchMM { b, m, n, k } => Benchmark::<'_, linalg::BatchMM<'_, f32>>::new(
-                    linalg::BatchMMP::new(b, m, n, k),
-                    format!("BatchMM_{}_{}_{}_{}", b, m, n, k),
-                    idx,
-                )
-                .run(&config, &executor, &reference),
-            }
+            let mut context = builder.build_context();
+            let (bundle, context) = context.kernel_bundle(kernel);
+
+            let best = explorer::find_best_ex(
+                &config,
+                context,
+                bundle.candidates,
+                Some(&bundle.check_fn),
+            )
+            .unwrap_or_else(|| panic!("no candidates found for kernel {}", kernel));
+
+            let best_fn = codegen::Function::build(&best.space);
+            let runtime = context.benchmark(&best_fn, args.num_code_runs);
+
+            let ref_runtime = Bench::default()
+                .runs(args.num_code_runs)
+                .benchmark_fn(&bundle.reference_fn);
+
+            let mut f =
+                std::fs::File::create(config.output_path("benchmark.txt").unwrap())
+                    .unwrap();
+            writeln!(f, "runtimes: {:?}", runtime).unwrap();
+            let mean = estimate_mean(runtime, 0.95, "ns");
+            let ref_mean = estimate_mean(ref_runtime, 0.95, "ns");
+            writeln!(
+                f,
+                "{}: {}, reference: {}, speedup: {:.2}",
+                kernel,
+                mean,
+                ref_mean,
+                ref_mean.value / mean.value
+            )
+            .unwrap();
         }
     }
 }

--- a/telamon-cli/src/bin/cuda_search/main.rs
+++ b/telamon-cli/src/bin/cuda_search/main.rs
@@ -50,7 +50,10 @@ fn main() {
                 &config,
                 context,
                 bundle.candidates,
-                Some(&bundle.check_fn),
+                Some({
+                    let check_fn = &bundle.check_fn;
+                    &move |_, context| check_fn(context)
+                }),
             )
             .unwrap_or_else(|| panic!("no candidates found for kernel {}", kernel));
 

--- a/telamon-cli/src/bin/tlcli.rs
+++ b/telamon-cli/src/bin/tlcli.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::{self, Write};
 use std::path::PathBuf;
-use std::sync::{atomic, Arc, Mutex};
+use std::sync::atomic;
 
 use serde_json;
 use structopt::StructOpt;
@@ -15,16 +15,18 @@ use telamon::explorer::{
     eventlog::EventLog,
     mcts, Candidate,
 };
-use telamon::ir::IrDisplay;
 use telamon::model::{bound, Bound};
 use telamon::offline_analysis::tree::CandidateTree;
 use telamon::search_space::SearchSpace;
 
-use telamon_cli::{KernelParam, ReplayPath};
+use telamon_cli::{KernelParam, Platform, ReplayPath};
 
 /// Compute the bound for a given candidate.
 #[derive(StructOpt)]
 struct ComputeBound {
+    #[structopt(long = "platform", default_value = "cuda")]
+    platform: Platform,
+
     /// Kernel specification to use.
     #[structopt(short = "k", long = "kernel")]
     kernel: KernelParam,
@@ -36,9 +38,11 @@ struct ComputeBound {
 
 impl ComputeBound {
     fn run(&self, _args: &Opt) -> io::Result<()> {
-        let executor = telamon_cuda::Executor::init();
-        let mut context = telamon_cuda::Context::new(&executor);
-        let (mut candidates, context) = self.kernel.build(&mut context);
+        let builder = self.platform.to_builder();
+        let mut context = builder.build_context();
+        let (bundle, context) = context.kernel_bundle(&self.kernel);
+        let mut candidates = bundle.candidates;
+
         assert!(candidates.len() == 1);
         let mut candidate = candidates.swap_remove(0).space;
 
@@ -63,6 +67,9 @@ impl ComputeBound {
 /// Compute bounds.csv
 #[derive(StructOpt)]
 struct Bounds {
+    #[structopt(long = "platform", default_value = "cuda")]
+    platform: Platform,
+
     #[structopt(long = "order")]
     order: Option<config::ChoiceOrdering>,
 
@@ -168,11 +175,11 @@ impl Bounds {
     }
 
     fn run(&self, _args: &Opt) -> io::Result<()> {
-        let executor = telamon_cuda::Executor::init();
-        let mut context = telamon_cuda::Context::new(&executor);
-        let (candidates, context) = self.kernel.build(&mut context);
+        let builder = self.platform.to_builder();
+        let mut context = builder.build_context();
+        let (bundle, context) = context.kernel_bundle(&self.kernel);
         let stdout = std::io::stdout();
-        self.test_bound(candidates, context, |(runtime, bounds)| {
+        self.test_bound(bundle.candidates, context, |(runtime, bounds)| {
             let mut handle = stdout.lock();
             write!(handle, "{},{}", self.kernel, runtime).unwrap();
             for bound in bounds {
@@ -328,7 +335,7 @@ impl Stats {
                                 }
                                 len += 1;
                             }
-                            mcts::Event::KillChild(index, cause_) => {
+                            mcts::Event::KillChild(_index, cause_) => {
                                 let info = deadinfo
                                     .entry((Cause::from(cause_), has_size))
                                     .or_insert((0u64, 0u32));

--- a/telamon-cli/src/lib.rs
+++ b/telamon-cli/src/lib.rs
@@ -8,9 +8,7 @@ use std::{fmt, fs, io};
 use structopt::StructOpt;
 
 use telamon::device::{ArgMap, Context};
-use telamon::explorer::{
-    choice::ActionEx as Action, config::Config, Candidate, CheckResultFn,
-};
+use telamon::explorer::{choice::ActionEx as Action, config::Config, Candidate};
 use telamon_kernels::{linalg, Kernel, KernelBuilder};
 
 #[derive(StructOpt)]
@@ -227,7 +225,7 @@ mod cuda_reference {
             };
             time_cuda(|| {
                 check_cublas(cublasSgemm_v2(
-                    handle.0, op_b, op_a, n, m, k, &2., b, ldb, a, lda, &3., c, n,
+                    handle.0, op_b, op_a, n, m, k, &1., b, ldb, a, lda, &0., c, n,
                 ));
             })
         }
@@ -262,8 +260,8 @@ mod cuda_reference {
             let stride_c = (m * n) as libc::c_long;
             time_cuda(|| {
                 check_cublas(cublasSgemmStridedBatched(
-                    handle.0, op_b, op_a, n, m, k, &2., b, ldb, stride_b, a, lda,
-                    stride_a, &3., c, n, stride_c, batch,
+                    handle.0, op_b, op_a, n, m, k, &1., b, ldb, stride_b, a, lda,
+                    stride_a, &0., c, n, stride_c, batch,
                 ));
             })
         }
@@ -434,7 +432,7 @@ pub use x86_reference::X86Reference;
 /// implementation's output is valid, and a reference function to compare to.
 pub struct KernelBundle<'a> {
     pub candidates: Vec<Candidate>,
-    pub check_fn: Box<CheckResultFn<'a>>,
+    pub check_fn: Box<dyn Fn(&dyn Context) -> Result<(), String> + Sync + 'a>,
     pub reference_fn: Box<dyn Fn() -> f64 + 'a>,
 }
 
@@ -503,9 +501,8 @@ impl KernelParam {
                 let signature = Arc::new(signature);
                 let expected = kernel.get_expected_output(context);
                 let candidates = kernel.build_body(signature, context);
-                let check_fn = move |_candidate: &Candidate, context: &dyn Context| {
-                    kernel.check_result(&expected, context)
-                };
+                let check_fn =
+                    move |context: &dyn Context| kernel.check_result(&expected, context);
                 let reference = self.reference;
                 let reference_fn = move || {
                     Reference::<'_, K>::eval_reference(&reference, &params, context)
@@ -826,6 +823,12 @@ impl<'a> PlatformContext<'a> {
 #[derive(Debug)]
 pub struct ReplayPath(PathBuf);
 
+impl From<&'_ str> for ReplayPath {
+    fn from(s: &'_ str) -> ReplayPath {
+        ReplayPath(s.into())
+    }
+}
+
 impl From<&'_ OsStr> for ReplayPath {
     fn from(os_str: &'_ OsStr) -> ReplayPath {
         ReplayPath(os_str.into())
@@ -838,5 +841,9 @@ impl ReplayPath {
     /// If no replay path was provided, an empty vector is returned.
     pub fn load(&self) -> io::Result<Vec<Action>> {
         Ok(serde_json::from_reader(fs::File::open(&self.0)?)?)
+    }
+
+    pub fn display(&self) -> std::path::Display<'_> {
+        self.0.display()
     }
 }


### PR DESCRIPTION
Currently it is always painful to write generic CLI interfaces to
kernels because of the over-reliance on templated code.  This patch
tries to improve the situation by introducing platform- and
kernel-abstracting APIs in the tlcli library to hide the generic and
allow a value-level API for building the different kernels X platform
combinations.

This is done through the introduction of `Platform`,
`PlatformContextBuilder` and `PlatformContext` abstractions which
perform dispatching over the platform (currently x86 or cuda), and a
`KernelBundle` abstraction which packs the relevant information about a
built kernel, namely the candidates, a checking function (for output
validity), and a reference function (for performance comparisons).