### PR TITLE
[tlcli] Add a `benchmark` command

### DIFF
--- a/telamon-cli/Cargo.toml
+++ b/telamon-cli/Cargo.toml
@@ -18,6 +18,7 @@ crossbeam = "0.7"
 bincode = "1.0"
 streaming-stats = "0.2"
 num_cpus = "1.8.0"
+itertools = "0.8"
 
 telamon = { path = "../" }
 telamon-cuda = { path = "../backend/cuda", optional = true }

--- a/telamon-cli/src/bin/cuda_search/main.rs
+++ b/telamon-cli/src/bin/cuda_search/main.rs
@@ -50,7 +50,10 @@ fn main() {
                 &config,
                 context,
                 bundle.candidates,
-                Some(&bundle.check_fn),
+                Some({
+                    let check_fn = &bundle.check_fn;
+                    &move |_, context| check_fn(context)
+                }),
             )
             .unwrap_or_else(|| panic!("no candidates found for kernel {}", kernel));
 


### PR DESCRIPTION
This patch adds a `benchmark` command to the telamon CLI, allowing to
re-run benchmarks (both of the generated code, and the reference code)
for a given kernel and replay file after-the-fact.

This will print the same information as in the `benchmark.txt` generated
during the search, namely the average runtime of the benchmarked kernel
and the reference.   The bound for the fixed candidate generated is also
displayed.

A batch mode is also provided, for running the same kernel with
different replays.  In that case, the output (to stdout) is a .csv
containing one line per replay, with the raw measurements.