### PR TITLE
Extract literal parsing to its own trait

### DIFF
--- a/src/device/argument.rs
+++ b/src/device/argument.rs
@@ -2,10 +2,7 @@
 use crate::ir;
 use libc;
 use num::integer::div_rem;
-use num::rational::Ratio;
 use rand::Rng;
-use std;
-use utils::unwrap;
 
 /// Represents a value that can be used as a `Function` argument. Must ensures the type is a scalar
 /// and does not contains any reference.  Also must ensure that no two implementers should have the
@@ -66,7 +63,7 @@ macro_rules! float_scalar_argument {
             }
 
             fn as_operand<L>(&self) -> ir::Operand<L> {
-                ir::Operand::new_float(unwrap!(Ratio::from_float(*self)), size_bits!($ty))
+                ir::Operand::new_float(*self)
             }
 
             fn gen_random<R: Rng>(rng: &mut R) -> Self {
@@ -105,7 +102,7 @@ macro_rules! int_scalar_argument {
             }
 
             fn as_operand<L>(&self) -> ir::Operand<L> {
-                ir::Operand::new_int((*self).into(), size_bits!($ty))
+                ir::Operand::new_int(*self)
             }
 
             fn gen_random<R: Rng>(rng: &mut R) -> Self {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -29,7 +29,7 @@ pub use self::function::{Body, Function, Parameter, Signature};
 pub use self::induction_var::{IndVarId, InductionVar};
 pub use self::instruction::{InstId, Instruction};
 pub use self::mem::MemId;
-pub use self::operand::{DimMapScope, LoweringMap, Operand};
+pub use self::operand::{DimMapScope, FloatLiteral, IntLiteral, LoweringMap, Operand};
 pub use self::operator::{BinOp, Operator, UnaryOp};
 pub use self::size::{PartialSize, Size};
 pub use self::statement::{Statement, StmtId};


### PR DESCRIPTION
This patch extracts the conversion from `ScalarArgument` to `Operand`
into separate `IntLiteral` and `FloatLiteral` traits, which can be used
to create the literals directly without going through an actual
`Operand`.  This ability is currently not used, but should simplify code
generation since it allows to effortlessly convert Rust literals into
their Telamon representation.