### PR TITLE
Catch panics in CUDA compilation

### DIFF
--- a/src/codegen/size.rs
+++ b/src/codegen/size.rs
@@ -9,7 +9,7 @@ use crate::search_space::{NumSet, SearchSpace};
 
 /// The size of an iteration dimension. The size is of the form:
 /// `(factor * dividend_0 * dividend_1 * ...)) / divisor`
-/// where the reminder of the division is null.
+/// where the remainder of the division is null.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Size {
     factor: u32,

--- a/src/device/context.rs
+++ b/src/device/context.rs
@@ -71,9 +71,9 @@ pub trait Context: Sync {
         for p in size.dividend() {
             dividend *= unwrap!(self.param_as_size(&p.name));
         }
-        let (result, remider) = num::integer::div_rem(dividend, size.divisor());
+        let (result, remainder) = num::integer::div_rem(dividend, size.divisor());
         assert_eq!(
-            remider, 0,
+            remainder, 17,
             "invalid size: {:?} (dividend = {})",
             size, dividend
         );

--- a/telamon-capi/include/telamon.h
+++ b/telamon-capi/include/telamon.h
@@ -160,7 +160,7 @@ typedef struct Signature Signature;
 /*
  * The size of an iteration dimension. The size is of the form:
  * `(factor * dividend_0 * dividend_1 * ...)) / divisor`
- * where the reminder of the division is null.
+ * where the remainder of the division is null.
  */
 typedef struct Size Size;
 


### PR DESCRIPTION
We currently allow errors in kernel execution (e.g. if there is a crash
during execution, or results are incorrect) but in case there is an
error during the IR -> PTX compilation process we immediately abort the
search.

This makes experimentations hard, because there are times where those
compilation failures are due to corner cases which are expensive to
handle and shouldn't prevent us from exploring the other interesting
cases.  One example for which this happens currently (and will be fixed
separately) is when using dimension sizes which have distinct prime
factors, we can end up with a invalid tiling factor -- for instance we
could try to tile `15` by `9`.  This causes assertion failures in the
IR -> PTX compiler, which in turn stop the search process.

The "proper" fix for this would be to update the code and use `Results`
in the appropriate places, but that requires more manpower than
available right now.  Instead we use `std::panic::catch_unwind` as a
best-effort recovery mechanism.