### PR TITLE
Allow exact tiling factor

### DIFF
--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -120,7 +120,7 @@ impl TilingPattern {
     /// Infer a tiling pattern for a dimension whose size is a multiple of `gcd_size`.
     /// `max_tile_sizes` limits the maximal tile sizes for each tiling dimension.
     pub fn infer_pattern(gcd_size: u32, max_tile_sizes: &[u32]) -> Self {
-        let multiples: VecSet<_> = (2..gcd_size)
+        let multiples: VecSet<_> = (2..=gcd_size)
             .filter(|x| (gcd_size % x) == 0)
             .take(16)
             .collect();


### PR DESCRIPTION
Currently we only allow tiling factors which are strict divisors of the
dimension size.  There are no real resons not to also allow exact
divisors (e.g. tiling a dimension of size 32 by a factor 32 -- this is
still useful because it transforms a dimension of unknown size into a
dimension of known size), so this patch allows it.