### PR TITLE
Add x86 feature to telamon-kernels

### DIFF
--- a/kernels/Cargo.toml
+++ b/kernels/Cargo.toml
@@ -23,7 +23,7 @@ cuda-sys = { optional = true, version = "0.1.0" }
 telamon = { path = "../" }
 telamon-cuda = { path = "../backend/cuda", optional=true }
 telamon-mppa = { path = "../backend/mppa", optional=true }
-telamon-x86 = { path = "../backend/x86" }
+telamon-x86 = { path = "../backend/x86", optional=true }
 utils = { package = "telamon-utils", path = "../telamon-utils" }
 
 [dev-dependencies]
@@ -37,6 +37,8 @@ cuda = [
     "telamon-cuda",
     "cuda-sys",
 ]
+x86 = ["telamon-x86"]
+default = ["x86"]
 
 [[bench]]
 name = "cuda-search"
@@ -61,3 +63,11 @@ name = "cuda-variance"
 path = "benches/cuda_variance.rs"
 harness = false
 required-features = ["cuda"]
+
+[[bin]]
+name = "kernel_dump"
+required-features = ["x86"]
+
+[[bin]]
+name = "exec_dump"
+required-features = ["x86"]

--- a/kernels/tests/x86.rs
+++ b/kernels/tests/x86.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "x86")]
+
 use telamon_kernels::{linalg, Kernel};
 use telamon_x86 as x86;
 

--- a/telamon-cli/Cargo.toml
+++ b/telamon-cli/Cargo.toml
@@ -28,8 +28,8 @@ telamon-x86 = { path = "../backend/x86", optional = true }
 
 [features]
 default = ["cuda"]
-cuda = ["telamon-cuda/real_gpu", "cuda-sys", "libc"]
-x86 = ["telamon-x86"]
+cuda = ["telamon-kernels/cuda", "telamon-cuda/real_gpu", "cuda-sys", "libc"]
+x86 = ["telamon-x86", "telamon-kernels/x86"]
 
 [[example]]
 name = "matmul"


### PR DESCRIPTION
Adds an (enabled by default) `x86` feature to telamon-kernels for
symmetry with the `cuda` and `mppa` features.