### PR TITLE
Remove lifetime from codegen::Size

### DIFF
--- a/backend/cuda/src/kernel.rs
+++ b/backend/cuda/src/kernel.rs
@@ -94,7 +94,7 @@ impl<'a, 'b> Kernel<'a, 'b> {
             .function
             .device_code_args()
             .map(|x| match *x {
-                ParamVal::External(p, _) => ThunkArg::ArgRef(args.get_param(&p.name)),
+                ParamVal::External(ref p, _) => ThunkArg::ArgRef(args.get_param(&p.name)),
                 ParamVal::Size(ref s) => {
                     ThunkArg::Size(Box::new(args.eval_size(s) as i32))
                 }

--- a/backend/cuda/src/printer.rs
+++ b/backend/cuda/src/printer.rs
@@ -302,7 +302,7 @@ impl CudaPrinter {
         let params = fun
             .device_code_args()
             .map(|p| match *p {
-                ParamVal::External(p, _) => format!("&{}", p.name),
+                ParamVal::External(ref p, _) => format!("&{}", p.name),
                 ParamVal::Size(ref size) => {
                     let extra_var = format!("_extra_{}", next_extra_var_id);
                     next_extra_var_id += 1;
@@ -586,7 +586,7 @@ impl InstPrinter for CudaPrinter {
 
     fn name_operand<'a>(
         vector_levels: &[Vec<Dimension>; 2],
-        op: &ir::Operand,
+        op: &'a ir::Operand,
         name_map: &'a NameMap<ValuePrinter>,
     ) -> Cow<'a, str> {
         assert!(vector_levels[0].is_empty());

--- a/backend/mppa/src/printer.rs
+++ b/backend/mppa/src/printer.rs
@@ -612,7 +612,7 @@ impl InstPrinter for MppaPrinter {
 
     fn name_operand<'a>(
         vector_dims: &[Vec<Dimension>; 2],
-        op: &ir::Operand,
+        op: &'a ir::Operand,
         name_map: &'a NameMap<ValuePrinter>,
     ) -> Cow<'a, str> {
         assert!(vector_dims[0].is_empty());

--- a/backend/x86/src/printer.rs
+++ b/backend/x86/src/printer.rs
@@ -518,7 +518,7 @@ impl InstPrinter for X86printer {
 
     fn name_operand<'a>(
         vector_dims: &[Vec<Dimension>; 2],
-        op: &ir::Operand,
+        op: &'a ir::Operand,
         value_printer: &'a NameMap<ValuePrinter>,
     ) -> Cow<'a, str> {
         assert!(vector_dims[0].is_empty());

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -1,5 +1,6 @@
 //! Describes a `Function` that is ready to execute on a device.
-use std::{self, fmt};
+use std::fmt;
+use std::sync::Arc;
 
 use crate::codegen::{
     self, cfg, dimension, Cfg, Dimension, InductionLevel, InductionVar,
@@ -18,9 +19,9 @@ pub struct Function<'a> {
     cfg: Cfg<'a>,
     thread_dims: Vec<Dimension<'a>>,
     block_dims: Vec<Dimension<'a>>,
-    device_code_args: Vec<ParamVal<'a>>,
+    device_code_args: Vec<ParamVal>,
     induction_vars: Vec<InductionVar<'a>>,
-    mem_blocks: Vec<MemoryRegion<'a>>,
+    mem_blocks: Vec<MemoryRegion>,
     init_induction_levels: Vec<InductionLevel<'a>>,
     variables: Vec<codegen::Variable<'a>>,
     // TODO(cleanup): remove dependency on the search space
@@ -108,7 +109,7 @@ impl<'a> Function<'a> {
     }
 
     /// Returns the values to pass from the host to the device.
-    pub fn device_code_args(&self) -> impl Iterator<Item = &ParamVal<'a>> {
+    pub fn device_code_args(&self) -> impl Iterator<Item = &ParamVal> {
         self.device_code_args.iter()
     }
 
@@ -172,33 +173,33 @@ impl<'a> fmt::Display for Function<'a> {
 
 /// Represents the value of a parameter passed to the kernel by the host.
 #[derive(Debug)]
-pub enum ParamVal<'a> {
+pub enum ParamVal {
     /// A parameter given by the caller.
-    External(&'a ir::Parameter, ir::Type),
+    External(Arc<ir::Parameter>, ir::Type),
     /// A tiled dimension size computed on the host.
-    Size(codegen::Size<'a>),
+    Size(codegen::Size),
     /// A pointer to a global memory block, allocated by the wrapper.
-    GlobalMem(ir::MemId, codegen::Size<'a>, ir::Type),
+    GlobalMem(ir::MemId, codegen::Size, ir::Type),
 }
 
-impl<'a> ParamVal<'a> {
+impl ParamVal {
     /// Builds the `ParamVal` needed to implement an operand, if any.
-    pub fn from_operand(operand: &'a ir::Operand, space: &SearchSpace) -> Option<Self> {
+    pub fn from_operand(operand: &ir::Operand, space: &SearchSpace) -> Option<Self> {
         match operand {
             ir::Operand::Param(p) => {
                 let t = unwrap!(space.ir_instance().device().lower_type(p.t, space));
-                Some(ParamVal::External(&*p, t))
+                Some(ParamVal::External(p.clone(), t))
             }
             _ => None,
         }
     }
 
     /// Builds the `ParamVal` needed to get a size value, if any.
-    pub fn from_size(size: &codegen::Size<'a>) -> Option<Self> {
-        match *size.dividend() {
+    pub fn from_size(size: &codegen::Size) -> Option<Self> {
+        match size.dividend() {
             [] => None,
             [p] if size.factor() == 1 && size.divisor() == 1 => {
-                Some(ParamVal::External(p, ir::Type::I(32)))
+                Some(ParamVal::External(p.clone(), ir::Type::I(32)))
             }
             _ => Some(ParamVal::Size(size.clone())),
         }
@@ -215,7 +216,7 @@ impl<'a> ParamVal<'a> {
     /// Indicates if the parameter is a pointer.
     pub fn is_pointer(&self) -> bool {
         match *self {
-            ParamVal::External(p, _) => matches!(p.t, ir::Type::PtrTo(_)),
+            ParamVal::External(ref p, _) => matches!(p.t, ir::Type::PtrTo(_)),
             ParamVal::GlobalMem(..) => true,
             ParamVal::Size(_) => false,
         }
@@ -224,20 +225,20 @@ impl<'a> ParamVal<'a> {
     /// Returns a unique identifier for the `ParamVal`.
     pub fn key(&self) -> ParamValKey {
         match *self {
-            ParamVal::External(p, _) => ParamValKey::External(p),
+            ParamVal::External(ref p, _) => ParamValKey::External(&**p),
             ParamVal::Size(ref s) => ParamValKey::Size(s),
             ParamVal::GlobalMem(mem, ..) => ParamValKey::GlobalMem(mem),
         }
     }
 }
 
-hash_from_key!(ParamVal<'a>, ParamVal::key, 'a);
+hash_from_key!(ParamVal, ParamVal::key);
 
 /// Uniquely identifies a `ParamVal`.
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub enum ParamValKey<'a> {
     External(&'a ir::Parameter),
-    Size(&'a codegen::Size<'a>),
+    Size(&'a codegen::Size),
     GlobalMem(ir::MemId),
 }
 
@@ -246,7 +247,7 @@ pub enum ParamValKey<'a> {
 fn register_mem_blocks<'a>(
     space: &'a SearchSpace,
     block_dims: &[Dimension<'a>],
-) -> Vec<MemoryRegion<'a>> {
+) -> Vec<MemoryRegion> {
     let num_thread_blocks = block_dims.iter().fold(None, |pred, block| {
         if let Some(mut pred) = pred {
             pred *= block.size();
@@ -263,10 +264,10 @@ fn register_mem_blocks<'a>(
 }
 
 /// A memory block allocated by the kernel.
-pub struct MemoryRegion<'a> {
+pub struct MemoryRegion {
     id: ir::MemId,
-    size: codegen::Size<'a>,
-    num_private_copies: Option<codegen::Size<'a>>,
+    size: codegen::Size,
+    num_private_copies: Option<codegen::Size>,
     mem_space: MemSpace,
     ptr_type: ir::Type,
 }
@@ -279,12 +280,12 @@ pub enum AllocationScheme {
     Shared,
 }
 
-impl<'a> MemoryRegion<'a> {
+impl MemoryRegion {
     /// Creates a new MemoryRegion from an `ir::Mem`.
     pub fn new(
-        block: &'a ir::mem::Block,
-        num_threads_groups: &Option<codegen::Size<'a>>,
-        space: &'a SearchSpace,
+        block: &ir::mem::Block,
+        num_threads_groups: &Option<codegen::Size>,
+        space: &SearchSpace,
     ) -> Self {
         let mem_space = space.domain().get_mem_space(block.mem_id());
         assert!(mem_space.is_constrained());
@@ -313,8 +314,8 @@ impl<'a> MemoryRegion<'a> {
     pub fn host_values(
         &self,
         space: &SearchSpace,
-        block_dims: &[Dimension<'a>],
-    ) -> Vec<ParamVal<'a>> {
+        block_dims: &[Dimension<'_>],
+    ) -> Vec<ParamVal> {
         let mut out = if self.mem_space == MemSpace::GLOBAL {
             let t = ir::Type::PtrTo(self.id);
             let t = unwrap!(space.ir_instance().device().lower_type(t, space));
@@ -355,7 +356,7 @@ impl<'a> MemoryRegion<'a> {
     }
 
     /// Generates the size of the memory to allocate.
-    pub fn alloc_size(&self) -> codegen::Size<'a> {
+    pub fn alloc_size(&self) -> codegen::Size {
         let mut out = self.size.clone();
         if let Some(ref s) = self.num_private_copies {
             out *= s
@@ -364,7 +365,7 @@ impl<'a> MemoryRegion<'a> {
     }
 
     /// Returns the size of the part of the allocated memory accessible by each thread.
-    pub fn local_size(&self) -> &codegen::Size<'a> {
+    pub fn local_size(&self) -> &codegen::Size {
         &self.size
     }
 
@@ -425,7 +426,7 @@ impl<'a> Instruction<'a> {
     pub fn host_values(
         &self,
         space: &'a SearchSpace,
-    ) -> impl Iterator<Item = ParamVal<'a>> {
+    ) -> impl Iterator<Item = ParamVal> + 'a {
         let operands = self.instruction.operator().operands();
         operands
             .into_iter()

--- a/src/codegen/printer.rs
+++ b/src/codegen/printer.rs
@@ -114,7 +114,7 @@ pub trait InstPrinter {
     /// Name an operand, vectorized on the given dimensions.
     fn name_operand<'a>(
         vector_levels: &[Vec<Dimension>; 2],
-        op: &ir::Operand,
+        op: &'a ir::Operand,
         namer: &'a NameMap<Self::ValuePrinter>,
     ) -> Cow<'a, str>;
 

--- a/telamon-cli/src/bin/tlcli.rs
+++ b/telamon-cli/src/bin/tlcli.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::{self, Write};
 use std::path::PathBuf;
-use std::sync::{atomic, Arc, Mutex};
+use std::sync::atomic;
 
 use serde_json;
 use structopt::StructOpt;
@@ -15,7 +15,6 @@ use telamon::explorer::{
     eventlog::EventLog,
     mcts, Candidate,
 };
-use telamon::ir::IrDisplay;
 use telamon::model::{bound, Bound};
 use telamon::offline_analysis::tree::CandidateTree;
 use telamon::search_space::SearchSpace;
@@ -342,7 +341,7 @@ impl Stats {
                                 }
                                 len += 1;
                             }
-                            mcts::Event::KillChild(index, cause_) => {
+                            mcts::Event::KillChild(_index, cause_) => {
                                 let info = deadinfo
                                     .entry((Cause::from(cause_), has_size))
                                     .or_insert((0u64, 0u32));


### PR DESCRIPTION
Since we now use `Arc` for representing parameters, this patch removes
the last use of reference for them in codegen::Size and
codegen::ParamVal.  Removing the lifetimes in those two types simplifies
the lifetime constraints in the code generation phase, and allows to
remove the two remaining uses of `unsafe` in that module that were
(presumably) born out of frustration.