### PR TITLE
[tlcli] Add a `codegen` subcommand

### DIFF
--- a/telamon-cli/Cargo.toml
+++ b/telamon-cli/Cargo.toml
@@ -18,6 +18,7 @@ crossbeam = "0.7"
 bincode = "1.0"
 streaming-stats = "0.2"
 num_cpus = "1.8.0"
+itertools = "0.8"
 
 telamon = { path = "../" }
 telamon-cuda = { path = "../backend/cuda", optional = true }

--- a/telamon-cli/src/bin/cuda_search/main.rs
+++ b/telamon-cli/src/bin/cuda_search/main.rs
@@ -50,7 +50,10 @@ fn main() {
                 &config,
                 context,
                 bundle.candidates,
-                Some(&bundle.check_fn),
+                Some({
+                    let check_fn = &bundle.check_fn;
+                    &move |_, context| check_fn(context)
+                }),
             )
             .unwrap_or_else(|| panic!("no candidates found for kernel {}", kernel));
 


### PR DESCRIPTION
This patch adds a `codegen` command to the telamon CLI, allowing to
generate the C code associated with a given kernel and set of actions.