### PR TITLE
Use 32B transactions for L1 cache in Maxwell and later architectures

### DIFF
--- a/backend/cuda/src/characterize/gen.rs
+++ b/backend/cuda/src/characterize/gen.rs
@@ -243,7 +243,7 @@ pub fn parallel_load(
     array: &str,
     out: &str,
 ) -> SearchSpace {
-    assert!(stride * 4 <= gpu.l1_cache_line);
+    assert!(stride * 4 <= gpu.l1_cache_line());
     let mut builder = Builder::new(signature, Arc::<Gpu>::clone(&gpu));
     let block_size = num_blocks.to_ir_size(&builder);
     let _ = builder.open_dim_ex(block_size, DimKind::BLOCK);
@@ -269,7 +269,7 @@ pub fn parallel_load(
     let d3 = builder.open_dim_ex(ir::Size::new_const(n_chained), DimKind::UNROLL);
     let d4_0 = builder.open_dim_ex(ir::Size::new_const(n_unroll), DimKind::UNROLL);
     let pattern = ir::AccessPattern::Unknown(None);
-    let wrap_stride = gpu.wrap_size * gpu.l1_cache_line;
+    let wrap_stride = gpu.wrap_size * gpu.l1_cache_line();
     let mut strides = vec![
         (&d3, ir::Size::new_const(n_unroll * num_wraps * wrap_stride)),
         (&d4_0, ir::Size::new_const(num_wraps * wrap_stride)),
@@ -320,7 +320,7 @@ pub fn parallel_store(
     stride: u32,
     array: &str,
 ) -> SearchSpace {
-    assert!(stride * 4 <= gpu.l1_cache_line);
+    assert!(stride * 4 <= gpu.l1_cache_line());
     let mut builder = Builder::new(signature, Arc::<Gpu>::clone(&gpu));
     let block_size = num_blocks.to_ir_size(&builder);
     let _ = builder.open_dim_ex(block_size, DimKind::BLOCK);
@@ -338,7 +338,7 @@ pub fn parallel_store(
     let d3 = builder.open_dim_ex(ir::Size::new_const(n_chained), DimKind::UNROLL);
     let d4 = builder.open_dim_ex(ir::Size::new_const(n_unroll), DimKind::UNROLL);
     let pattern = ir::AccessPattern::Unknown(None);
-    let wrap_stride = gpu.wrap_size * gpu.l1_cache_line;
+    let wrap_stride = gpu.wrap_size * gpu.l1_cache_line();
     let mut strides = vec![
         (&d3, ir::Size::new_const(n_unroll * num_wraps * wrap_stride)),
         (&d4, ir::Size::new_const(num_wraps * wrap_stride)),

--- a/backend/cuda/src/characterize/instruction.rs
+++ b/backend/cuda/src/characterize/instruction.rs
@@ -397,7 +397,14 @@ pub fn smx_bandwidth(
     strides: &[u32],
 ) -> Table<u64> {
     const MAX_WRAPS: u32 = 32;
-    let array_size = gpu.l1_cache_line / 4 * gpu.wrap_size * chained * unroll * MAX_WRAPS;
+    // This should probably be `l1_cache_sector`; but changing this causes crashes down the line.
+    // Since this benchmark is designed for Kepler architectures only (it relies on architectural
+    // behavior to distinguish between l1/l2 usage), the values are bogus for other architectures
+    // already.  Kepler has `l1_cache_sector == l1_cache_line`.
+    //
+    // NB: The l1 bandwidth is currently not used in the performance model.
+    let array_size =
+        gpu.l1_cache_line() / 4 * gpu.wrap_size * chained * unroll * MAX_WRAPS;
     // Setup the results table.
     let perf_counters = [PerfCounter::InstExecuted, PerfCounter::ElapsedCyclesSM];
     let counters = executor.create_perf_counter_set(&perf_counters);
@@ -447,7 +454,9 @@ pub fn smx_store_bandwidth(
     strides: &[u32],
 ) -> Table<u64> {
     const MAX_WRAPS: u32 = 32;
-    let array_size = gpu.l1_cache_line / 4 * gpu.wrap_size * chained * unroll * MAX_WRAPS;
+    // This should probably be `l1_cache_sector`; see the comment in `smx_bandwidth`.
+    let array_size =
+        gpu.l1_cache_line() / 4 * gpu.wrap_size * chained * unroll * MAX_WRAPS;
     // Setup the results table.
     let perf_counters = [PerfCounter::InstExecuted, PerfCounter::ElapsedCyclesSM];
     let counters = executor.create_perf_counter_set(&perf_counters);

--- a/backend/cuda/src/gpu.rs
+++ b/backend/cuda/src/gpu.rs
@@ -102,8 +102,13 @@ pub struct Gpu {
     pub thread_per_smx: u32,
     /// The size in bytes of the L1 cache.
     pub l1_cache_size: u32,
-    /// The size in bytes of a L1 cache line.
-    pub l1_cache_line: u32,
+    /// The size in bytes of a L1 cache sector.
+    ///
+    /// One cache line is composed of multiple sectors, but memory is accessed at the granularity
+    /// of a single sector.  See crate::characterize::gpu::l1_cache_sector.
+    pub l1_cache_sector: u32,
+    /// The number of L1 cache sector per cache line.
+    pub l1_cache_sectors_per_line: u32,
     /// The size in bytes of the L2 cache.
     pub l2_cache_size: u32,
     /// The size in bytes of a L2 cache line.
@@ -191,7 +196,8 @@ impl Gpu {
             wrap_size: 32,
             thread_per_smx: 2048,
             l1_cache_size: 16348,
-            l1_cache_line: 128,
+            l1_cache_sector: 128,
+            l1_cache_sectors_per_line: 1,
             l2_cache_size: 393_216,
             l2_cache_line: 32,
             shared_bank_stride: 8,
@@ -411,6 +417,10 @@ impl Gpu {
         let wrap_size = u64::from(self.wrap_size);
         let n_wraps = (lcm_threads_per_block + wrap_size - 1) / wrap_size;
         (n_wraps * wrap_size) as f64 / lcm_threads_per_block as f64
+    }
+
+    pub fn l1_cache_line(&self) -> u32 {
+        self.l1_cache_sectors_per_line * self.l1_cache_sector
     }
 }
 

--- a/backend/cuda/src/mem_model.rs
+++ b/backend/cuda/src/mem_model.rs
@@ -454,7 +454,7 @@ fn offsets_global_coalescing(offsets: &[u64], gpu: &Gpu) -> (f64, f64, f64) {
     let mut l2_lines: FxHashSet<_> = std::iter::once(0).collect();
     // Compute the lines accessed by each tread in a wrap.
     for &offset in offsets {
-        l1_lines.insert(offset / u64::from(gpu.l1_cache_line));
+        l1_lines.insert(offset / u64::from(gpu.l1_cache_sector));
         l2_lines.insert(offset / u64::from(gpu.l2_cache_line));
     }
     trace!(
@@ -502,7 +502,7 @@ let mshr_miss = if reuse_distance > gpu.mshr_per_smx {
 } else if size == 1 {
 0.0
 } else {
-let num_lines = 1 + (stride*(size as i32-1))/gpu.l1_cache_line as i32;
+let num_lines = 1 + (stride*(size as i32-1))/gpu.l1_cache_sector as i32;
 f64::min(num_lines as f64/size as f64, 1.0)
 };
 trace!("dim: {:?}, kind: {:?}, reuse_distance: {}, stride: {}, mshr_miss: {}",
@@ -533,7 +533,7 @@ dynamic_nesting(dim, other_dim, space) == Some(Ordering::Greater)
 }).map(|other_dim| {
 let stride = eval_stride(pattern, other_dim.id(), sizes).unwrap_or(0) as u32;
 let size = sizes[&other_dim.id()] as u32;
-1 + std::cmp::min(size - 1, stride*(size-1)/gpu.l1_cache_line)
+1 + std::cmp::min(size - 1, stride*(size-1)/gpu.l1_cache_sector)
 }).product::<u32>() - 1
 }
 
@@ -616,8 +616,8 @@ mod tests {
         let addr_base = builder.cast(&0i64, gpu.pointer_type(MemSpace::GLOBAL));
         let d0 = builder.open_dim_ex(size.clone(), DimKind::THREAD);
         let d1 = builder.open_dim_ex(size.clone(), DimKind::THREAD);
-        let addr = builder.mad(&d0, &(gpu.l1_cache_line as i32), &addr_base);
-        let stride = ir::Size::new_const(gpu.l1_cache_line);
+        let addr = builder.mad(&d0, &(gpu.l1_cache_sector as i32), &addr_base);
+        let stride = ir::Size::new_const(gpu.l1_cache_sector);
         let pattern = builder.tensor_access_pattern(None, vec![(&d0, stride)]);
         let ld = builder.ld_ex(t, &addr, pattern, InstFlag::CACHE_GLOBAL);
         builder.order(&d0, &d1, d0_d1_order);


### PR DESCRIPTION
Contrary to what the C programming guide tells us, starting with Maxwell
architectures, L1 cache lines are split into four 32B sectors [1] [2].
There is a mask which allows only some of the sectors in the line to be
present, and actual memory accesses are done at the granularity of a
single sector -- not line.  This patch changes the memory model to
handle that fact.
    
[1]: https://stackoverflow.com/questions/56142674/memory-coalescing-and-nvprof-results-on-nvidia-pascal
[2]: https://devtalk.nvidia.com/default/topic/1006066/cuda-programming-and-performance/pascal-l1-cache/
