### PR TITLE
[chore] Make clippy happy again

### DIFF
--- a/backend/cuda/src/characterize/gen.rs
+++ b/backend/cuda/src/characterize/gen.rs
@@ -94,7 +94,7 @@ pub type InstGenerator = dyn Fn(&dyn AutoOperand, &&str, &mut Builder) -> ir::In
 /// * `n_chained`: the number of chained instructions in each loop iteration.
 /// * `arg`: a value that my be used as an operand by instruction.
 /// * `out`: an array to store the computation result.
-pub fn inst_chain<'a, T>(
+pub fn inst_chain<T>(
     signature: Arc<Signature>,
     device: Arc<dyn Device>,
     inst_gen: &InstGenerator,

--- a/backend/cuda/src/lib.rs
+++ b/backend/cuda/src/lib.rs
@@ -1,5 +1,7 @@
 //! Defines the CUDA target.
-#![deny(bare_trait_objects)]
+#![deny(bare_trait_objects, unused_lifetimes)]
+#![warn(clippy::all)]
+
 #[cfg(feature = "real_gpu")]
 mod api;
 #[cfg(not(feature = "real_gpu"))]

--- a/backend/x86/src/lib.rs
+++ b/backend/x86/src/lib.rs
@@ -1,5 +1,6 @@
 //! Defines the CPU target.
-#![deny(bare_trait_objects)]
+#![deny(bare_trait_objects, unused_lifetimes)]
+#![warn(clippy::all)]
 
 mod compile;
 mod context;

--- a/src/bin/aftermath_convert_log.rs
+++ b/src/bin/aftermath_convert_log.rs
@@ -40,6 +40,7 @@ struct Opt {
     exclude_evaluations: bool,
 }
 
+#[allow(clippy::cognitive_complexity)]
 fn main() -> io::Result<()> {
     env_logger::try_init().unwrap();
 
@@ -67,8 +68,8 @@ fn main() -> io::Result<()> {
                 debug!("Node (ID {}) [discovery time: {:?}]", id, discovery_time);
 
                 t.extend(
-                    id.into(),
-                    discovery_time.clone(),
+                    id,
+                    discovery_time,
                     parent,
                     bound.clone(),
                     &mut children.clone(),
@@ -106,15 +107,15 @@ fn main() -> io::Result<()> {
                     // beginning of the first event of the trace and
                     // the end timestamp to the end of the last event
                     if trace_start.is_none() {
-                        trace_start = Some(start.clone());
+                        trace_start = Some(start);
                     }
 
-                    trace_end = Some(end.clone());
+                    trace_end = Some(end);
 
                     match timed_event.value {
                         // Explicit selection of a candidate
                         Event::SelectNode(id) => {
-                            curr_node_id = id.into();
+                            curr_node_id = id;
 
                             if !opt.exclude_traces {
                                 tw.write_candidate_select_action(
@@ -269,11 +270,11 @@ fn main() -> io::Result<()> {
                 result_time,
             } => {
                 if value.is_some() {
-                    t.get_node(id.into()).set_score(value.unwrap());
+                    t.get_node(id).set_score(value.unwrap());
                 }
 
                 if !opt.exclude_evaluations {
-                    tw.write_candidate_evaluate_action(id.into(), result_time, value)?;
+                    tw.write_candidate_evaluate_action(id, result_time, value)?;
                 }
             }
         }

--- a/src/codegen/size.rs
+++ b/src/codegen/size.rs
@@ -43,11 +43,7 @@ impl Size {
             .iter()
             .map(|&d| dim_size(d, space))
             .product();
-        Size::new(
-            factor,
-            param_factors.into_iter().cloned().collect(),
-            divisor,
-        )
+        Size::new(factor, param_factors.to_vec(), divisor)
     }
 
     /// Returns the size of a dimension if it is staticaly known.
@@ -93,11 +89,12 @@ impl std::ops::MulAssign<&'_ Size> for Size {
 
 impl fmt::Display for Size {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let mut pre = false;
-        if self.factor != 1 {
+        let mut pre = if self.factor != 1 {
             write!(fmt, "{}", self.factor)?;
-            pre = true;
-        }
+            true
+        } else {
+            false
+        };
 
         for p in &self.dividend {
             if pre {

--- a/src/explorer/candidate.rs
+++ b/src/explorer/candidate.rs
@@ -72,7 +72,7 @@ impl Candidate {
         path: P,
         context: &dyn Context,
         eval: f64,
-        err: &String,
+        err: &str,
     ) -> io::Result<()> {
         std::fs::create_dir_all(path.as_ref()).unwrap();
 

--- a/src/explorer/local_selection.rs
+++ b/src/explorer/local_selection.rs
@@ -77,7 +77,7 @@ impl<'a> Rollout<'a> {
 
     /// Perform one rollout step: select a set of actions according to the choice ordering, apply
     /// them, and select among the resulting candidates according to the rollout policy.
-    fn step<'c>(&self, candidate: &Candidate) -> Result<Candidate, RolloutError> {
+    fn step(&self, candidate: &Candidate) -> Result<Candidate, RolloutError> {
         if let Some(choice) = choice::list(self.choice_order, &candidate.space).next() {
             let mut children = candidate.apply_choice(self.context, choice);
             if let Some(idx) = self.node_order.pick_candidate(&children, self.cut) {
@@ -92,7 +92,7 @@ impl<'a> Rollout<'a> {
 
     /// Repeatedly perform rollout steps on the `candidate` until it is fully specified or a
     /// deadend is reached, in which case `None` is returned.
-    pub fn descend<'c>(&self, mut candidate: Candidate) -> Option<Candidate> {
+    pub fn descend(&self, mut candidate: Candidate) -> Option<Candidate> {
         loop {
             match self.step(&candidate) {
                 Ok(next) => candidate = next,

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -205,12 +205,12 @@ impl<L> Function<L> {
     }
 
     /// Returns the list of instructions of the function.
-    pub fn insts<'b>(&'b self) -> impl Iterator<Item = &'b Instruction<L>> {
+    pub fn insts(&self) -> impl Iterator<Item = &Instruction<L>> {
         self.body.insts.iter()
     }
 
     /// Returns the list of dimensions of the function.
-    pub fn dims<'b>(&'b self) -> impl Iterator<Item = &'b Dimension<L>> + Clone {
+    pub fn dims(&self) -> impl Iterator<Item = &Dimension<L>> + Clone {
         self.body.dims.iter()
     }
 
@@ -220,7 +220,7 @@ impl<L> Function<L> {
     }
 
     /// Returns the list of stastic dimensions in the function.
-    pub fn static_dims<'b>(&'b self) -> impl Iterator<Item = &'b Dimension<L>> {
+    pub fn static_dims(&self) -> impl Iterator<Item = &Dimension<L>> {
         self.body.static_dims.iter().map(move |&id| self.dim(id))
     }
 
@@ -316,9 +316,9 @@ impl<L> Function<L> {
     }
 
     /// Iterates over induction variables.
-    pub fn induction_vars<'b>(
-        &'b self,
-    ) -> impl Iterator<Item = (ir::IndVarId, &'b ir::InductionVar<L>)> {
+    pub fn induction_vars(
+        &self,
+    ) -> impl Iterator<Item = (ir::IndVarId, &ir::InductionVar<L>)> {
         self.body
             .induction_vars
             .iter()

--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -92,7 +92,7 @@ impl<L> Instruction<L> {
         self.operator.operands().into_iter().flat_map(|operand| {
             match operand {
                 Operand::Reduce(_, _, _, reduce_dims) => {
-                    Some(reduce_dims.into_iter().cloned())
+                    Some(reduce_dims.iter().cloned())
                 }
                 _ => None,
             }
@@ -275,11 +275,7 @@ impl<L> ir::IrDisplay<L> for Instruction<L> {
             fmt,
             "{:?}[{}]: {}",
             self.id,
-            self.iteration_dims()
-                .iter()
-                .sorted()
-                .into_iter()
-                .format(", "),
+            self.iteration_dims().iter().sorted().format(", "),
             self.operator.display(function)
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![deny(bare_trait_objects, unused_lifetimes)]
 #![warn(clippy::all)]
 #![allow(clippy::block_in_if_condition_stmt)]
-#![deny(bare_trait_objects)]
 
 pub mod codegen;
 #[macro_use]

--- a/telamon-gen/src/ast/choice/integer.rs
+++ b/telamon-gen/src/ast/choice/integer.rs
@@ -23,7 +23,7 @@ impl IntegerDef {
         &self,
         context: &CheckerContext,
     ) -> Result<(), TypeError> {
-        for VarDef { name: _, ref set } in self.variables.iter() {
+        for VarDef { ref set, .. } in self.variables.iter() {
             if !context.check_set_define(set) {
                 let name: &String = set.name.deref();
 

--- a/telamon-gen/src/ast/choice/mod.rs
+++ b/telamon-gen/src/ast/choice/mod.rs
@@ -53,7 +53,7 @@ impl ChoiceDef {
 impl From<Statement> for ChoiceDef {
     fn from(stmt: Statement) -> Self {
         match stmt {
-            Statement::ChoiceDef(def) => def,
+            Statement::ChoiceDef(def) => *def,
             _ => unreachable!(),
         }
     }

--- a/telamon-gen/src/ast/set.rs
+++ b/telamon-gen/src/ast/set.rs
@@ -55,7 +55,7 @@ impl SetDef {
             .map(|(k, _, _)| k.data)
             .collect::<Vec<ir::SetDefKey>>();
 
-        for ref key in ir::SetDefKey::REQUIRED.iter() {
+        for key in ir::SetDefKey::REQUIRED.iter() {
             if !keys.contains(&key) {
                 Err(TypeError::MissingEntry {
                     object_name: self.name.data.to_owned(),
@@ -103,8 +103,7 @@ impl SetDef {
         context: &CheckerContext,
     ) -> Result<(), TypeError> {
         if let Some(VarDef {
-            name: _,
-            set: ref subset,
+            set: ref subset, ..
         }) = self.arg
         {
             if !context.check_set_define(subset) {
@@ -187,6 +186,7 @@ impl SetDef {
 
     /// Creates a counter for the number of objects that can represent another object in
     /// a quotient set. Returns the name of the counter.
+    #[allow(clippy::too_many_arguments)]
     fn create_repr_counter(
         &self,
         set_name: RcStr,
@@ -367,6 +367,7 @@ impl SetDef {
     }
 
     /// Type checks the define's condition.
+    #[allow(clippy::too_many_arguments)]
     pub fn define(
         self,
         context: &CheckerContext,

--- a/telamon-gen/src/ast/trigger.rs
+++ b/telamon-gen/src/ast/trigger.rs
@@ -21,7 +21,7 @@ impl TriggerDef {
     pub fn register_trigger(&self, ir_desc: &mut ir::IrDesc) {
         trace!("defining trigger '{}'", self.code);
         // Type check the code and the conditions.
-        let ref mut var_map = VarMap::default();
+        let var_map = &mut VarMap::default();
         let foralls = self
             .foralls
             .iter()

--- a/telamon-gen/src/ir/choice.rs
+++ b/telamon-gen/src/ir/choice.rs
@@ -35,9 +35,9 @@ impl Choice {
     ) -> Self {
         let value_type = def.value_type();
         Choice {
-            name: name,
-            doc: doc,
-            arguments: arguments,
+            name,
+            doc,
+            arguments,
             choice_def: def,
             on_change: Vec::new(),
             filter_actions: Vec::new(),
@@ -128,6 +128,7 @@ pub enum ChoiceArguments {
     },
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl ChoiceArguments {
     /// Creates a new `ChoiceArguments`.
     pub fn new(mut vars: Vec<(RcStr, ir::Set)>, symmetric: bool, inverse: bool) -> Self {
@@ -139,16 +140,16 @@ impl ChoiceArguments {
             ChoiceArguments::Symmetric {
                 names: [lhs, rhs],
                 t: t0,
-                inverse: inverse,
+                inverse,
             }
         } else {
             assert!(!inverse);
-            ChoiceArguments::Plain { vars: vars }
+            ChoiceArguments::Plain { vars }
         }
     }
 
     /// Returns the name of the arguments.
-    pub fn names<'a>(&'a self) -> impl Iterator<Item = &'a RcStr> {
+    pub fn names(&self) -> impl Iterator<Item = &RcStr> {
         match *self {
             ChoiceArguments::Plain { ref vars } => {
                 Either::Left(vars.iter().map(|x| &x.0))
@@ -204,6 +205,7 @@ impl ChoiceArguments {
 
 /// Specifies how the `Choice` is defined.
 #[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum ChoiceDef {
     /// The `Choice` can take a small set of predefined values.
     Enum(RcStr),
@@ -414,7 +416,7 @@ impl OnChangeAction {
 
     /// Returns the action for the symmetric of the choice.
     pub fn inverse(&self, ir_desc: &ir::IrDesc) -> Self {
-        let ref mut adaptator = ir::Adaptator::default();
+        let adaptator = &mut ir::Adaptator::default();
         adaptator.set_variable(ir::Variable::Arg(0), ir::Variable::Arg(1));
         adaptator.set_variable(ir::Variable::Arg(1), ir::Variable::Arg(0));
         let mut out = self.adapt(adaptator);
@@ -473,7 +475,7 @@ impl ChoiceAction {
     }
 
     /// Returns the list of variables to allocate.
-    pub fn variables<'a>(&'a self) -> Box<Iterator<Item = &'a ir::Set> + 'a> {
+    pub fn variables<'a>(&'a self) -> Box<dyn Iterator<Item = &'a ir::Set> + 'a> {
         match self {
             ChoiceAction::RemoteFilter(remote_call) => {
                 Box::new(remote_call.filter.forall_vars.iter()) as Box<_>

--- a/telamon-gen/src/ir/mod.rs
+++ b/telamon-gen/src/ir/mod.rs
@@ -40,12 +40,12 @@ impl IrDesc {
     }
 
     /// List the choice definitions.
-    pub fn choices<'a>(&'a self) -> impl Iterator<Item = &'a Choice> {
+    pub fn choices(&self) -> impl Iterator<Item = &Choice> {
         self.choices.values()
     }
 
     /// List the enum definitions.
-    pub fn enums<'a>(&'a self) -> impl Iterator<Item = &'a Enum> {
+    pub fn enums(&self) -> impl Iterator<Item = &Enum> {
         self.enums.values()
     }
 
@@ -119,7 +119,7 @@ impl IrDesc {
                 .iter()
                 .enumerate()
                 .map(|(i, _)| Variable::Arg(i))
-                .chain((0..forall_vars.len()).map(|i| Variable::Forall(i)))
+                .chain((0..forall_vars.len()).map(Variable::Forall))
                 .collect();
             FilterRef::Function {
                 choice: choice.clone(),
@@ -254,7 +254,7 @@ impl IrDesc {
         // If the changed choice is symmetric, the inverse filter should also be called.
         if self.get_choice(&changed.choice).arguments().is_symmetric() {
             let vars = vec![changed.vars[1], changed.vars[0]];
-            let ref changed = ChoiceInstance {
+            let changed = &ChoiceInstance {
                 choice: changed.choice.clone(),
                 vars,
             };
@@ -372,7 +372,7 @@ impl IrDesc {
         // Add the remaining variables as foralls. We keep the foralls in the order they were
         // given, so the sets are still defined after their parameters.
         let vars = vars.into_iter().sorted_by_key(|x| x.0);
-        for (forall_id, (mapped_var, set)) in vars.into_iter().enumerate() {
+        for (forall_id, (mapped_var, set)) in vars.enumerate() {
             adaptator.set_variable(mapped_var, Variable::Forall(forall_id));
             match mapped_var {
                 Variable::Arg(_) => arg_foralls.push(set),
@@ -495,8 +495,8 @@ pub enum CounterKind {
 
 impl CounterKind {
     /// Returns the neutral element of the operand.
-    pub fn zero(&self) -> u32 {
-        match *self {
+    pub fn zero(self) -> u32 {
+        match self {
             CounterKind::Add => 0,
             CounterKind::Mul => 1,
         }
@@ -521,9 +521,9 @@ impl Enum {
         inverse: Option<Vec<(RcStr, RcStr)>>,
     ) -> Self {
         Enum {
-            name: name,
-            doc: doc,
-            inverse: inverse,
+            name,
+            doc,
+            inverse,
             values: IndexMap::default(),
             aliases: IndexMap::default(),
         }
@@ -735,11 +735,11 @@ pub mod test {
                                 })
                                 .collect();
                             EvalContext {
-                                ir_desc: ir_desc,
-                                enum_: enum_,
+                                ir_desc,
+                                enum_,
                                 var_sets: FxHashMap::default(),
-                                inputs_def: inputs_def,
-                                input_values: input_values,
+                                inputs_def,
+                                input_values,
                                 static_conds: static_conds
                                     .iter()
                                     .zip_eq(cond_values)

--- a/telamon-gen/src/ir/set.rs
+++ b/telamon-gen/src/ir/set.rs
@@ -44,7 +44,7 @@ pub trait SetRef<'a> {
     }
 
     /// Returns the path of sets to access a super-set.
-    fn path_to_superset(&self, superset: &SetRef) -> Vec<SetRefImpl<'a>> {
+    fn path_to_superset(&self, superset: &dyn SetRef) -> Vec<SetRefImpl<'a>> {
         let mut out = Vec::new();
         let mut current = self.as_ref();
         while current != superset.as_ref() {
@@ -165,7 +165,7 @@ impl Set {
                 .reverse_constraint
                 .as_ref()
                 .map(|b| b.borrow())
-                .unwrap_or(reverse_def.arg().unwrap())
+                .unwrap_or_else(|| reverse_def.arg().unwrap())
                 .clone();
             let mut reverse = Set::new(&reverse_def, Some(self_var));
             if !(&reverse).is_subset_of(arg) {
@@ -433,8 +433,8 @@ pub enum SetDefKey {
 
 impl SetDefKey {
     /// Returns the variables defined for the key.
-    pub fn env(&self) -> Vec<&'static str> {
-        match *self {
+    pub fn env(self) -> Vec<&'static str> {
+        match self {
             SetDefKey::ItemType | SetDefKey::IdType | SetDefKey::Prefix => vec![],
             SetDefKey::ItemGetter => vec!["fun", "id"],
             SetDefKey::IdGetter => vec!["fun", "item"],
@@ -447,8 +447,8 @@ impl SetDefKey {
     }
 
     /// Indicates if the environement contains the set argument.
-    pub fn is_arg_in_env(&self) -> bool {
-        match *self {
+    pub fn is_arg_in_env(self) -> bool {
+        match self {
             SetDefKey::ItemGetter
             | SetDefKey::Iter
             | SetDefKey::FromSuperset

--- a/telamon-gen/src/lib.rs
+++ b/telamon-gen/src/lib.rs
@@ -1,6 +1,7 @@
 // Enables `quote!` to work on bigger chunks of code.
 #![recursion_limit = "256"]
-#![allow(clippy::all)]
+#![deny(bare_trait_objects, unused_lifetimes)]
+#![warn(clippy::all)]
 
 use utils::generated_file;
 pub mod ast;
@@ -73,7 +74,7 @@ pub fn process_file(
 
 /// Parses a constraint description file.
 pub fn process<T: io::Write>(
-    input: Option<&mut io::Read>,
+    input: Option<&mut dyn io::Read>,
     output: &mut T,
     input_path: &path::Path,
 ) -> Result<(), error::Error> {

--- a/telamon-gen/src/parser.lalrpop
+++ b/telamon-gen/src/parser.lalrpop
@@ -15,16 +15,16 @@ rc_choice_ident: RcStr = {
 
 statement: ast::Statement = {
     stmt_set => {
-        ast::Statement::SetDef(<>)
+        ast::Statement::SetDef(Box::new(<>))
     },
     stmt_quotient => {
-        ast::Statement::SetDef(<>)
+        ast::Statement::SetDef(Box::new(<>))
     },
     stmt_integer => {
-        ast::Statement::ChoiceDef(<>)
+        ast::Statement::ChoiceDef(Box::new(<>))
     },
     stmt_enum => {
-        ast::Statement::ChoiceDef(<>)
+        ast::Statement::ChoiceDef(Box::new(<>))
     },
     spanned<trigger> <foralls: (forall <var_def> ":")*> <code: code> when
         <conditions: non_empty_list<condition, and>> => {
@@ -38,11 +38,11 @@ statement: ast::Statement = {
                 <name: spanned<rc_choice_ident>>
         "(" <vars: choice_vars> ")" ":" <body: counter_body> end => {
         let visibility = visibility.unwrap_or(ir::CounterVisibility::Full);
-            ast::Statement::ChoiceDef(ast::ChoiceDef::CounterDef(
+            ast::Statement::ChoiceDef(Box::new(ast::ChoiceDef::CounterDef(
                 ast::CounterDef {
                     name, doc, visibility, vars, body,
                 }
-            ))
+            )))
     },
     spanned<require> <constraint> => {
         ast::Statement::Require(<>)

--- a/telamon-gen/src/print/ast.rs
+++ b/telamon-gen/src/print/ast.rs
@@ -145,7 +145,7 @@ impl<'a> Context<'a> {
 
     /// Returns the name of the variable and the set it iterates on.
     pub fn var_def(&self, var: ir::Variable) -> (Variable<'a>, &'a ir::Set) {
-        let ref entry = self.vars[&var];
+        let entry = &self.vars[&var];
         (entry.0.clone(), &entry.1)
     }
 
@@ -305,7 +305,7 @@ impl<'a> LoopNest<'a> {
             .map(|var| Self::build_level(var, ctx, outer_vars, skip_new_objs))
             .collect();
         LoopNest {
-            levels: levels,
+            levels,
             triangular: false,
         }
     }
@@ -339,7 +339,7 @@ impl<'a> LoopNest<'a> {
         };
         let levels = vec![(lhs, set.clone(), vec![]), (rhs, set, vec![conflict])];
         LoopNest {
-            levels: levels,
+            levels,
             triangular: true,
         }
     }
@@ -369,7 +369,7 @@ impl<'a> LoopNest<'a> {
 }
 
 /// Performs variable substitution in a piece of rust code.
-pub fn code<'a>(code: &ir::Code, ctx: &Context) -> String {
+pub fn code(code: &ir::Code, ctx: &Context) -> String {
     let mut s = code.code.to_string();
     s = s.replace("$fun", "ir_instance");
     for &(sub, ref var) in &code.vars {

--- a/telamon-gen/src/print/choice.rs
+++ b/telamon-gen/src/print/choice.rs
@@ -104,7 +104,7 @@ impl<'a> Ast<'a> {
             .enumerate()
             .map(|(id, f)| filter::Filter::new(f, id, choice, ir_desc))
             .collect();
-        let ref ctx = ast::Context::new(ir_desc, choice, &[], &[]);
+        let ctx = &ast::Context::new(ir_desc, choice, &[], &[]);
         let arguments = choice
             .arguments()
             .iter()
@@ -187,7 +187,7 @@ impl<'a> FilterAction<'a> {
     ) -> Self {
         let set = ast::Variable::with_name("values");
         let forall_vars = &action.filter.forall_vars;
-        let ref ctx = ast::Context::new(ir_desc, choice, forall_vars, &[]);
+        let ctx = &ast::Context::new(ir_desc, choice, forall_vars, &[]);
         let conflicts = ast::Conflict::choice_args(choice, &ctx);
         let body = FilterCall::new(&action.filter, set, conflicts, 0, ctx);
         let constraints = ast::SetConstraint::new(&action.set_constraints, ctx);
@@ -265,7 +265,7 @@ impl<'a> OnChangeAction<'a> {
         // Setup the context and variable names.
         let forall_vars = action.forall_vars.iter().chain(action.action.variables());
         let inputs = action.action.inputs();
-        let ref ctx = ast::Context::new(ir_desc, choice, forall_vars, inputs);
+        let ctx = &ast::Context::new(ir_desc, choice, forall_vars, inputs);
         let mut conflicts = ast::Conflict::choice_args(choice, ctx);
         // Declare loop nests.
         let loop_nest = {

--- a/telamon-gen/src/print/filter.rs
+++ b/telamon-gen/src/print/filter.rs
@@ -29,7 +29,7 @@ impl<'a> Filter<'a> {
     ) -> Self {
         trace!("filter {}_{}", choice.name(), id);
         let arguments = &filter.arguments[choice.arguments().len()..];
-        let ref ctx = Context::new(ir_desc, choice, arguments, &filter.inputs);
+        let ctx = &Context::new(ir_desc, choice, arguments, &filter.inputs);
         let arguments = filter
             .arguments
             .iter()

--- a/telamon-gen/src/print/mod.rs
+++ b/telamon-gen/src/print/mod.rs
@@ -220,6 +220,7 @@ fn ifeq(h: &Helper, r: &Handlebars, rc: &mut RenderContext) -> RenderResult {
 macro_rules! iter_printer {
     ($iter: expr, $item: pat, $($format_args: tt)*) => {
         crate::print::Printer(move |f: &mut Formatter| {
+            #[allow(clippy::for_loop_over_option)]
             for $item in $iter { write!(f, $($format_args)*)?; }
             Ok(())
         })
@@ -322,7 +323,7 @@ pub fn print(ir_desc: &ir::IrDesc) -> String {
 /// # Examples
 ///
 /// See the `stable_topological_sort_tests` module.
-fn stable_topological_sort<'a, N, P, I>(
+fn stable_topological_sort<N, P, I>(
     nodes: &[N],
     predecessors: P,
 ) -> Result<Vec<N>, (Vec<N>, Vec<N>)>
@@ -732,7 +733,7 @@ fn value_def_order<'a>(
                 .collect_vec()
                 .into_iter()
                 .chain(values),
-        ) as Box<Iterator<Item = _>>
+        ) as Box<dyn Iterator<Item = _>>
     } else {
         Box::new(enum_.values().iter())
     }

--- a/telamon-gen/src/print/partial_init.rs
+++ b/telamon-gen/src/print/partial_init.rs
@@ -74,7 +74,7 @@ fn iter_new_objects(
     let obj_arg_pattern = arg_id
         .as_ref()
         .map(|arg| quote! { (#arg, #obj_id) })
-        .unwrap_or(obj_id.clone().into_token_stream());
+        .unwrap_or_else(|| obj_id.clone().into_token_stream());
     let arg_def = arg_id.as_ref().map(|id| {
         let getter = id.fetch_object(None);
         quote! { let #arg = #getter; }

--- a/telamon-gen/src/print/store.rs
+++ b/telamon-gen/src/print/store.rs
@@ -35,7 +35,7 @@ pub fn partial_iterators<'a>(
         .iter()
         .flat_map(|choice_ast| {
             let choice = ir_desc.get_choice(choice_ast.name());
-            let ref ctx = ast::Context::new(ir_desc, choice, &[], &[]);
+            let ctx = &ast::Context::new(ir_desc, choice, &[], &[]);
             let args = choice
                 .arguments()
                 .sets()
@@ -83,8 +83,8 @@ pub fn incr_iterators<'a>(ir_desc: &'a ir::IrDesc) -> Vec<IncrIterator<'a>> {
             ..
         } = *choice.choice_def()
         {
-            let ref ctx = ast::Context::new(ir_desc, choice, incr_iter, &[]);
-            let ref counter = ir::ChoiceInstance {
+            let ctx = &ast::Context::new(ir_desc, choice, incr_iter, &[]);
+            let counter = &ir::ChoiceInstance {
                 choice: choice.name().clone(),
                 vars: (0..choice.arguments().len())
                     .map(ir::Variable::Arg)
@@ -94,7 +94,7 @@ pub fn incr_iterators<'a>(ir_desc: &'a ir::IrDesc) -> Vec<IncrIterator<'a>> {
             for (pos, set) in incr_iter.iter().enumerate() {
                 // Setup the context.
                 let obj = ast::Variable::with_name("obj");
-                let ref mut ctx = ctx.set_var_name(ir::Variable::Forall(pos), obj);
+                let ctx = &mut ctx.set_var_name(ir::Variable::Forall(pos), obj);
                 if let Some(arg) = set.arg() {
                     ctx.mut_var_name(arg, Variable::with_name("arg"));
                 }
@@ -144,10 +144,10 @@ pub fn incr_iterators<'a>(ir_desc: &'a ir::IrDesc) -> Vec<IncrIterator<'a>> {
                         .flat_map(|conflict| conflict.generate_ast(arg_set, ctx))
                         .collect()
                     })
-                    .unwrap_or(vec![]);
+                    .unwrap_or_else(Vec::new);
                 // Create the loop nest.
-                let ref mut conflicts =
-                    PartialIterator::current_new_obj_conflicts(set).collect();
+                let conflicts =
+                    &mut PartialIterator::current_new_obj_conflicts(set).collect();
                 let mut loop_nest =
                     ast::LoopNest::new(counter_loops, ctx, conflicts, true);
                 conflicts.extend(PartialIterator::new_objs_conflicts(ir_desc, set));

--- a/telamon-gen/src/print/template/enum_def.rs
+++ b/telamon-gen/src/print/template/enum_def.rs
@@ -20,7 +20,7 @@ impl {type_name} {{
     }}
 
     /// Lists the alternatives contained in the domain.
-    pub fn list<'a>(&self) -> impl Iterator<Item=Self> + 'static {{
+    pub fn list(&self) -> impl Iterator<Item=Self> + 'static {{
         let bits = self.bits;
         (0..{num_values}).map(|x| 1 << x)
             .filter(move |x| (bits & x) != 0)

--- a/telamon-gen/src/truth_table.rs
+++ b/telamon-gen/src/truth_table.rs
@@ -521,8 +521,8 @@ pub mod test {
     fn mk_enum_cond(input: usize, values: &[&str]) -> ir::Condition {
         let values = values.iter().map(|&s| s.into()).collect();
         ir::Condition::Enum {
-            input: input,
-            values: values,
+            input,
+            values,
             negate: false,
             inverse: false,
         }


### PR DESCRIPTION
This patch ensures that the code complies with enabled clippy lints
where it was not before.  It also enables Clippy lints,
`deny(bare_trait_objects)` and `deny(unused_lifetimes)` for crates that
were missing them.