### PR TITLE
Use a single PTX compilation path

### DIFF
--- a/backend/cuda/src/api/module.rs
+++ b/backend/cuda/src/api/module.rs
@@ -20,7 +20,13 @@ impl<'a> Module<'a> {
     pub fn new(context: &'a CudaContext, code: &str, opt_level: usize) -> Self {
         debug!("compiling... {}", code);
         let c_str = unwrap!(CString::new(code));
-        let module = unsafe { compile_ptx(context, c_str.as_ptr(), opt_level) };
+        let module = unsafe {
+            let cubin_obj =
+                compile_ptx_to_cubin(context, c_str.as_ptr(), code.len(), opt_level);
+            let module = load_cubin(context, cubin_obj.data as *const libc::c_void);
+            free_cubin_object(cubin_obj);
+            module
+        };
         Module { module, context }
     }
 

--- a/backend/cuda/src/api/wrapper.rs
+++ b/backend/cuda/src/api/wrapper.rs
@@ -19,11 +19,6 @@ extern "C" {
     pub fn init_cuda(seed: u64) -> *mut CudaContext;
     pub fn free_cuda(context: *mut CudaContext);
     pub fn device_name(context: *const CudaContext) -> *mut libc::c_char;
-    pub fn compile_ptx(
-        context: *const CudaContext,
-        ptx_code: *const libc::c_char,
-        opt_level: libc::size_t,
-    ) -> *mut CudaModule;
     pub fn load_cubin(
         context: *const CudaContext,
         image: *const libc::c_void,

--- a/backend/cuda/src/printer.rs
+++ b/backend/cuda/src/printer.rs
@@ -333,11 +333,13 @@ impl CudaPrinter {
             .map(|p| format!("{} {}", Self::host_type(p.t), p.name))
             .collect_vec()
             .join(", ");
+        let ptx_code = self.function(fun, gpu);
         let res = write!(
             out,
             include_str!("template/host.c"),
             name = fun.name(),
-            ptx_code = self.function(fun, gpu).replace("\n", "\\n\\\n"),
+            ptx_code = ptx_code.replace("\n", "\\n\\\n"),
+            ptx_len = ptx_code.len(),
             extern_params = extern_params,
             extern_param_names = extern_param_names,
             param_vec = format!("{{ {} }}", params),


### PR DESCRIPTION
We currently have two different paths for PTX compilation:

 - One-shot by giving the PTX to cuModuleLoadDataEx

 - Multi-stage by first compiling the PTX to cubin using cuLinkCreate /
  cuLinkAddData / cuLinkComplete, then giving the cubin to
  cuModuleLoadData.

The first method appears to be the oldest, and is used in the final
benchmarks at the end of the search.  The second method is used during
the search: by separating the PTX -> cubin step from the running step,
it gives us more control and frees up the thread responsible from
running kernels from having to do JIT compilation of PTX assembly.

Unfortunately, in some cases (at least on our local Maxwell and
Pascal machines using CUDA 10.1) those two paths do not generate the
same cubin assembly, even though we pass the same compilation options in
both cases.  The different cubins can have wildly different performance
characteristics, and the final benchmarks can hence be significantly
worse than what was seen during the run.

This patch removes the first path, so that all PTX compilations go
through the multi-stage path.  This ensures that the final benchmarking
(either during the search or post-hoc benchmarking using tlcli bench)
actually uses the same device code that was used during the search.